### PR TITLE
remove newsletter from the footer for the sandbox

### DIFF
--- a/templates/partials/footers/_auth-footer.html
+++ b/templates/partials/footers/_auth-footer.html
@@ -13,7 +13,7 @@
                         <a class="underline-hover" href="https://localcontexts.org/contact/"> Contact Us</a> | 
                         <a id="feedback-form" class="pointer underline-hover">Report an Issue</a> |
                         <a class="underline-hover" href="/api">API</a> |
-                        {% if 'localhost' in request.get_host or 'localcontextshub' in request.get_host %}
+                        {% if 'localhost' in request.get_host or 'localcontextshub' in request.get_host and 'sandbox' not in request.get_host %}
                             <a class="underline-hover" href="{% url 'newsletter-subscription' %}">Newsletter</a> |
                         {% endif %}
                         <a class="underline-hover" href="https://localcontexts.org/privacy-policy/" target="_blank" rel="noopener">Privacy Policy <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a> | 


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8686p45we)**
  
- Description: Newsletter subscription is only available in PROD.
Currently when you click on the newsletter in the footer, it redirects to dashboard.
Remove the newsletter from there OR redirect to actual newsletter in PROD.

**Solution:**
- Removed the newsletter from the footer.


<img width="1100" alt="image" src="https://github.com/localcontexts/localcontextshub/assets/145371882/2ae2847b-e857-43cf-81cb-e6cbbdf85644">
