### PR TITLE
8686g6j1c notification indicator

### DIFF
--- a/localcontexts/static/css/main.css
+++ b/localcontexts/static/css/main.css
@@ -230,6 +230,7 @@ input:focus {
 .auto-margin { margin: auto; }
 .no-top-margin { margin-top: 0; }
 .no-bottom-margin { margin-bottom: 0; }
+.no-margin{margin:0 !important; }
 .margin-top-8 { margin-top: 8px; }
 .margin-bottom-8 { margin-bottom: 8px; }
 .margin-left-8 { margin-left: 8px; }
@@ -262,6 +263,9 @@ input:focus {
     border-bottom: 1px solid #E6F1F3;
 }
 
+/* Boder-Radius */
+.border-raduis50 { border-radius:50% !important; }
+
 /* FLEX */
 .flex-this { display: flex; }
 .row { flex-direction: row; }
@@ -293,6 +297,9 @@ input:focus {
 /* HEIGHTS */
 .h-25 { height: 25%; }
 .h-100 { height: 100% }
+
+/* GAP */
+.gap-1 { gap: 0.5rem;}
 
 /* ACTION Buttons / Register,Sign in, etc. */
 .primary-btn {
@@ -1067,6 +1074,15 @@ i[data-tooltip]:hover:after {
 
 .show { display: block; }
 .hide { display: none; }
+
+.notification-button {
+    background-color:#007385 !important;
+    color: #fff !important;
+}
+.notification-button > i {
+    background-color:#007385 !important;
+    color: #fff !important;
+}
 
 /* Textbox message add-members */
 .add-member-message {

--- a/localcontexts/static/javascript/main.js
+++ b/localcontexts/static/javascript/main.js
@@ -1329,26 +1329,32 @@ function toggleNotifications(scope) {
 
     let activebutton = document.getElementById(`notification-button-${scope}`);
     let allButtons = document.querySelectorAll('[id^="notification-button-"]');
-    allButtons.forEach(function(button) {
-        button.classList.remove('notification-button');
-    });
-
-    activebutton.classList.add('notification-button');
-    
     let allNotificationDivs = document.querySelectorAll('[id^="notification-v2-"]');
-    allNotificationDivs.forEach(function(element) {
-        element.classList.remove('show');
+    let activeNotificationDiv = document.getElementById(`notification-v2-${scope}`)
+    
+    allButtons.forEach(function(button) {
+        if (button !== activebutton) {
+            button.classList.remove('notification-button');
+    
+        }
     });
 
-    document.getElementById(`notification-v2-${scope}`).classList.toggle('show');
+    activebutton.classList.toggle('notification-button');    
+
+    allNotificationDivs.forEach(function(element) {
+        if (element !== activeNotificationDiv){
+            element.classList.remove('show');
+        }
+    });
+
+    activeNotificationDiv.classList.toggle('show');
+
     window.onclick = function(event) {
         if (!event.target.matches('.dropbtn, .dropbtn i')) {
-            // Remove the "notification-button" class from all buttons
             allButtons.forEach(function(button) {
                 button.classList.remove('notification-button');
             });
 
-            // Hide all notification divs
             allNotificationDivs.forEach(function(element) {
                 element.classList.remove('show');
             });

--- a/localcontexts/static/javascript/main.js
+++ b/localcontexts/static/javascript/main.js
@@ -1325,8 +1325,13 @@ function validateProjectDisableSubmitBtn() {
 
 }
 
-function toggleNotifications() {
-    document.getElementById('notification-v2').classList.toggle('show')
+function toggleNotifications(scope) {
+    // To hide all elements with the common prefix
+    let allNotificationDivs = document.querySelectorAll('[id^="notification-v2-"]');
+    allNotificationDivs.forEach(function(element) {
+        element.classList.remove('show');
+    });
+    document.getElementById('notification-v2-'+scope).classList.toggle('show')
 
     window.onclick = function(event) {
         if(!event.target.matches('.dropbtn')) {

--- a/localcontexts/static/javascript/main.js
+++ b/localcontexts/static/javascript/main.js
@@ -1326,6 +1326,9 @@ function validateProjectDisableSubmitBtn() {
 }
 
 function toggleNotifications(scope) {
+    let activebutton= document.getElementById(`notification-button-${scope}`)
+    activebutton.classList.add('notification-button');
+    
     // To hide all elements with the common prefix
     let allNotificationDivs = document.querySelectorAll('[id^="notification-v2-"]');
     allNotificationDivs.forEach(function(element) {
@@ -1334,7 +1337,8 @@ function toggleNotifications(scope) {
     document.getElementById('notification-v2-'+scope).classList.toggle('show')
 
     window.onclick = function(event) {
-        if(!event.target.matches('.dropbtn')) {
+        if(!event.target.matches('.dropbtn, .dropbtn i')) {
+            activebutton.classList.remove("notification-button")
             let dropdowns = document.getElementsByClassName("notification-dropdown-content")
             for (let i=0; i < dropdowns.length; i++) {
                 let openDropdown = dropdowns[i]

--- a/localcontexts/static/javascript/main.js
+++ b/localcontexts/static/javascript/main.js
@@ -1326,28 +1326,34 @@ function validateProjectDisableSubmitBtn() {
 }
 
 function toggleNotifications(scope) {
-    let activebutton= document.getElementById(`notification-button-${scope}`)
+
+    let activebutton = document.getElementById(`notification-button-${scope}`);
+    let allButtons = document.querySelectorAll('[id^="notification-button-"]');
+    allButtons.forEach(function(button) {
+        button.classList.remove('notification-button');
+    });
+
     activebutton.classList.add('notification-button');
     
-    // To hide all elements with the common prefix
     let allNotificationDivs = document.querySelectorAll('[id^="notification-v2-"]');
     allNotificationDivs.forEach(function(element) {
         element.classList.remove('show');
     });
-    document.getElementById('notification-v2-'+scope).classList.toggle('show')
 
+    document.getElementById(`notification-v2-${scope}`).classList.toggle('show');
     window.onclick = function(event) {
-        if(!event.target.matches('.dropbtn, .dropbtn i')) {
-            activebutton.classList.remove("notification-button")
-            let dropdowns = document.getElementsByClassName("notification-dropdown-content")
-            for (let i=0; i < dropdowns.length; i++) {
-                let openDropdown = dropdowns[i]
-                if (openDropdown.classList.contains('show')) {
-                    openDropdown.classList.remove('show')
-                }
-            }
+        if (!event.target.matches('.dropbtn, .dropbtn i')) {
+            // Remove the "notification-button" class from all buttons
+            allButtons.forEach(function(button) {
+                button.classList.remove('notification-button');
+            });
+
+            // Hide all notification divs
+            allNotificationDivs.forEach(function(element) {
+                element.classList.remove('show');
+            });
         }
-    }
+    };
 }
 
 if (window.location.href.includes('connect-community') || window.location.href.includes('connect-institution')) {

--- a/templates/accounts/dashboard.html
+++ b/templates/accounts/dashboard.html
@@ -1,6 +1,6 @@
 {% extends 'auth-base.html' %} {% block title %} Home {% endblock %}{% load static %} {% block main %}
 
-    {% include 'partials/infocards/_user-dashcard.html' %}
+    {% include 'partials/infocards/_user-dashcard.html' with scope=user %}
 
     <div class="flex-this justify-center">{% include 'partials/_alerts.html' %}</div>
     

--- a/templates/partials/infocards/_community-card.html
+++ b/templates/partials/infocards/_community-card.html
@@ -30,7 +30,10 @@
                         href="{% url 'public-community' community.id %}" 
                     >View public page</a>
                 {% endif %}
- 
+
+                {% include 'snippets/notifications.html' with scope=community %}
+                <br>
+                
                 {% if '/dashboard/' in request.path %}
                     {% if approved_label %}
                         {% if request.user in community.get_collaborator or request.user == community.community_creator %}

--- a/templates/partials/infocards/_community-card.html
+++ b/templates/partials/infocards/_community-card.html
@@ -33,17 +33,17 @@
 
                 <div class="margin-right-8">                 
                     {% if '/dashboard/' in request.path %}
-                    {% if approved_label %}
-                    {% if request.user in community.get_collaborator or request.user == community.community_creator %}
-                    <a class="primary-btn action-btn" href="{% url 'community-projects' community.id %}">View account</a>
-                    {% endif %}
-                    {% else %}
-                    <a class="primary-btn action-btn" href="{% url 'select-label' community.id %}">View account</a>
-                    {% endif %} 
+                        {% if approved_label %}
+                            {% if request.user in community.get_collaborator or request.user == community.community_creator %}
+                                <a class="primary-btn action-btn" href="{% url 'community-projects' community.id %}">View account</a>
+                            {% endif %}
+                        {% else %}
+                            <a class="primary-btn action-btn" href="{% url 'select-label' community.id %}">View account</a>
+                        {% endif %} 
                     {% endif %}
                     
                     {% if request.user in  community.get_viewers and approved_label %}
-                    <a class="primary-btn action-btn" href="{% url 'select-label' community.id %}">View account</a>
+                        <a class="primary-btn action-btn" href="{% url 'select-label' community.id %}">View account</a>
                     {% endif %}
                 </div>
                 <!-- Notification -->

--- a/templates/partials/infocards/_community-card.html
+++ b/templates/partials/infocards/_community-card.html
@@ -23,7 +23,7 @@
         </div>
 
         <div class="dashcard-btn-container">
-            <div class="margin-left-16">
+            <div class="margin-left-16 flex-this gap-1">
                 {% if '/registry/' in request.path %}
                     <a 
                         class="primary-btn action-btn"
@@ -31,21 +31,28 @@
                     >View public page</a>
                 {% endif %}
 
-                {% include 'snippets/notifications.html' with scope=community %}
-                <br>
-                
-                {% if '/dashboard/' in request.path %}
+                <div class="margin-right-8">                 
+                    {% if '/dashboard/' in request.path %}
                     {% if approved_label %}
-                        {% if request.user in community.get_collaborator or request.user == community.community_creator %}
-                            <a class="primary-btn action-btn" href="{% url 'community-projects' community.id %}">View account</a>
-                        {% endif %}
+                    {% if request.user in community.get_collaborator or request.user == community.community_creator %}
+                    <a class="primary-btn action-btn" href="{% url 'community-projects' community.id %}">View account</a>
+                    {% endif %}
                     {% else %}
-                        <a class="primary-btn action-btn" href="{% url 'select-label' community.id %}">View account</a>
-                    {% endif %} 
-                {% endif %}
-
-                {% if request.user in  community.get_viewers and approved_label %}
                     <a class="primary-btn action-btn" href="{% url 'select-label' community.id %}">View account</a>
+                    {% endif %} 
+                    {% endif %}
+                    
+                    {% if request.user in  community.get_viewers and approved_label %}
+                    <a class="primary-btn action-btn" href="{% url 'select-label' community.id %}">View account</a>
+                    {% endif %}
+                </div>
+                <!-- Notification -->
+                {% include 'snippets/notifications.html' with scope=community %}
+                <!-- Settings -->
+                {% if request.user == community.community_creator or member_role == 'admin' %}
+                    <div>
+                        <a href="{% url 'update-community' community.id %}" class=" border-raduis50 darkteal-text primary-btn white-btn"><i class=" no-margin fa fa-cog" aria-hidden="true"></i></a>
+                    </div>
                 {% endif %}
             </div>
         </div>

--- a/templates/partials/infocards/_community-dashcard.html
+++ b/templates/partials/infocards/_community-dashcard.html
@@ -15,7 +15,7 @@
 
             <!-- Notifications -->
             <div class="flex-this w-30 flex-end">
-                {% include 'snippets/notifications.html' %}
+                {% include 'snippets/notifications.html' with scope=community %}
 
                 <!-- Settings -->
                 {% if request.user == community.community_creator or member_role == 'admin' %}

--- a/templates/partials/infocards/_institution-card.html
+++ b/templates/partials/infocards/_institution-card.html
@@ -25,7 +25,7 @@
         </div>
 
         <div class="dashcard-btn-container">
-            <div class="margin-left-16">
+            <div class="margin-left-16 flex-this gap-1">
                 {% if '/registry/' in request.path %}
                     <div class="margin-bottom-16">
                         <a 
@@ -40,30 +40,37 @@
                     {% endif %}
                 {% endif %}
 
-
-                {% include 'snippets/notifications.html' with scope=institution %}
-                <br>
-                
-                {% if '/dashboard/' in request.path %}
-                    {% if institution_projects %}
-                        {% if request.user in institution.get_distinct_creators  %}
-                            <a 
-                                class="primary-btn action-btn"
-                                href="{% url 'institution-projects' institution.id %}"
-                            >View account</a>
+                <div class="margin-right-8">
+                    {% if '/dashboard/' in request.path %}
+                        {% if institution_projects %}
+                            {% if request.user in institution.get_distinct_creators  %}
+                                <a 
+                                    class="primary-btn action-btn"
+                                    href="{% url 'institution-projects' institution.id %}"
+                                >View account</a>
+                            {% else %}
+                                <a 
+                                    class="primary-btn action-btn"
+                                    href="{% url 'institution-notices' institution.id %}"
+                                >View account</a>
+                            {% endif %}
                         {% else %}
                             <a 
                                 class="primary-btn action-btn"
                                 href="{% url 'institution-notices' institution.id %}"
                             >View account</a>
                         {% endif %}
-                    {% else %}
-                        <a 
-                            class="primary-btn action-btn"
-                            href="{% url 'institution-notices' institution.id %}"
-                        >View account</a>
                     {% endif %}
+                </div>
+                <!-- Notification -->
+                {% include 'snippets/notifications.html' with scope=institution %}
+                <!-- Settings -->
+                {% if request.user == institution.institution_creator or member_role == 'admin'%}
+                    <div>
+                        <a href="{% url 'update-institution' institution.id%}" class="border-raduis50 darkteal-text primary-btn white-btn"><i class="no-margin fa fa-cog" aria-hidden="true"></i></a>
+                    </div>
                 {% endif %}
+               
             </div>
         </div>
 

--- a/templates/partials/infocards/_institution-card.html
+++ b/templates/partials/infocards/_institution-card.html
@@ -40,6 +40,10 @@
                     {% endif %}
                 {% endif %}
 
+
+                {% include 'snippets/notifications.html' with scope=institution %}
+                <br>
+                
                 {% if '/dashboard/' in request.path %}
                     {% if institution_projects %}
                         {% if request.user in institution.get_distinct_creators  %}

--- a/templates/partials/infocards/_institution-dashcard.html
+++ b/templates/partials/infocards/_institution-dashcard.html
@@ -15,7 +15,7 @@
 
             <!-- Notifications -->
             <div class="flex-this w-30 flex-end">
-                {% include 'snippets/notifications.html' %}
+                {% include 'snippets/notifications.html' with scope=institution %}
 
                 {% if request.user == institution.institution_creator or member_role == 'admin'%}
                     <div class="margin-left-8">

--- a/templates/partials/infocards/_researcher-card.html
+++ b/templates/partials/infocards/_researcher-card.html
@@ -39,6 +39,9 @@
                     {% endif %}
                 {% endif %}
 
+                {% include 'snippets/notifications.html' with scope=researcher.id %}
+                <br>
+
                 {% if '/dashboard/' in request.path %}
                     {% if researcher.get_projects %}
                         <a 

--- a/templates/partials/infocards/_researcher-card.html
+++ b/templates/partials/infocards/_researcher-card.html
@@ -41,17 +41,17 @@
 
                 <div class="margin-right-8">
                     {% if '/dashboard/' in request.path %}
-                    {% if researcher.get_projects %}
-                    <a 
-                    class="primary-btn action-btn"
-                    href="{% url 'researcher-projects' researcher.id %}"
-                    >View account</a>
-                    {% else %}
-                    <a 
-                    class="primary-btn action-btn"
-                    href="{% url 'researcher-notices' researcher.id %}"
-                    >View account</a>
-                    {% endif %}
+                        {% if researcher.get_projects %}
+                            <a 
+                            class="primary-btn action-btn"
+                            href="{% url 'researcher-projects' researcher.id %}"
+                            >View account</a>
+                        {% else %}
+                            <a 
+                            class="primary-btn action-btn"
+                            href="{% url 'researcher-notices' researcher.id %}"
+                            >View account</a>
+                        {% endif %}
                     {% endif %}
                 </div>
                 <!-- Notification -->

--- a/templates/partials/infocards/_researcher-card.html
+++ b/templates/partials/infocards/_researcher-card.html
@@ -24,7 +24,7 @@
         </div>
 
         <div class="dashcard-btn-container">
-            <div class="margin-left-16">
+            <div class="margin-left-16 flex-this gap-1">
                 {% if '/registry/' in request.path %}
                     <div class="margin-bottom-16">
                         <a 
@@ -39,22 +39,25 @@
                     {% endif %}
                 {% endif %}
 
-                {% include 'snippets/notifications.html' with scope=researcher.id %}
-                <br>
-
-                {% if '/dashboard/' in request.path %}
+                <div class="margin-right-8">
+                    {% if '/dashboard/' in request.path %}
                     {% if researcher.get_projects %}
-                        <a 
-                            class="primary-btn action-btn"
-                            href="{% url 'researcher-projects' researcher.id %}"
-                        >View account</a>
+                    <a 
+                    class="primary-btn action-btn"
+                    href="{% url 'researcher-projects' researcher.id %}"
+                    >View account</a>
                     {% else %}
-                        <a 
-                            class="primary-btn action-btn"
-                            href="{% url 'researcher-notices' researcher.id %}"
-                        >View account</a>
+                    <a 
+                    class="primary-btn action-btn"
+                    href="{% url 'researcher-notices' researcher.id %}"
+                    >View account</a>
                     {% endif %}
-                {% endif %}
+                    {% endif %}
+                </div>
+                <!-- Notification -->
+                {% include 'snippets/notifications.html' with scope=researcher.id %}
+                <!-- Settings -->
+                <div><a href="{% url 'update-researcher' researcher.id %}" class="border-raduis50  darkteal-text primary-btn white-btn"><i class="no-margin fa fa-cog" aria-hidden="true"></i></a></div>
             </div>
         </div>
 

--- a/templates/partials/infocards/_researcher-dashcard.html
+++ b/templates/partials/infocards/_researcher-dashcard.html
@@ -17,7 +17,7 @@
             {% if user_can_view %}
                 <!-- Notifications -->
                 <div class="flex-this w-30 flex-end">
-                    {% include 'snippets/notifications.html' %}
+                    {% include 'snippets/notifications.html' with scope=researcher %}
 
                     <div class="margin-left-8"><a href="{% url 'update-researcher' researcher.id %}" class="darkteal-text primary-btn white-btn">Settings <i class="fa fa-cog" aria-hidden="true"></i></a></div>
                 </div>

--- a/templates/partials/infocards/_user-dashcard.html
+++ b/templates/partials/infocards/_user-dashcard.html
@@ -41,7 +41,7 @@
                 <div class="margin-right-8"><a href="{% url 'dashboard' %}" class="primary-btn white-btn">Back to Profile</a></div>
             {% else %}
                 <!-- Notifications -->
-                {% include 'snippets/notifications.html' %}
+                {% include 'snippets/notifications.html' with scope=user %}
                     
                 <div><a href="{% url 'update-profile' %}" class="primary-btn green-btn">Edit profile <i class="fa fa-pencil" aria-hidden="true"></i></a></div>
             {% endif %}

--- a/templates/snippets/notifications.html
+++ b/templates/snippets/notifications.html
@@ -12,40 +12,40 @@
 <div class="dropdown margin-right-8" >
 
     {% if 'dashboard' in request.path  and scope != user %}
-    <div class="no-margin">
-        <a id="notification-button-{{scope|cut:"'"}}" onclick="toggleNotifications('{{ scope|cut:"'" }}')" class="primary-btn white-btn dropbtn border-raduis50">
-            <i 
-            class="
-                {% if unread_exist_user and 'dashboard' in request.path and scope == user %} no-margin fa-solid fa-bell-on orange-text 
-                {% elif unread_exist_community %} no-margin fa-solid fa-bell-on orange-text 
-                {% elif unread_exist_institution %} no-margin fa-solid fa-bell-on orange-text 
-                {% elif unread_exist_researcher and scope == researcher %} no-margin fa-solid fa-bell-on orange-text
-                {% elif unread_exist_researcher and scope == researcher.id %} no-margin fa-solid fa-bell-on orange-text
-                {% elif return_notifications %} no-margin fa-regular fa-bell 
-                {% else %} no-margin fa-regular fa-bell {% endif %} 
-                " 
-            aria-hidden="true"
-            ></i>
-        </a>
-    </div>
+        <div class="no-margin">
+            <a id="notification-button-{{scope|cut:"'"}}" onclick="toggleNotifications('{{ scope|cut:"'" }}')" class="primary-btn white-btn dropbtn border-raduis50">
+                <i 
+                class="
+                    {% if unread_exist_user and 'dashboard' in request.path and scope == user %} no-margin fa-solid fa-bell-on orange-text 
+                    {% elif unread_exist_community %} no-margin fa-solid fa-bell-on orange-text 
+                    {% elif unread_exist_institution %} no-margin fa-solid fa-bell-on orange-text 
+                    {% elif unread_exist_researcher and scope == researcher %} no-margin fa-solid fa-bell-on orange-text
+                    {% elif unread_exist_researcher and scope == researcher.id %} no-margin fa-solid fa-bell-on orange-text
+                    {% elif return_notifications %} no-margin fa-regular fa-bell 
+                    {% else %} no-margin fa-regular fa-bell {% endif %} 
+                    " 
+                aria-hidden="true"
+                ></i>
+            </a>
+        </div>
     {% else %}
-    <div>
-        <a id="notification-button-{{scope|cut:"'"}}" onclick="toggleNotifications('{{ scope|cut:"'" }}')" class="primary-btn white-btn dropbtn"> 
-            Notifications
-            <i 
-            class="
-                {% if unread_exist_user and 'dashboard' in request.path and scope == user %} fa-solid fa-bell-on orange-text 
-                {% elif unread_exist_community %} fa-solid fa-bell-on orange-text 
-                {% elif unread_exist_institution %} fa-solid fa-bell-on orange-text 
-                {% elif unread_exist_researcher and scope == researcher %} fa-solid fa-bell-on orange-text
-                {% elif unread_exist_researcher and scope == researcher.id %} fa-solid fa-bell-on orange-text
-                {% elif return_notifications %} fa-regular fa-bell 
-                {% else %} fa-regular fa-bell {% endif %} 
-                " 
-            aria-hidden="true"
-            ></i>
-        </a>
-    </div>
+        <div>
+            <a id="notification-button-{{scope|cut:"'"}}" onclick="toggleNotifications('{{ scope|cut:"'" }}')" class="primary-btn white-btn dropbtn"> 
+                Notifications
+                <i 
+                class="
+                    {% if unread_exist_user and 'dashboard' in request.path and scope == user %} fa-solid fa-bell-on orange-text 
+                    {% elif unread_exist_community %} fa-solid fa-bell-on orange-text 
+                    {% elif unread_exist_institution %} fa-solid fa-bell-on orange-text 
+                    {% elif unread_exist_researcher and scope == researcher %} fa-solid fa-bell-on orange-text
+                    {% elif unread_exist_researcher and scope == researcher.id %} fa-solid fa-bell-on orange-text
+                    {% elif return_notifications %} fa-regular fa-bell 
+                    {% else %} fa-regular fa-bell {% endif %} 
+                    " 
+                aria-hidden="true"
+                ></i>
+            </a>
+        </div>
     {% endif %}
     <div id="notification-v2-{{ scope|cut:"'" }}" class="notification-dropdown-content">
     <div class="border-bottom-solid-teal center-text">

--- a/templates/snippets/notifications.html
+++ b/templates/snippets/notifications.html
@@ -9,23 +9,45 @@
 {% return_notifications researcher as researcher_notifications %}
 
 
-<div class="dropdown margin-right-8">
-    <a onclick="toggleNotifications('{{ scope|escapejs }}')" class="primary-btn white-btn dropbtn"> 
-        Notifications
-        <i 
-        class="
-            {% if unread_exist_user and 'dashboard' in request.path and scope == user %} fa-solid fa-bell-on orange-text 
-            {% elif unread_exist_community %} fa-solid fa-bell-on orange-text 
-            {% elif unread_exist_institution %} fa-solid fa-bell-on orange-text 
-            {% elif unread_exist_researcher and scope == researcher %} fa-solid fa-bell-on orange-text
-            {% elif unread_exist_researcher and scope == researcher.id %} fa-solid fa-bell-on orange-text
-            {% elif return_notifications %} fa-regular fa-bell 
-            {% else %} fa-regular fa-bell {% endif %} 
-            " 
-        aria-hidden="true"
-        ></i>
-    </a>
-    <div id="notification-v2-{{ scope }}" class="notification-dropdown-content">
+<div class="dropdown margin-right-8" >
+
+    {% if 'dashboard' in request.path  and scope != user %}
+    <div class="no-margin">
+        <a id="notification-button-{{scope|cut:"'"}}" onclick="toggleNotifications('{{ scope|cut:"'" }}')" class="primary-btn white-btn dropbtn border-raduis50">
+            <i 
+            class="
+                {% if unread_exist_user and 'dashboard' in request.path and scope == user %} no-margin fa-solid fa-bell-on orange-text 
+                {% elif unread_exist_community %} no-margin fa-solid fa-bell-on orange-text 
+                {% elif unread_exist_institution %} no-margin fa-solid fa-bell-on orange-text 
+                {% elif unread_exist_researcher and scope == researcher %} no-margin fa-solid fa-bell-on orange-text
+                {% elif unread_exist_researcher and scope == researcher.id %} no-margin fa-solid fa-bell-on orange-text
+                {% elif return_notifications %} no-margin fa-regular fa-bell 
+                {% else %} no-margin fa-regular fa-bell {% endif %} 
+                " 
+            aria-hidden="true"
+            ></i>
+        </a>
+    </div>
+    {% else %}
+    <div>
+        <a id="notification-button-{{scope|cut:"'"}}" onclick="toggleNotifications('{{ scope|cut:"'" }}')" class="primary-btn white-btn dropbtn"> 
+            Notifications
+            <i 
+            class="
+                {% if unread_exist_user and 'dashboard' in request.path and scope == user %} fa-solid fa-bell-on orange-text 
+                {% elif unread_exist_community %} fa-solid fa-bell-on orange-text 
+                {% elif unread_exist_institution %} fa-solid fa-bell-on orange-text 
+                {% elif unread_exist_researcher and scope == researcher %} fa-solid fa-bell-on orange-text
+                {% elif unread_exist_researcher and scope == researcher.id %} fa-solid fa-bell-on orange-text
+                {% elif return_notifications %} fa-regular fa-bell 
+                {% else %} fa-regular fa-bell {% endif %} 
+                " 
+            aria-hidden="true"
+            ></i>
+        </a>
+    </div>
+    {% endif %}
+    <div id="notification-v2-{{ scope|cut:"'" }}" class="notification-dropdown-content">
     <div class="border-bottom-solid-teal center-text">
         <span class="orange-text bold">Notifications</span>
     </div>

--- a/templates/snippets/notifications.html
+++ b/templates/snippets/notifications.html
@@ -10,7 +10,7 @@
 
 
 <div class="dropdown margin-right-8">
-    <a onclick="toggleNotifications('{{ scope }}')" class="primary-btn white-btn dropbtn"> 
+    <a onclick="toggleNotifications('{{ scope|escapejs }}')" class="primary-btn white-btn dropbtn"> 
         Notifications
         <i 
         class="

--- a/templates/snippets/notifications.html
+++ b/templates/snippets/notifications.html
@@ -10,25 +10,26 @@
 
 
 <div class="dropdown margin-right-8">
-    <a onclick="toggleNotifications()" class="primary-btn white-btn dropbtn"> 
-        Notifications 
+    <a onclick="toggleNotifications('{{ scope }}')" class="primary-btn white-btn dropbtn"> 
+        Notifications
         <i 
         class="
-            {% if unread_exist_user and 'dashboard' in request.path %} fa-solid fa-bell-on orange-text 
+            {% if unread_exist_user and 'dashboard' in request.path and scope == user %} fa-solid fa-bell-on orange-text 
             {% elif unread_exist_community %} fa-solid fa-bell-on orange-text 
             {% elif unread_exist_institution %} fa-solid fa-bell-on orange-text 
-            {% elif unread_exist_researcher and not 'dashboard' in request.path %} fa-solid fa-bell-on orange-text 
+            {% elif unread_exist_researcher and scope == researcher %} fa-solid fa-bell-on orange-text
+            {% elif unread_exist_researcher and scope == researcher.id %} fa-solid fa-bell-on orange-text
+            {% elif return_notifications %} fa-regular fa-bell 
             {% else %} fa-regular fa-bell {% endif %} 
             " 
         aria-hidden="true"
         ></i>
     </a>
-    <div id="notification-v2" class="notification-dropdown-content">
+    <div id="notification-v2-{{ scope }}" class="notification-dropdown-content">
     <div class="border-bottom-solid-teal center-text">
         <span class="orange-text bold">Notifications</span>
     </div>
-
-        {% if user_notifications and '/dashboard/' in request.path %}
+        {% if user_notifications and '/dashboard/' in request.path and scope == user %}
             {% for n in user_notifications %}
 
                 <div class="border-bottom-solid-teal flex-this space-between">
@@ -70,7 +71,7 @@
         {% endif %}
 
 
-        {% if community %}
+        {% if community and scope == community %}
 
             {% if community_notifications %}
                 {% for n in community_notifications %}
@@ -130,7 +131,7 @@
 
         {% endif %}
 
-        {% if institution %}
+        {% if institution  and scope == institution %}
 
             {% if institution_notifications %}
                 {% for n in institution_notifications %}
@@ -183,7 +184,7 @@
 
         {% endif %}
         
-        {% if researcher and not '/dashboard/' in request.path %}
+        {% if researcher and scope == researcher.id or scope == researcher %}
 
             {% if researcher_notifications %}
                 {% for n in researcher_notifications %}


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8686g6j1c)**
  
- Description: There should be some indicator on the dasboard of any accounts that have notifications or how many notifications are in the account. Since the dashboard only shows notifications for the user's account, there is no way of knowing if an institution or community account the user is a part of has notifications pending unless the go into the account and look at the notification icon.

**Solution:**
- Added notification snippet to the dashboard's every card.
- Provided scope for notification snippet to get the notification of individual card.
- Handle notification for individual card and their read and unread status.
- Added settings button to respective account card.

**Before:**
![notification(1)](https://github.com/localcontexts/localcontextshub/assets/145371882/b0e2bae6-6d13-4714-b591-b7e3d4a0aa63)

![notification(2)](https://github.com/localcontexts/localcontextshub/assets/145371882/3a1ed6c5-6577-4365-b8a0-58d77bb284f4)

**After:**


https://github.com/localcontexts/localcontextshub/assets/145371882/e179a8ed-e64e-448f-9eff-6d7682c67a1d




