### PR TITLE
8686qqbhc bug notify multiple communities

### DIFF
--- a/institutions/views.py
+++ b/institutions/views.py
@@ -843,7 +843,8 @@ def project_actions(request, pk, project_uuid):
 
                         # Create email 
                         send_email_notice_placed(request, project, community, institution)
-                        return redirect('institution-project-actions', institution.id, project.unique_id)
+                        
+                    return redirect('institution-project-actions', institution.id, project.unique_id)
                 elif 'link_projects_btn' in request.POST:
                     selected_projects = request.POST.getlist('projects_to_link')
 

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -600,6 +600,7 @@ def project_actions(request, pk, project_uuid):
 
                             # Create email 
                             send_email_notice_placed(request, project, community, researcher)
+
                         return redirect('researcher-project-actions', researcher.id, project.unique_id)
                     elif 'link_projects_btn' in request.POST:
                         selected_projects = request.POST.getlist('projects_to_link')

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -600,7 +600,7 @@ def project_actions(request, pk, project_uuid):
 
                             # Create email 
                             send_email_notice_placed(request, project, community, researcher)
-                            return redirect('researcher-project-actions', researcher.id, project.unique_id)
+                        return redirect('researcher-project-actions', researcher.id, project.unique_id)
                     elif 'link_projects_btn' in request.POST:
                         selected_projects = request.POST.getlist('projects_to_link')
 


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8686qqbhc)**
  
- Description: Ashley tried to notify 2 communities of a Project and it only notified one and reported the bug on projects/action page. 
- Expected behavior:  All selected communities should be notified.

**Solution:**
- Removed the bug by setting the flow of for loop.

**Before:**

https://github.com/localcontexts/localcontextshub/assets/145371882/4d33d29b-6442-4256-832b-96ccb269da5f

**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/37c1e1db-6c1a-4e8c-b201-9dd108f5d426



