### PR TITLE
Added pointer-event none to labels/notices img's

### DIFF
--- a/localcontexts/static/css/main.css
+++ b/localcontexts/static/css/main.css
@@ -176,6 +176,11 @@ input:focus {
     box-shadow: 0px 0px 1px 0.5px #007385;
 }
 
+/* POINTEREVENT */
+.pointer-event-none{
+    pointer-events: none;
+}
+
 /* OPACITY */
 .opacity-4 { opacity: 0.4;}
 

--- a/localcontexts/static/css/main.css
+++ b/localcontexts/static/css/main.css
@@ -177,7 +177,7 @@ input:focus {
 }
 
 /* POINTEREVENT */
-.pointer-event-none{
+.pointer-event-none {
     pointer-events: none;
 }
 

--- a/templates/accounts/select-account.html
+++ b/templates/accounts/select-account.html
@@ -16,7 +16,7 @@
                         </span>
                     </div>                    
                 </div>
-                <div><img loading="lazy" class="tiny-label" src="{% static 'images/tk-labels/tk-attribution.png' %}"></div>
+                <div><img loading="lazy" class="tiny-label pointer-event-none" src="{% static 'images/tk-labels/tk-attribution.png' %}"></div>
                 <p><strong>Who?</strong> An Indigenous or local community entity or representative</p>
                 <p class="no-top-margin"><strong>What?</strong> Customize and apply TK and BC Labels, and create Projects</p>
                 <a href="{% url 'connect-community' %}"><div class="primary-btn white-btn-select"><span>Join</span></div></a>
@@ -30,8 +30,9 @@
                     </div>
                 </div>
                 <div class="flex-this">
-                    <div class="margin-right-1"><img loading="lazy" class="tiny-notice" src="{% static 'images/notices/tk-notice.png' %}"></div>
-                    <div class="margin-left-16"><img loading="lazy" class="tiny-notice" src="{% static 'images/notices/ci-open-to-collaborate.png' %}"></div>
+                    <div class="margin-right-1"><img loading="lazy" 
+                    class="tiny-notice pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}"></div>
+                    <div class="margin-left-16"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}"></div>
                 </div>
                 <p><strong>Who?</strong> Cultural or research institution, data repository, and other organizations</p>
                 <p><strong>What?</strong> Create projects and generate Notices</p>
@@ -41,8 +42,8 @@
             <div class="account-card margin-left-1">
                 <p><strong>Researcher Account</strong></p>
                 <div class="flex-this">
-                    <div class="margin-right-1"><img loading="lazy" class="tiny-notice" src="{% static 'images/notices/tk-notice.png' %}"></div>
-                    <div class="margin-left-16"><img loading="lazy" class="tiny-notice" src="{% static 'images/notices/bc-notice.png' %}"></div>
+                    <div class="margin-right-1"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}"></div>
+                    <div class="margin-left-16"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}"></div>
                 </div>
                 <p><strong>Who?</strong> An individual who carries out academic or scientific research independently or in an institution </p>
                 <p><strong>What?</strong> Create projects and generate Notices</p>

--- a/templates/bclabels/mini-labels.html
+++ b/templates/bclabels/mini-labels.html
@@ -3,7 +3,7 @@
 <div>
     <img 
         loading="lazy" 
-        class="img-sizedown-small {% if not bclabel.is_approved %}opacity-4{% endif %}"
+        class="img-sizedown-small {% if not bclabel.is_approved %}opacity-4{% endif %} pointer-event-none"
         
         {% if bclabel.label_type == 'commercialization'%}
             src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" 

--- a/templates/bclabels/tiny-labels.html
+++ b/templates/bclabels/tiny-labels.html
@@ -3,7 +3,7 @@
 <div>
     <img 
         loading="lazy" 
-        class="img-sizedown-tiny {% if not bclabel.is_approved %}opacity-4{% endif %}"
+        class="img-sizedown-tiny {% if not bclabel.is_approved %}opacity-4{% endif %} pointer-event-none"
         
         {% if bclabel.label_type == 'commercialization'%}
             src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" 

--- a/templates/bclabels/which-label.html
+++ b/templates/bclabels/which-label.html
@@ -4,7 +4,7 @@
 <div>
     <img 
         loading="lazy" 
-        class="label-medium {% if not bclabel.is_approved %}opacity-4{% endif %}"
+        class="label-medium {% if not bclabel.is_approved %}opacity-4{% endif %} pointer-event-none"
         
         {% if bclabel.label_type == 'commercialization'%}
             src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" 

--- a/templates/communities/apply-labels.html
+++ b/templates/communities/apply-labels.html
@@ -71,13 +71,13 @@
                             {% for notice in project.project_notice.all %}
                                 {% if not notice.archived %}
                                     {% if notice.notice_type == 'biocultural' %}
-                                        <div class="margin-left-8"><img loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" width="62px"></div>
+                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="62px"></div>
                                     {% endif %}
                                     {% if notice.notice_type == 'traditional_knowledge' %}
-                                        <div class="margin-left-8"><img loading="lazy" src="{% static 'images/notices/tk-notice.png' %}" width="62px"></div>
+                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="62px"></div>
                                     {% endif %}
                                     {% if notice.notice_type == 'attribution_incomplete' %}
-                                        <div class="margin-left-8"><img loading="lazy" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="62px"></div>
+                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="62px"></div>
                                     {% endif %}
                                 {% endif %}
                             {% endfor %}

--- a/templates/communities/customize-label.html
+++ b/templates/communities/customize-label.html
@@ -20,7 +20,7 @@
         <div class="flex-this margin-left-16 margin-right-16">
 
             <div id="target-img-div" class="margin-top-16">
-                <img 
+                <img class="pointer-event-none"
                     loading="lazy"
                     {% if label_code == 'bcr' %}
                         id="bcr" 

--- a/templates/communities/customize-label.html
+++ b/templates/communities/customize-label.html
@@ -17,10 +17,10 @@
 <div class="content-card-v2 content-card-space">
     <h3 class="no-top-margin">Step 1. Select a Label to customize</h3>
     <div class="margin-bottom-16 margin-top-16 w-100 about-this-label">    
-        <div class="flex-this margin-left-16 margin-right-16">
+        <div class="flex-this margin-left-16 margin-right-16 pointer-event-none">
 
             <div id="target-img-div" class="margin-top-16">
-                <img class="pointer-event-none"
+                <img
                     loading="lazy"
                     {% if label_code == 'bcr' %}
                         id="bcr" 

--- a/templates/communities/select-label.html
+++ b/templates/communities/select-label.html
@@ -296,32 +296,32 @@
                 <div class="flex-this wrap w-100">
 
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div><img loading="lazy" id="tka" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-attribution.png' %}" alt="TK Attribution (TK A) Label"></div>
+                        <div><img loading="lazy" id="tka" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-attribution.png' %}" alt="TK Attribution (TK A) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Attribution <br> (TK A) </p></div>
                     </div>
             
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div><img loading="lazy" id="tkcl" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-clan.png' %}" alt="TK Clan (TK CL) Label"></div>
+                        <div><img loading="lazy" id="tkcl" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-clan.png' %}" alt="TK Clan (TK CL) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Clan <br> (TK CL)</p></div>
                     </div>
             
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div><img loading="lazy" id="tkf" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-family.png' %}" alt="TK Family (TK F) Label"></div>
+                        <div><img loading="lazy" id="tkf" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-family.png' %}" alt="TK Family (TK F) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Family (TK F) </p></div>
                     </div>
             
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div><img loading="lazy" id="tkmc" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-multiple-community.png' %}" alt="TK Multiple Communities (TK MC) Label"></div>
+                        <div><img loading="lazy" id="tkmc" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-multiple-community.png' %}" alt="TK Multiple Communities (TK MC) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Multiple <br>Communities <br> (TK MC)</p></div>
                     </div>
 
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkcv" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-community-voice.png' %}" alt="TK Community Voice (TK CV) Label"></div>
+                        <div><img loading="lazy" id="tkcv" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-community-voice.png' %}" alt="TK Community Voice (TK CV) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Community Voice <br> (TK CV) </p></div>
                     </div>
 
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkcr" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-creative.png' %}" alt="TK Creative (TK CR) Label"></div>
+                        <div><img loading="lazy" id="tkcr" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-creative.png' %}" alt="TK Creative (TK CR) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Creative <br> (TK CR) </p></div>
                     </div>
 
@@ -334,22 +334,22 @@
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
 
                         <div id="tklabel-expanded-img-tka" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tka' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tka' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkcl" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcl' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcl' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkf" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkf' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkf' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkmc" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmc' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmc' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkcv" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcv' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcv' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkcr" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcr' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcr' %}" class="default-label-img pointer-event-none">
                         </div>
                         
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -400,46 +400,46 @@
 
                 <div class="w-100 flex-this wrap">
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkv" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-verified.png' %}" alt="TK Verified (TK V) Label"></div>
+                        <div><img loading="lazy" id="tkv" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-verified.png' %}" alt="TK Verified (TK V) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Verified <br> (TK V) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tknv" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-non-verified.png' %}" alt="TK Non-Verified (TK NV) Label"></div>
+                        <div><img loading="lazy" id="tknv" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-non-verified.png' %}" alt="TK Non-Verified (TK NV) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Non-Verified <br> (TK NV) </p></div>
                     </div>
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tks" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-seasonal.png' %}" alt="TK Seasonal (TK S) Label"></div>
+                        <div><img loading="lazy" id="tks" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-seasonal.png' %}" alt="TK Seasonal (TK S) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Seasonal <br> (TK S) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkwg" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-women-general.png' %}" alt="TK Weomen General (TK WG) Label"></div>
+                        <div><img loading="lazy" id="tkwg" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-women-general.png' %}" alt="TK Weomen General (TK WG) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Women General <br> (TK WG) </p></div>
                     </div>
         
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkmg" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-men-general.png' %}" alt="TK Men General (TK MG) Label"></div>
+                        <div><img loading="lazy" id="tkmg" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-men-general.png' %}" alt="TK Men General (TK MG) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Men General <br> (TK MG) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkmr" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-men-restricted.png' %}" alt="TK Men Restricted (TK MR) Label"></div>
+                        <div><img loading="lazy" id="tkmr" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-men-restricted.png' %}" alt="TK Men Restricted (TK MR) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Men Restricted <br> (TK MR) </p></div>
                     </div>
         
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkwr" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-women-restricted.png' %}" alt="TK Women Restricted (TK WR) Label"></div>
+                        <div><img loading="lazy" id="tkwr" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-women-restricted.png' %}" alt="TK Women Restricted (TK WR) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Women Restricted <br> (TK WR) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkcs" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-culturally-sensitive.png' %}" alt="TK Culturally Sensitive (TK CS) Label"></div>
+                        <div><img loading="lazy" id="tkcs" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-culturally-sensitive.png' %}" alt="TK Culturally Sensitive (TK CS) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Culturally <br> Sensitive <br> (TK CS) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkss" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-secret-sacred.png' %}" alt="TK Secret Sacred (TK SS) Label"></div>
+                        <div><img loading="lazy" id="tkss" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-secret-sacred.png' %}" alt="TK Secret Sacred (TK SS) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Secret Sacred <br> (TK SS) </p></div>
                     </div>
                 </div>
@@ -451,31 +451,31 @@
                 <div class="flex-this">
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
                         <div id="tklabel-expanded-img-tknv" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tknv' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tknv' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkv" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkv' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkv' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tks" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tks' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tks' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkwg" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkwg' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkwg' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkmg" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmg' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmg' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkmr" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmr' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmr' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkwr" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkwr' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkwr' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkcs" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcs' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcs' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkss" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkss' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkss' %}" class="default-label-img pointer-event-none">
                         </div>
 
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -526,27 +526,27 @@
                 <div class="flex-this wrap">
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkoc" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-commercial.png' %}" alt="TK Open to Commercialization (TK OC) Label"></div>
+                        <div><img loading="lazy" id="tkoc" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-commercial.png' %}" alt="TK Open to Commercialization (TK OC) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Open to Commercialization <br> (TK OC) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tknc" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-non-commercial.png' %}" alt="TK Non-Commercial (TK NC) Label"></div>
+                        <div><img loading="lazy" id="tknc" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-non-commercial.png' %}" alt="TK Non-Commercial (TK NC) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Non-Commercial <br> (TK NC) </p></div>
                     </div>
         
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkco" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-community-use-only.png' %}" alt="TK Community Use Only (TK CO) Label"></div>
+                        <div><img loading="lazy" id="tkco" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-community-use-only.png' %}" alt="TK Community Use Only (TK CO) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Community Use <br> Only <br> (TK CO) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tko" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-outreach.png' %}" alt="TK Outreach (TK O) Label"></div>
+                        <div><img loading="lazy" id="tko" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-outreach.png' %}" alt="TK Outreach (TK O) Label"></div>
                         <div class="toggle-txt-color grey-text"><p> TK Outreach <br> (TK O)</p></div>
                     </div>
 
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkcb" onclick="expandTKLabel(this)" class="default-label-img pointer" src="{% static 'images/tk-labels/tk-open-to-collaboration.png' %}" alt="TK Open to Collaboration (TK CB) Label"></div>
+                        <div><img loading="lazy" id="tkcb" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-open-to-collaboration.png' %}" alt="TK Open to Collaboration (TK CB) Label"></div>
                         <div class="toggle-txt-color grey-text"><p> TK Open to Collaboration <br> (TK CB)</p></div>
                     </div>
 
@@ -559,19 +559,19 @@
                 <div class="flex-this">
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
                         <div id="tklabel-expanded-img-tko" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tko' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tko' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tknc" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tknc' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tknc' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkoc" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkoc' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkoc' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkco" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkco' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkco' %}" class="default-label-img pointer-event-none">
                         </div>
                         <div id="tklabel-expanded-img-tkcb" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcb' %}" class="default-label-img">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcb' %}" class="default-label-img pointer-event-none">
                         </div>
 
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -653,17 +653,17 @@
             <div class="flex-this wrap w-100">
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bcp" onclick="expandBCLabel(this)" class="default-label-img pointer" src="{% static 'images/bc-labels/bc-provenance.png' %}" alt="BC Provenance (BC P) Label"></div>
+                    <div><img loading="lazy" id="bcp" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-provenance.png' %}" alt="BC Provenance (BC P) Label"></div>
                     <div class="toggle-txt-color grey-text"><p> Provenance <br> (BC P)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bcmc" onclick="expandBCLabel(this)" class="default-label-img pointer" src="{% static 'images/bc-labels/bc-multiple-community.png' %}" alt="BC Multiple Communities (BC MC) Label"></div>
+                    <div><img loading="lazy" id="bcmc" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-multiple-community.png' %}" alt="BC Multiple Communities (BC MC) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Multiple Communities <br> (BC MC)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bccl" onclick="expandBCLabel(this)" class="default-label-img pointer" src="{% static 'images/bc-labels/bc-clan.png' %}" alt="BC Clan (BC CL) Label"></div>
+                    <div><img loading="lazy" id="bccl" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-clan.png' %}" alt="BC Clan (BC CL) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Clan <br> (BC CL)</p></div>
                 </div>
 
@@ -674,15 +674,15 @@
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
         
                         <div id="bclabel-expanded-img-bcp" class="bc-img-div hide">
-                            <img loading="lazy" src="{% get_bclabel_img_url 'bcp' %}" class="default-label-img">
+                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcp' %}" class="default-label-img">
                         </div>
         
                         <div id="bclabel-expanded-img-bcmc" class="bc-img-div hide">
-                            <img loading="lazy" src="{% get_bclabel_img_url 'bcmc' %}" class="default-label-img">
+                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcmc' %}" class="default-label-img">
                         </div>
         
                         <div id="bclabel-expanded-img-bccl" class="bc-img-div hide">
-                            <img loading="lazy" src="{% get_bclabel_img_url 'bccl' %}" class="default-label-img">
+                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccl' %}" class="default-label-img">
                         </div>
         
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -733,12 +733,12 @@
             <div class="flex-this wrap w-100">
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bccv" onclick="expandBCLabel(this)" class="default-label-img pointer" src="{% static 'images/bc-labels/bc-consent-verified.png' %}" alt="BC Consent Verified (BC CV) Label"></div>
+                    <div><img loading="lazy" id="bccv" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-consent-verified.png' %}" alt="BC Consent Verified (BC CV) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Consent Verified <br> (BC CV) </p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bccnv" onclick="expandBCLabel(this)" class="default-label-img pointer" src="{% static 'images/bc-labels/bc-consent-non-verified.png' %}" alt="BC Consent Non-Verified (BC CNV) Label"></div>
+                    <div><img loading="lazy" id="bccnv" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-consent-non-verified.png' %}" alt="BC Consent Non-Verified (BC CNV) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Consent Non-Verified <br> (BC CNV) </p></div>
                 </div>
             </div>
@@ -748,11 +748,11 @@
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
         
                         <div id="bclabel-expanded-img-bccv" class="bc-img-div hide">
-                            <img loading="lazy" src="{% get_bclabel_img_url 'bccv' %}" class="default-label-img">
+                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccv' %}" class="default-label-img">
                         </div>
         
                         <div id="bclabel-expanded-img-bccnv" class="bc-img-div hide">
-                            <img loading="lazy" src="{% get_bclabel_img_url 'bccnv' %}" class="default-label-img">
+                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccnv' %}" class="default-label-img">
                         </div>
         
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -803,27 +803,27 @@
             <div class="flex-this wrap w-100">
     
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bcr" onclick="expandBCLabel(this)" class="default-label-img pointer" src="{% static 'images/bc-labels/bc-research-use.png' %}" alt="BC Research Use (BC R) Label"></div>
+                    <div><img loading="lazy" id="bcr" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-pointer" src="{% static 'images/bc-labels/bc-research-use.png' %}" alt="BC Research Use (BC R) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Research Use <br> (BC R) </p></div>
                 </div>
     
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bccb" onclick="expandBCLabel(this)" class="default-label-img pointer" src="{% static 'images/bc-labels/bc-open-to-collaboration.png' %}" alt="BC Open to Collaboration (BC CB) Label"></div>
+                    <div><img loading="lazy" id="bccb" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-collaboration.png' %}" alt="BC Open to Collaboration (BC CB) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Open to <br>Collaboration <br> (BC CB) </p></div>
                 </div>
     
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bcoc" onclick="expandBCLabel(this)" class="default-label-img pointer" src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" alt="BC Open to Commercialization (BC OC) Label"></div>
+                    <div><img loading="lazy" id="bcoc" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" alt="BC Open to Commercialization (BC OC) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Open to <br>Commercialization <br> (BC OC)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bco" onclick="expandBCLabel(this)" class="default-label-img pointer" src="{% static 'images/bc-labels/bc-outreach.png' %}" alt="BC Outreach (BC O) Label"></div>
+                    <div><img loading="lazy" id="bco" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-outreach.png' %}" alt="BC Outreach (BC O) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Outreach <br> (BC O)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bcnc" onclick="expandBCLabel(this)" class="default-label-img pointer" src="{% static 'images/bc-labels/bc-non-commercial.png' %}" alt="BC Non-Commercial (BC NC) Label"></div>
+                    <div><img loading="lazy" id="bcnc" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-non-commercial.png' %}" alt="BC Non-Commercial (BC NC) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Non-Commercial <br> (BC NC)</p></div>
                 </div>
 
@@ -837,23 +837,23 @@
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
 
                         <div id="bclabel-expanded-img-bcr" class="bc-img-div hide">
-                            <img loading="lazy" src="{% get_bclabel_img_url 'bcr' %}" class="default-label-img">
+                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcr' %}" class="default-label-img">
                         </div>
 
                         <div id="bclabel-expanded-img-bccb" class="bc-img-div hide">
-                            <img loading="lazy" src="{% get_bclabel_img_url 'bccb' %}">
+                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccb' %}">
                         </div>
 
                         <div id="bclabel-expanded-img-bcoc" class="bc-img-div hide">
-                            <img loading="lazy" src="{% get_bclabel_img_url 'bcoc' %}" class="default-label-img">
+                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcoc' %}" class="default-label-img">
                         </div>
 
                         <div id="bclabel-expanded-img-bco" class="bc-img-div hide">
-                            <img loading="lazy" src="{% get_bclabel_img_url 'bco' %}" class="default-label-img">
+                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bco' %}" class="default-label-img">
                         </div>
 
                         <div id="bclabel-expanded-img-bcnc" class="bc-img-div hide">
-                            <img loading="lazy" src="{% get_bclabel_img_url 'bcnc' %}" class="default-label-img">
+                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcnc' %}" class="default-label-img">
                         </div>
                     </div>
 

--- a/templates/communities/select-label.html
+++ b/templates/communities/select-label.html
@@ -126,7 +126,7 @@
     {% for bclabel in bclabels %}
         <div id="open-div-{{ bclabel.unique_id }}" style="height: 0px; overflow: hidden;" class="div-toggle">
             <div class="full-label-card flex-this">
-                <div class="margin-right-16"><img src="{{bclabel.img_url}}" class="label-large"></div>
+                <div class="margin-right-16"><img src="{{bclabel.img_url}}" class="label-large pointer-event-none"></div>
                 <div>
                     <div class="flex-this space-between">
                         <div><h3 class="no-top-margin">{{ bclabel.name }}</h3></div>
@@ -185,7 +185,7 @@
         <div id="open-div-{{ tklabel.unique_id }}" style="height: 0px; overflow: hidden;" class="div-toggle">
             <div class="full-label-card flex-this">
                 <div class="margin-right-16">
-                    <img src="{{ tklabel.img_url }}" class="label-large">
+                    <img src="{{ tklabel.img_url }}" class="label-large pointer-event-none">
                 </div>
                 <div>
                     <div class="flex-this space-between">
@@ -296,32 +296,35 @@
                 <div class="flex-this wrap w-100">
 
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div><img loading="lazy" id="tka" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-attribution.png' %}" alt="TK Attribution (TK A) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))">
+                            <img loading="lazy" id="tka" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-attribution.png' %}" alt="TK Attribution (TK A) Label">
+                        </div>
                         <div class="toggle-txt-color grey-text"><p>TK Attribution <br> (TK A) </p></div>
                     </div>
             
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div><img loading="lazy" id="tkcl" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-clan.png' %}" alt="TK Clan (TK CL) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))">
+                            <img loading="lazy" id="tkcl" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-clan.png' %}" alt="TK Clan (TK CL) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Clan <br> (TK CL)</p></div>
                     </div>
             
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div><img loading="lazy" id="tkf" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-family.png' %}" alt="TK Family (TK F) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkf" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-family.png' %}" alt="TK Family (TK F) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Family (TK F) </p></div>
                     </div>
             
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div><img loading="lazy" id="tkmc" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-multiple-community.png' %}" alt="TK Multiple Communities (TK MC) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmc" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-multiple-community.png' %}" alt="TK Multiple Communities (TK MC) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Multiple <br>Communities <br> (TK MC)</p></div>
                     </div>
 
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkcv" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-community-voice.png' %}" alt="TK Community Voice (TK CV) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcv" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-community-voice.png' %}" alt="TK Community Voice (TK CV) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Community Voice <br> (TK CV) </p></div>
                     </div>
 
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkcr" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-creative.png' %}" alt="TK Creative (TK CR) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcr" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-creative.png' %}" alt="TK Creative (TK CR) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Creative <br> (TK CR) </p></div>
                     </div>
 
@@ -400,46 +403,46 @@
 
                 <div class="w-100 flex-this wrap">
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkv" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-verified.png' %}" alt="TK Verified (TK V) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkv" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-verified.png' %}" alt="TK Verified (TK V) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Verified <br> (TK V) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tknv" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-non-verified.png' %}" alt="TK Non-Verified (TK NV) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tknv" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-non-verified.png' %}" alt="TK Non-Verified (TK NV) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Non-Verified <br> (TK NV) </p></div>
                     </div>
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tks" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-seasonal.png' %}" alt="TK Seasonal (TK S) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tks" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-seasonal.png' %}" alt="TK Seasonal (TK S) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Seasonal <br> (TK S) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkwg" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-women-general.png' %}" alt="TK Weomen General (TK WG) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkwg" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-women-general.png' %}" alt="TK Weomen General (TK WG) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Women General <br> (TK WG) </p></div>
                     </div>
         
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkmg" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-men-general.png' %}" alt="TK Men General (TK MG) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmg" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-men-general.png' %}" alt="TK Men General (TK MG) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Men General <br> (TK MG) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkmr" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-men-restricted.png' %}" alt="TK Men Restricted (TK MR) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmr" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-men-restricted.png' %}" alt="TK Men Restricted (TK MR) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Men Restricted <br> (TK MR) </p></div>
                     </div>
         
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkwr" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-women-restricted.png' %}" alt="TK Women Restricted (TK WR) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkwr" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-women-restricted.png' %}" alt="TK Women Restricted (TK WR) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Women Restricted <br> (TK WR) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkcs" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-culturally-sensitive.png' %}" alt="TK Culturally Sensitive (TK CS) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcs" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-culturally-sensitive.png' %}" alt="TK Culturally Sensitive (TK CS) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Culturally <br> Sensitive <br> (TK CS) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkss" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-secret-sacred.png' %}" alt="TK Secret Sacred (TK SS) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkss" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-secret-sacred.png' %}" alt="TK Secret Sacred (TK SS) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Secret Sacred <br> (TK SS) </p></div>
                     </div>
                 </div>
@@ -526,27 +529,27 @@
                 <div class="flex-this wrap">
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkoc" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-commercial.png' %}" alt="TK Open to Commercialization (TK OC) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkoc" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-commercial.png' %}" alt="TK Open to Commercialization (TK OC) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Open to Commercialization <br> (TK OC) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tknc" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-non-commercial.png' %}" alt="TK Non-Commercial (TK NC) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tknc" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-non-commercial.png' %}" alt="TK Non-Commercial (TK NC) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Non-Commercial <br> (TK NC) </p></div>
                     </div>
         
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkco" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-community-use-only.png' %}" alt="TK Community Use Only (TK CO) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkco" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-community-use-only.png' %}" alt="TK Community Use Only (TK CO) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Community Use <br> Only <br> (TK CO) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tko" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-outreach.png' %}" alt="TK Outreach (TK O) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tko" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-outreach.png' %}" alt="TK Outreach (TK O) Label"></div>
                         <div class="toggle-txt-color grey-text"><p> TK Outreach <br> (TK O)</p></div>
                     </div>
 
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div><img loading="lazy" id="tkcb" onclick="expandTKLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-open-to-collaboration.png' %}" alt="TK Open to Collaboration (TK CB) Label"></div>
+                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcb" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-open-to-collaboration.png' %}" alt="TK Open to Collaboration (TK CB) Label"></div>
                         <div class="toggle-txt-color grey-text"><p> TK Open to Collaboration <br> (TK CB)</p></div>
                     </div>
 
@@ -653,17 +656,17 @@
             <div class="flex-this wrap w-100">
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bcp" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-provenance.png' %}" alt="BC Provenance (BC P) Label"></div>
+                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcp" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-provenance.png' %}" alt="BC Provenance (BC P) Label"></div>
                     <div class="toggle-txt-color grey-text"><p> Provenance <br> (BC P)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bcmc" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-multiple-community.png' %}" alt="BC Multiple Communities (BC MC) Label"></div>
+                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcmc" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-multiple-community.png' %}" alt="BC Multiple Communities (BC MC) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Multiple Communities <br> (BC MC)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bccl" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-clan.png' %}" alt="BC Clan (BC CL) Label"></div>
+                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccl" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-clan.png' %}" alt="BC Clan (BC CL) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Clan <br> (BC CL)</p></div>
                 </div>
 
@@ -733,12 +736,12 @@
             <div class="flex-this wrap w-100">
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bccv" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-consent-verified.png' %}" alt="BC Consent Verified (BC CV) Label"></div>
+                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccv" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-consent-verified.png' %}" alt="BC Consent Verified (BC CV) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Consent Verified <br> (BC CV) </p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bccnv" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-consent-non-verified.png' %}" alt="BC Consent Non-Verified (BC CNV) Label"></div>
+                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccnv" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-consent-non-verified.png' %}" alt="BC Consent Non-Verified (BC CNV) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Consent Non-Verified <br> (BC CNV) </p></div>
                 </div>
             </div>
@@ -803,27 +806,27 @@
             <div class="flex-this wrap w-100">
     
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bcr" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-pointer" src="{% static 'images/bc-labels/bc-research-use.png' %}" alt="BC Research Use (BC R) Label"></div>
+                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcr" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-research-use.png' %}" alt="BC Research Use (BC R) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Research Use <br> (BC R) </p></div>
                 </div>
     
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bccb" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-collaboration.png' %}" alt="BC Open to Collaboration (BC CB) Label"></div>
+                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccb" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-collaboration.png' %}" alt="BC Open to Collaboration (BC CB) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Open to <br>Collaboration <br> (BC CB) </p></div>
                 </div>
     
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bcoc" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" alt="BC Open to Commercialization (BC OC) Label"></div>
+                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcoc" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" alt="BC Open to Commercialization (BC OC) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Open to <br>Commercialization <br> (BC OC)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bco" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-outreach.png' %}" alt="BC Outreach (BC O) Label"></div>
+                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bco" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-outreach.png' %}" alt="BC Outreach (BC O) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Outreach <br> (BC O)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div><img loading="lazy" id="bcnc" onclick="expandBCLabel(this)" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-non-commercial.png' %}" alt="BC Non-Commercial (BC NC) Label"></div>
+                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcnc" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-non-commercial.png' %}" alt="BC Non-Commercial (BC NC) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Non-Commercial <br> (BC NC)</p></div>
                 </div>
 

--- a/templates/communities/select-label.html
+++ b/templates/communities/select-label.html
@@ -296,35 +296,35 @@
                 <div class="flex-this wrap w-100">
 
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))">
-                            <img loading="lazy" id="tka" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-attribution.png' %}" alt="TK Attribution (TK A) Label">
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))">
+                            <img loading="lazy" id="tka" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-attribution.png' %}" alt="TK Attribution (TK A) Label">
                         </div>
                         <div class="toggle-txt-color grey-text"><p>TK Attribution <br> (TK A) </p></div>
                     </div>
             
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))">
-                            <img loading="lazy" id="tkcl" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-clan.png' %}" alt="TK Clan (TK CL) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))">
+                            <img loading="lazy" id="tkcl" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-clan.png' %}" alt="TK Clan (TK CL) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Clan <br> (TK CL)</p></div>
                     </div>
             
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkf" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-family.png' %}" alt="TK Family (TK F) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkf" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-family.png' %}" alt="TK Family (TK F) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Family (TK F) </p></div>
                     </div>
             
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmc" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-multiple-community.png' %}" alt="TK Multiple Communities (TK MC) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmc" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-multiple-community.png' %}" alt="TK Multiple Communities (TK MC) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Multiple <br>Communities <br> (TK MC)</p></div>
                     </div>
 
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcv" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-community-voice.png' %}" alt="TK Community Voice (TK CV) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcv" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-community-voice.png' %}" alt="TK Community Voice (TK CV) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Community Voice <br> (TK CV) </p></div>
                     </div>
 
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcr" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-creative.png' %}" alt="TK Creative (TK CR) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcr" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-creative.png' %}" alt="TK Creative (TK CR) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Creative <br> (TK CR) </p></div>
                     </div>
 
@@ -403,46 +403,46 @@
 
                 <div class="w-100 flex-this wrap">
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkv" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-verified.png' %}" alt="TK Verified (TK V) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkv" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-verified.png' %}" alt="TK Verified (TK V) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Verified <br> (TK V) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tknv" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-non-verified.png' %}" alt="TK Non-Verified (TK NV) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tknv" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-non-verified.png' %}" alt="TK Non-Verified (TK NV) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Non-Verified <br> (TK NV) </p></div>
                     </div>
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tks" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-seasonal.png' %}" alt="TK Seasonal (TK S) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tks" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-seasonal.png' %}" alt="TK Seasonal (TK S) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Seasonal <br> (TK S) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkwg" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-women-general.png' %}" alt="TK Weomen General (TK WG) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkwg" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-women-general.png' %}" alt="TK Weomen General (TK WG) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Women General <br> (TK WG) </p></div>
                     </div>
         
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmg" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-men-general.png' %}" alt="TK Men General (TK MG) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmg" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-men-general.png' %}" alt="TK Men General (TK MG) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Men General <br> (TK MG) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmr" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-men-restricted.png' %}" alt="TK Men Restricted (TK MR) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmr" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-men-restricted.png' %}" alt="TK Men Restricted (TK MR) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Men Restricted <br> (TK MR) </p></div>
                     </div>
         
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkwr" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-women-restricted.png' %}" alt="TK Women Restricted (TK WR) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkwr" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-women-restricted.png' %}" alt="TK Women Restricted (TK WR) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Women Restricted <br> (TK WR) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcs" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-culturally-sensitive.png' %}" alt="TK Culturally Sensitive (TK CS) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcs" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-culturally-sensitive.png' %}" alt="TK Culturally Sensitive (TK CS) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Culturally <br> Sensitive <br> (TK CS) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkss" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-secret-sacred.png' %}" alt="TK Secret Sacred (TK SS) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkss" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-secret-sacred.png' %}" alt="TK Secret Sacred (TK SS) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Secret Sacred <br> (TK SS) </p></div>
                     </div>
                 </div>
@@ -529,27 +529,27 @@
                 <div class="flex-this wrap">
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkoc" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-commercial.png' %}" alt="TK Open to Commercialization (TK OC) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkoc" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-commercial.png' %}" alt="TK Open to Commercialization (TK OC) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Open to Commercialization <br> (TK OC) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tknc" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-non-commercial.png' %}" alt="TK Non-Commercial (TK NC) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tknc" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-non-commercial.png' %}" alt="TK Non-Commercial (TK NC) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Non-Commercial <br> (TK NC) </p></div>
                     </div>
         
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkco" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-community-use-only.png' %}" alt="TK Community Use Only (TK CO) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkco" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-community-use-only.png' %}" alt="TK Community Use Only (TK CO) Label"></div>
                         <div class="toggle-txt-color grey-text"><p>TK Community Use <br> Only <br> (TK CO) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tko" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-outreach.png' %}" alt="TK Outreach (TK O) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tko" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-outreach.png' %}" alt="TK Outreach (TK O) Label"></div>
                         <div class="toggle-txt-color grey-text"><p> TK Outreach <br> (TK O)</p></div>
                     </div>
 
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcb" class="default-label-img pointer pointer-event-none" src="{% static 'images/tk-labels/tk-open-to-collaboration.png' %}" alt="TK Open to Collaboration (TK CB) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcb" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-open-to-collaboration.png' %}" alt="TK Open to Collaboration (TK CB) Label"></div>
                         <div class="toggle-txt-color grey-text"><p> TK Open to Collaboration <br> (TK CB)</p></div>
                     </div>
 
@@ -656,17 +656,17 @@
             <div class="flex-this wrap w-100">
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcp" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-provenance.png' %}" alt="BC Provenance (BC P) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcp" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-provenance.png' %}" alt="BC Provenance (BC P) Label"></div>
                     <div class="toggle-txt-color grey-text"><p> Provenance <br> (BC P)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcmc" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-multiple-community.png' %}" alt="BC Multiple Communities (BC MC) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcmc" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-multiple-community.png' %}" alt="BC Multiple Communities (BC MC) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Multiple Communities <br> (BC MC)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccl" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-clan.png' %}" alt="BC Clan (BC CL) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccl" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-clan.png' %}" alt="BC Clan (BC CL) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Clan <br> (BC CL)</p></div>
                 </div>
 
@@ -736,12 +736,12 @@
             <div class="flex-this wrap w-100">
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccv" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-consent-verified.png' %}" alt="BC Consent Verified (BC CV) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccv" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-consent-verified.png' %}" alt="BC Consent Verified (BC CV) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Consent Verified <br> (BC CV) </p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccnv" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-consent-non-verified.png' %}" alt="BC Consent Non-Verified (BC CNV) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccnv" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-consent-non-verified.png' %}" alt="BC Consent Non-Verified (BC CNV) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Consent Non-Verified <br> (BC CNV) </p></div>
                 </div>
             </div>
@@ -806,27 +806,27 @@
             <div class="flex-this wrap w-100">
     
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcr" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-research-use.png' %}" alt="BC Research Use (BC R) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcr" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-research-use.png' %}" alt="BC Research Use (BC R) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Research Use <br> (BC R) </p></div>
                 </div>
     
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccb" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-collaboration.png' %}" alt="BC Open to Collaboration (BC CB) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccb" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-collaboration.png' %}" alt="BC Open to Collaboration (BC CB) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Open to <br>Collaboration <br> (BC CB) </p></div>
                 </div>
     
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcoc" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" alt="BC Open to Commercialization (BC OC) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcoc" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" alt="BC Open to Commercialization (BC OC) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Open to <br>Commercialization <br> (BC OC)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bco" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-outreach.png' %}" alt="BC Outreach (BC O) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bco" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-outreach.png' %}" alt="BC Outreach (BC O) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Outreach <br> (BC O)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcnc" class="default-label-img pointer pointer-event-none" src="{% static 'images/bc-labels/bc-non-commercial.png' %}" alt="BC Non-Commercial (BC NC) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcnc" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-non-commercial.png' %}" alt="BC Non-Commercial (BC NC) Label"></div>
                     <div class="toggle-txt-color grey-text"><p>Non-Commercial <br> (BC NC)</p></div>
                 </div>
 

--- a/templates/partials/_notices.html
+++ b/templates/partials/_notices.html
@@ -43,7 +43,7 @@
         </div>
     </div>
     <div class="flex-this">
-        <div><img loading="lazy" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="119px" alt="black square with a rectangle and on hand on top and bottom in the middle in white"></div>
+        <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="119px" alt="black square with a rectangle and on hand on top and bottom in the middle in white"></div>
         <div class="flex-this column margin-left-16">
             <div class="w-90">
                 <h3 class="no-top-margin">Open to Collaborate</h3>
@@ -135,16 +135,16 @@
 
     <div class="flex-this justify-center">
         <div id="disclosureTK" class="cc-notice__container" onclick="expandDisclosureNotice(this)">
-            <div><img loading="lazy" src="{% static 'images/notices/tk-notice.png' %}" width="119px" alt="black square with the letters TK in the middle in white"></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="119px" alt="black square with the letters TK in the middle in white"></div>
             <div><p>Traditional Knowledge</p></div>
         </div>
         <div id="disclosureBC" class="cc-notice__container" onclick="expandDisclosureNotice(this)">
-            <div><img loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" width="119px" alt="black square with the letters BC in the middle in white"></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="119px" alt="black square with the letters BC in the middle in white"></div>
             <div><p>Biocultural</p></div>
         </div>
         
         <div id="disclosureAI" class="cc-notice__container" onclick="expandDisclosureNotice(this)">
-            <div><img loading="lazy" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="black square with an unfinished square in the middle in white"></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="black square with an unfinished square in the middle in white"></div>
             <div><p>Attribution Incomplete</p></div>
         </div>
     </div>
@@ -153,7 +153,7 @@
 
         <div id="openDiv-disclosureTK" class="disclosure-notice__expanded-container hide">
             <div class="flex-this">
-                <div><img loading="lazy" src="{% static 'images/notices/tk-notice.png' %}" alt="black square with the letters TK in the middle in white"></div>
+                <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="black square with the letters TK in the middle in white"></div>
                 <div class="flex-this column margin-left-16">
                     <div class="w-90">
                         <h2 class="no-top-margin">Traditional Knowledge Notice</h2>
@@ -175,7 +175,7 @@
 
         <div id="openDiv-disclosureBC" class="disclosure-notice__expanded-container hide">
             <div class="flex-this">
-                <div><img loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" alt="black square with the letters BC in the middle in white"></div>
+                <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" alt="black square with the letters BC in the middle in white"></div>
                 <div class="flex-this column margin-left-16">
                     <div class="w-90">
                         <h2 class="no-top-margin">Biocultural Notice</h2>
@@ -197,7 +197,7 @@
 
         <div id="openDiv-disclosureAI" class="disclosure-notice__expanded-container hide">
             <div class="flex-this">
-                <div><img loading="lazy" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="black square with an unfinished square in the middle in white"></div>
+                <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="black square with an unfinished square in the middle in white"></div>
                 <div class="flex-this column margin-left-16">
                     <div class="w-90">
                         <h2 class="no-top-margin">Attribution Incomplete Notice</h2>
@@ -254,7 +254,7 @@
             </div>
         </div>
         <div class="flex-this">
-            <div><img loading="lazy" src="{% static 'images/notices/collections-care/cc-overall-notice.png' %}" width="119px" alt=""></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-overall-notice.png' %}" width="119px" alt=""></div>
             <div class="flex-this column margin-left-16">
                 <div class="w-80">
                     <p>
@@ -280,45 +280,45 @@
 
                     <div class="flex-this space-between">
                         <div id="authorization" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" src="{% static 'images/notices/collections-care/cc-authorization.png' %}" width="119px" alt="Icon for Authorization Notice. Abstract design within a white square. Black circle above a set of three curved black lines with one curved black line below."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-authorization.png' %}" width="119px" alt="Icon for Authorization Notice. Abstract design within a white square. Black circle above a set of three curved black lines with one curved black line below."></div>
                             <div><p>Authorization</p></div>
                         </div>
                         <div id="belonging" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" src="{% static 'images/notices/collections-care/cc-belonging.png' %}" width="119px" alt="Icon for Belonging Notice. Abstract design within a white square. Three layered sets of black circles with two curved black lines representing three people."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-belonging.png' %}" width="119px" alt="Icon for Belonging Notice. Abstract design within a white square. Three layered sets of black circles with two curved black lines representing three people."></div>
                             <div><p>Belonging</p></div>
                         </div>
                         
                         <div id="caring" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" src="{% static 'images/notices/collections-care/cc-caring.png' %}" width="119px" alt="Icon for Caring Notice. Abstract design within a white square. Two curved black lines surround a black circle."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-caring.png' %}" width="119px" alt="Icon for Caring Notice. Abstract design within a white square. Two curved black lines surround a black circle."></div>
                             <div><p>Caring</p></div>
                         </div>
                     
                         <div id="gender-aware" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" src="{% static 'images/notices/collections-care/cc-gender-aware.png' %}" width="119px" alt="Icon for Gender Aware Notice. Abstract design within a white square. Three circles in a diagonal line: A black outlined circle, a black filled circle, and a striped black and white circle."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-gender-aware.png' %}" width="119px" alt="Icon for Gender Aware Notice. Abstract design within a white square. Three circles in a diagonal line: A black outlined circle, a black filled circle, and a striped black and white circle."></div>
                             <div><p>Gender Aware</p></div>
                         </div>
                     </div>
                     <div class="flex-this space-between">
                         <div id="leave-undisturbed" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" src="{% static 'images/notices/collections-care/cc-leave-undisturbed.png' %}" width="119px" alt="Icon for Leave Undisturbed Notice. Abstract design within a white square. A black circle in the center of two curved black lines which form a struck-through circle."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-leave-undisturbed.png' %}" width="119px" alt="Icon for Leave Undisturbed Notice. Abstract design within a white square. A black circle in the center of two curved black lines which form a struck-through circle."></div>
                             <div><p>Leave Undisturbed</p></div>
                         </div>
                         <div id="safety" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" src="{% static 'images/notices/collections-care/cc-safety.png' %}" width="119px" alt="Icon for Safety Notice. Abstract design within a white square. A black circle in the center of three curved black lines which form a circle."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-safety.png' %}" width="119px" alt="Icon for Safety Notice. Abstract design within a white square. A black circle in the center of three curved black lines which form a circle."></div>
                             <div><p>Safety</p></div>
                         </div>
                         <div id="viewing" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" src="{% static 'images/notices/collections-care/cc-viewing.png' %}" width="119px" alt="Icon for Viewing Notice. Abstract design within a white square. A black circle in the center of two curved lines, forming an abstract eye."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-viewing.png' %}" width="119px" alt="Icon for Viewing Notice. Abstract design within a white square. A black circle in the center of two curved lines, forming an abstract eye."></div>
                             <div><p>Viewing</p></div>
                         </div>
                         <div id="withholding" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" src="{% static 'images/notices/collections-care/cc-withholding.png' %}" width="119px" alt="Icon for Withholding Notice. Abstract design within a white square. A black circle in the center of two curved lines."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-withholding.png' %}" width="119px" alt="Icon for Withholding Notice. Abstract design within a white square. A black circle in the center of two curved lines."></div>
                             <div><p>Withholding</p></div>
                         </div>
                     </div>
 
                     <div id="openDiv-authorization" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" src="{% static 'images/notices/collections-care/cc-authorization.png' %}" width="119px" alt="Icon for Authorization Notice. Abstract design within a white square. Black circle above a set of three curved black lines with one curved black line below."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-authorization.png' %}" width="119px" alt="Icon for Authorization Notice. Abstract design within a white square. Black circle above a set of three curved black lines with one curved black line below."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Authorization</h2></div>
 
@@ -334,7 +334,7 @@
                     </div>
 
                     <div id="openDiv-belonging" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" src="{% static 'images/notices/collections-care/cc-belonging.png' %}" width="119px" alt="Icon for Belonging Notice. Abstract design within a white square. Three layered sets of black circles with two curved black lines representing three people."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-belonging.png' %}" width="119px" alt="Icon for Belonging Notice. Abstract design within a white square. Three layered sets of black circles with two curved black lines representing three people."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Belonging</h2></div>
 
@@ -349,7 +349,7 @@
                     </div>
 
                     <div id="openDiv-caring" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" src="{% static 'images/notices/collections-care/cc-caring.png' %}" width="119px" alt="Icon for Caring Notice. Abstract design within a white square. Two curved black lines surround a black circle."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-caring.png' %}" width="119px" alt="Icon for Caring Notice. Abstract design within a white square. Two curved black lines surround a black circle."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Caring</h2></div>
 
@@ -364,7 +364,7 @@
                     </div>
 
                     <div id="openDiv-gender-aware" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" src="{% static 'images/notices/collections-care/cc-gender-aware.png' %}" width="119px" alt="Icon for Gender Aware Notice. Abstract design within a white square. Three circles in a diagonal line: A black outlined circle, a black filled circle, and a striped black and white circle."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-gender-aware.png' %}" width="119px" alt="Icon for Gender Aware Notice. Abstract design within a white square. Three circles in a diagonal line: A black outlined circle, a black filled circle, and a striped black and white circle."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Gender Aware</h2></div>
 
@@ -379,7 +379,7 @@
                     </div>
 
                     <div id="openDiv-leave-undisturbed" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" src="{% static 'images/notices/collections-care/cc-leave-undisturbed.png' %}" width="119px" alt="Icon for Leave Undisturbed Notice. Abstract design within a white square. A black circle in the center of two curved black lines which form a struck-through circle."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-leave-undisturbed.png' %}" width="119px" alt="Icon for Leave Undisturbed Notice. Abstract design within a white square. A black circle in the center of two curved black lines which form a struck-through circle."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Leave Undisturbed</h2></div>
 
@@ -394,7 +394,7 @@
                     </div>
 
                     <div id="openDiv-safety" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" src="{% static 'images/notices/collections-care/cc-safety.png' %}" width="119px" alt="Icon for Safety Notice. Abstract design within a white square. A black circle in the center of three curved black lines which form a circle."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-safety.png' %}" width="119px" alt="Icon for Safety Notice. Abstract design within a white square. A black circle in the center of three curved black lines which form a circle."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Safety</h2></div>
 
@@ -409,7 +409,7 @@
                     </div>
 
                     <div id="openDiv-viewing" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" src="{% static 'images/notices/collections-care/cc-viewing.png' %}" width="119px" alt="Icon for Viewing Notice. Abstract design within a white square. A black circle in the center of two curved lines, forming an abstract eye."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-viewing.png' %}" width="119px" alt="Icon for Viewing Notice. Abstract design within a white square. A black circle in the center of two curved lines, forming an abstract eye."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Viewing</h2></div>
 
@@ -425,7 +425,7 @@
                     </div>
 
                     <div id="openDiv-withholding" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" src="{% static 'images/notices/collections-care/cc-withholding.png' %}" width="119px" alt="Icon for Withholding Notice. Abstract design within a white square. A black circle in the center of two curved lines."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-withholding.png' %}" width="119px" alt="Icon for Withholding Notice. Abstract design within a white square. A black circle in the center of two curved lines."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Withholding</h2></div>
 

--- a/templates/partials/_project-actions.html
+++ b/templates/partials/_project-actions.html
@@ -264,7 +264,7 @@
                             </div>
                             <div>
                                 <div class="margin-top-16">
-                                    <img loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="black square with white letters TK in the middle">
+                                    <img class="pointer-event-none" loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="black square with white letters TK in the middle">
                                 </div>
                                 <p>
                                     {{ notice.default_text }} <br><br>

--- a/templates/partials/infocards/_institution-card.html
+++ b/templates/partials/infocards/_institution-card.html
@@ -35,7 +35,7 @@
                     </div>
                     {% if institution.otc_institution_url.all %}
                         <div class="flex-this flex-end">
-                            <img src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="60px">
+                            <img class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="60px">
                         </div>
                     {% endif %}
                 {% endif %}

--- a/templates/partials/infocards/_researcher-card.html
+++ b/templates/partials/infocards/_researcher-card.html
@@ -34,7 +34,7 @@
                     </div>
                     {% if researcher.otc_researcher_url.all %}
                         <div class="flex-this flex-end">
-                            <img src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="60px">
+                            <img class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="60px">
                         </div>
                     {% endif %}
                 {% endif %}

--- a/templates/public.html
+++ b/templates/public.html
@@ -215,15 +215,15 @@
                 <h3>Notices Used</h3>
                 <div class="flex-this">
                     {% if bcnotice %} 
-                        <div class="margin-right-16"><img loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" width="90px" alt="black square with white letters BC in the middle"></div>
+                        <div class="margin-right-16"><img class="pointer-event-none" loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" width="90px" alt="black square with white letters BC in the middle"></div>
                     {% endif %}
 
                     {% if tknotice %} 
-                        <div class="margin-right-16"><img loading="lazy" src="{% static 'images/notices/tk-notice.png' %}" width="90px" alt="black square with white letters TK in the middle"></div>
+                        <div class="margin-right-16"><img class="pointer-event-none" loading="lazy" src="{% static 'images/notices/tk-notice.png' %}" width="90px" alt="black square with white letters TK in the middle"></div>
                     {% endif %}
 
                     {% if attrnotice %} 
-                        <div class="margin-right-16"><img loading="lazy" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="90px"></div>
+                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="90px"></div>
                     {% endif %}
                     {% if not bcnotice and not tknotice and not attrnotice %} No Notices to display yet {% endif %}
                 </div>
@@ -233,7 +233,7 @@
                 <div class="flex-this column">
                     <h3>Open To Collaboration</h3>
                     <div class="flex-this">
-                        <div class="margin-right-8"><img loading="lazy" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="90px" alt="black square with white rectangle being held by two hands in the middle"></div>
+                        <div class="margin-right-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="90px" alt="black square with white rectangle being held by two hands in the middle"></div>
                         <ul>
                             {% for notice in otc_notices %}
                                 <li>
@@ -321,15 +321,15 @@
                 <h3>Notices Used</h3>
                 <div class="flex-this">
                     {% if bcnotice %} 
-                        <div class="margin-right-16"><img loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" width="90px" alt="black square with white letters BC in the middle"></div>
+                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="90px" alt="black square with white letters BC in the middle"></div>
                     {% endif %}
 
                     {% if tknotice %} 
-                        <div class="margin-right-16"><img loading="lazy" src="{% static 'images/notices/tk-notice.png' %}" width="90px" alt="black square with white letters TK in the middle"></div>
+                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="90px" alt="black square with white letters TK in the middle"></div>
                     {% endif %}
 
                     {% if attrnotice %} 
-                        <div class="margin-right-16"><img loading="lazy" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="90px"></div>
+                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="90px"></div>
                     {% endif %}
                     {% if not bcnotice and not tknotice and not attrnotice %} No Notices to display yet {% endif %}
                 </div>
@@ -339,7 +339,7 @@
                 <div class="flex-this column">
                     <h3>Open To Collaboration</h3>
                     <div class="flex-this">
-                        <div class="margin-right-8"><img loading="lazy" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="90px" alt="black square with white rectangle being held by two hands in the middle"></div>
+                        <div class="margin-right-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="90px" alt="black square with white rectangle being held by two hands in the middle"></div>
                         <ul>
                             {% for notice in otc_notices %}
                                 <li>

--- a/templates/snippets/project_notices.html
+++ b/templates/snippets/project_notices.html
@@ -19,7 +19,7 @@
     <!-- NOTICE CHECKBOXES -->
     <div class="flex-this w-40 space-between margin-left-16 margin-bottom-16">     
         <div class="flex-this column center-text">
-            <div><img loading="lazy" src="{% static 'images/notices/tk-notice.png' %}" width="73px" alt="black square with white letters TK in the middle"></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="73px" alt="black square with white letters TK in the middle"></div>
             <div><p id="title-tk-notice" class="grey-text">Traditional<br> Knowledge Notice</p></div>
             <div class="notice-checkbox-container">
 
@@ -40,7 +40,7 @@
         </div>
 
         <div class="flex-this column center-text margin-left-16">
-            <div><img loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" width="73px" alt="black square with white letters BC in the middle"></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="73px" alt="black square with white letters BC in the middle"></div>
             <div><p id="title-bc-notice" class="grey-text">Biocultural<br> Notice</p></div>
             <div class="notice-checkbox-container">
 
@@ -62,7 +62,7 @@
         </div>
 
         <div class="flex-this column center-text margin-left-16 align-center">
-            <div><img loading="lazy" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="73px"></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="73px"></div>
             <div><p id="title-attr-notice" class="grey-text">Attribution Incomplete <br> Notice</p></div>
             <div class="notice-checkbox-container">
 
@@ -95,7 +95,7 @@
                     class="show"
                 >
                     <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                        <div class="w-15 pad-top-1"><img loading="lazy" src="{% static 'images/notices/tk-notice.png' %}" alt="black square with white letters TK in the middle"></div>
+                        <div class="w-15 pad-top-1"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="black square with white letters TK in the middle"></div>
                         <div class="w-80 pad-top-1">
                             <h3 class="no-top-margin">{{ notice.name }}</h3>
                             <p>
@@ -185,7 +185,7 @@
                     class="show"
                 >
                     <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                        <div class="w-15 pad-top-1"><img loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" alt="black square with white letters BC in the middle"></div>
+                        <div class="w-15 pad-top-1"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" alt="black square with white letters BC in the middle"></div>
                         <div class="w-80 pad-top-1">
                             <h3 class="no-top-margin">{{ notice.name }}</h3>
                             <p>
@@ -275,7 +275,7 @@
                     class="show"
                 >
                     <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                        <div class="w-15 pad-top-1"><img loading="lazy" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="black square with white letters BC in the middle"></div>
+                        <div class="w-15 pad-top-1"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="black square with white letters BC in the middle"></div>
                         <div class="w-80 pad-top-1">
                             <h3 class="no-top-margin">{{ notice.name }}</h3>
                             <p>
@@ -372,7 +372,7 @@
                 class="hide"
             >
                 <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                    <div class="w-15 pad-top-1"><img loading="lazy" src="{% static 'images/notices/tk-notice.png' %}" alt="black square with white letters TK in the middle"></div>
+                    <div class="w-15 pad-top-1"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="black square with white letters TK in the middle"></div>
                     <div class="w-80 pad-top-1">
                         <div>
                             <h3 class="no-top-margin">{{ notice.noticeName }}</h3>
@@ -449,7 +449,7 @@
                 class="hide"
             >
                 <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                    <div class="w-15 pad-top-1"><img loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" alt="black square with white letters BC in the middle"></div>
+                    <div class="w-15 pad-top-1"><img class="pointer-event-none" loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" alt="black square with white letters BC in the middle"></div>
                     <div class="w-80 pad-top-1">
                         <div>
                             <h3 class="no-top-margin">Biocultural Notice</h3>
@@ -524,7 +524,7 @@
                 class="hide"
             >
                 <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                    <div class="w-15 pad-top-1"><img loading="lazy" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="black square with white letters BC in the middle"></div>
+                    <div class="w-15 pad-top-1"><img class="pointer-event-none" loading="lazy" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="black square with white letters BC in the middle"></div>
                     <div class="w-80 pad-top-1">
                         <div>
                             <h3 class="no-top-margin">{{ notice.noticeName }}</h3>

--- a/templates/tklabels/mini-labels.html
+++ b/templates/tklabels/mini-labels.html
@@ -3,7 +3,7 @@
 <div>
     <img
         loading="lazy"
-        class="img-sizedown-small {% if not tklabel.is_approved %}opacity-4{% endif %}"
+        class="img-sizedown-small {% if not tklabel.is_approved %}opacity-4{% endif %} pointer-event-none"
 
         {% if tklabel.label_type == 'attribution' %} 
             src="{% static 'images/tk-labels/tk-attribution.png' %}" 

--- a/templates/tklabels/tiny-labels.html
+++ b/templates/tklabels/tiny-labels.html
@@ -3,7 +3,7 @@
 <div>
     <img
         loading="lazy"
-        class="img-sizedown-tiny {% if not tklabel.is_approved %}opacity-4{% endif %}"
+        class="img-sizedown-tiny {% if not tklabel.is_approved %}opacity-4{% endif %} pointer-event-none"
 
         {% if tklabel.label_type == 'attribution' %} 
             src="{% static 'images/tk-labels/tk-attribution.png' %}" 

--- a/templates/tklabels/which-label.html
+++ b/templates/tklabels/which-label.html
@@ -4,7 +4,7 @@
 <div>
     <img
         loading="lazy"
-        class="label-medium {% if not tklabel.is_approved %}opacity-4{% endif %}"
+        class="label-medium {% if not tklabel.is_approved %}opacity-4{% endif %} pointer-event-none"
 
         {% if tklabel.label_type == 'attribution' %} 
             src="{% static 'images/tk-labels/tk-attribution.png' %}" 


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8685v3xkd)**
  
- Description: Prevent others from downloading the icons from project pages instead of getting them from the api or project download.

**Solution:**
- Added pointer event none (css proporty) to labels/notices images.

**Before:**

https://github.com/localcontexts/localcontextshub/assets/145371882/70b133f8-ea1f-439b-8e06-cf98b47a9732


**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/3edf0cb7-0f2d-42ca-a657-df305b673cde

