### PR TITLE
8686u8crr updated the url of PasswordResetView

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path, re_path
+from django.conf import settings
 from django.contrib.auth import views as auth_views
 from . import views
 
@@ -38,7 +39,7 @@ urlpatterns = [
     path('newsletter/preferences/<emailb64>/', views.newsletter_unsubscription, name='newsletter-unsubscription'),
 
 
-    path('reset-password/', auth_views.PasswordResetView.as_view(template_name="accounts/password-reset.html"), name="reset_password"),
+    path('reset-password/', auth_views.PasswordResetView.as_view(template_name="accounts/password-reset.html", from_email=settings.EMAIL_HOST_USER), name="reset_password"),
     path('reset-password-sent/', auth_views.PasswordResetDoneView.as_view(template_name="accounts/password-reset-sent.html"), name="password_reset_done"),
     path('reset/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(template_name="accounts/password-reset-confirm.html"), name="password_reset_confirm"),
     path('reset-password-complete/', auth_views.PasswordResetCompleteView.as_view(template_name="accounts/password-reset-done.html"), name="password_reset_complete"),


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8686u8crr)**
  
- Description: Several users in the production hub have tried to reset their password using the Forgot Password flow and then not be able to login with the new password or the old password. Most of the users didn't receive the forget Password email with the link to change passwod.

**Solution:**
- Removed the bug by updating the url for ResetPasswordView.


**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/443f6ae8-4268-49d2-9863-ed31abb003a5



