### PR TITLE
8685ck3u5 remove code to run backups in run.sh

### DIFF
--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -11,7 +11,7 @@ steps:
     secretEnv: ["APP_ENGINE_ENVS", "DJANGO_STORAGES_GCS_KEY"]
     waitFor: ["-"]
 
-  - name: "hdizzle/lc:2023-12-11"
+  - name: "python:3.8-slim-buster"
     id: "install-deps"
     entrypoint: "bash"
     args:
@@ -20,7 +20,7 @@ steps:
         python3 -m pip install -r requirements.txt --user
     waitFor: [ "-" ]
 
-  - name: "hdizzle/lc:2023-12-11"
+  - name: "python:3.8-slim-buster"
     id: "collect-statics"
     entrypoint: "bash"
     args:
@@ -51,7 +51,7 @@ steps:
           && chmod +x /workspace/cloud_sql_proxy
     waitFor: ["-"]
 
-  - name: "hdizzle/lc:2023-12-11"
+  - name: "python:3.8-slim-buster"
     id: "migrate-db"
     entrypoint: "bash"
     args:

--- a/helpers/management/commands/run_data_backup.py
+++ b/helpers/management/commands/run_data_backup.py
@@ -9,8 +9,6 @@ from django.conf import settings
 from django.core import management
 from django.core.management.base import BaseCommand
 
-from apscheduler.schedulers.background import BlockingScheduler
-
 from dbbackup.storage import Storage
 from dbbackup.management.commands import dbbackup
 
@@ -134,6 +132,4 @@ class Command(BaseCommand):
         self.stdout.write(
             self.style.SUCCESS('Running backup Script')
         )
-        scheduler = BlockingScheduler()
-        scheduler.add_job(self.job, 'cron', minute='5,15,30,45,55')
-        scheduler.start()
+        self.job()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 appdirs==1.4.4
-apscheduler==3.10.4
 arabic-reshaper==3.0.0
 asgiref==3.2.10
 astroid==2.4.2

--- a/run.sh
+++ b/run.sh
@@ -8,5 +8,4 @@
 #
 
 . ./env.sh
-python manage.py run_data_backup &
 gunicorn -b :$PORT -w 2 --timeout 90 localcontexts.wsgi:application


### PR DESCRIPTION
Since we'll use Google Cloud to schedule jobs to run `manage.py run_data_backup`. We no longer need to run the data backup command in the run.sh right before running the `manage.py runserver` command.