### PR TITLE
8685tnmg0 alt text for notices and labels

### DIFF
--- a/templates/accounts/select-account.html
+++ b/templates/accounts/select-account.html
@@ -16,7 +16,7 @@
                         </span>
                     </div>                    
                 </div>
-                <div><img loading="lazy" class="tiny-label pointer-event-none" src="{% static 'images/tk-labels/tk-attribution.png' %}"></div>
+                <div><img loading="lazy" class="tiny-label pointer-event-none" src="{% static 'images/tk-labels/tk-attribution.png' %}" alt="TK Attribution (TK A) Label"></div>
                 <p><strong>Who?</strong> An Indigenous or local community entity or representative</p>
                 <p class="no-top-margin"><strong>What?</strong> Customize and apply TK and BC Labels, and create Projects</p>
                 <a href="{% url 'connect-community' %}"><div class="primary-btn white-btn-select"><span>Join</span></div></a>
@@ -31,8 +31,8 @@
                 </div>
                 <div class="flex-this">
                     <div class="margin-right-1"><img loading="lazy" 
-                    class="tiny-notice pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}"></div>
-                    <div class="margin-left-16"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}"></div>
+                    class="tiny-notice pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="black square with white letters TK in the middle"></div>
+                    <div class="margin-left-16"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" alt="black square with white rectangle being held by two hands in the middle"></div>
                 </div>
                 <p><strong>Who?</strong> Cultural or research institution, data repository, and other organizations</p>
                 <p><strong>What?</strong> Create projects and generate Notices</p>
@@ -42,8 +42,8 @@
             <div class="account-card margin-left-1">
                 <p><strong>Researcher Account</strong></p>
                 <div class="flex-this">
-                    <div class="margin-right-1"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}"></div>
-                    <div class="margin-left-16"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}"></div>
+                    <div class="margin-right-1"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="black square with white letters TK in the middle"></div>
+                    <div class="margin-left-16"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" alt="black square with white letters BC in the middle"></div>
                 </div>
                 <p><strong>Who?</strong> An individual who carries out academic or scientific research independently or in an institution </p>
                 <p><strong>What?</strong> Create projects and generate Notices</p>

--- a/templates/communities/apply-labels.html
+++ b/templates/communities/apply-labels.html
@@ -71,13 +71,13 @@
                             {% for notice in project.project_notice.all %}
                                 {% if not notice.archived %}
                                     {% if notice.notice_type == 'biocultural' %}
-                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="62px"></div>
+                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="62px" alt="black square with white letters BC in the middle"></div>
                                     {% endif %}
                                     {% if notice.notice_type == 'traditional_knowledge' %}
-                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="62px"></div>
+                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="62px" alt="black square with white letters TK in the middle"></div>
                                     {% endif %}
                                     {% if notice.notice_type == 'attribution_incomplete' %}
-                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="62px"></div>
+                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="62px" alt="black square with an unfinished square in the middle in white"></div>
                                     {% endif %}
                                 {% endif %}
                             {% endfor %}

--- a/templates/communities/select-label.html
+++ b/templates/communities/select-label.html
@@ -126,7 +126,7 @@
     {% for bclabel in bclabels %}
         <div id="open-div-{{ bclabel.unique_id }}" style="height: 0px; overflow: hidden;" class="div-toggle">
             <div class="full-label-card flex-this">
-                <div class="margin-right-16"><img src="{{bclabel.img_url}}" class="label-large pointer-event-none"></div>
+                <div class="margin-right-16"><img src="{{bclabel.img_url}}" class="label-large pointer-event-none" alt="{{ bclabel.name }} Label"></div>
                 <div>
                     <div class="flex-this space-between">
                         <div><h3 class="no-top-margin">{{ bclabel.name }}</h3></div>
@@ -185,7 +185,7 @@
         <div id="open-div-{{ tklabel.unique_id }}" style="height: 0px; overflow: hidden;" class="div-toggle">
             <div class="full-label-card flex-this">
                 <div class="margin-right-16">
-                    <img src="{{ tklabel.img_url }}" class="label-large pointer-event-none">
+                    <img src="{{ tklabel.img_url }}" class="label-large  pointer-event-none" alt="{{ tklabel.name }} Label">
                 </div>
                 <div>
                     <div class="flex-this space-between">
@@ -337,22 +337,22 @@
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
 
                         <div id="tklabel-expanded-img-tka" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tka' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tka' %}" class="default-label-img pointer-event-none" alt="TK Attribution (TK A) Label">
                         </div>
                         <div id="tklabel-expanded-img-tkcl" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcl' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcl' %}" class="default-label-img pointer-event-none" alt="TK Clan (TK CL) Label">
                         </div>
                         <div id="tklabel-expanded-img-tkf" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkf' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkf' %}" class="default-label-img pointer-event-none" alt="TK Family (TK F) Label">
                         </div>
                         <div id="tklabel-expanded-img-tkmc" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmc' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmc' %}" class="default-label-img pointer-event-none" alt="TK Multiple Communities (TK MC) Label">
                         </div>
                         <div id="tklabel-expanded-img-tkcv" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcv' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcv' %}" class="default-label-img pointer-event-none" alt="TK Community Voice (TK CV) Label ">
                         </div>
                         <div id="tklabel-expanded-img-tkcr" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcr' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcr' %}" class="default-label-img pointer-event-none" alt="TK Creative (TK CR) Label">
                         </div>
                         
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -454,31 +454,31 @@
                 <div class="flex-this">
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
                         <div id="tklabel-expanded-img-tknv" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tknv' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tknv' %}" class="default-label-img pointer-event-none" alt="TK Non-Verified (TK NV) Label">
                         </div>
                         <div id="tklabel-expanded-img-tkv" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkv' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkv' %}" class="default-label-img pointer-event-none" alt="TK Verified (TK V) Label">
                         </div>
                         <div id="tklabel-expanded-img-tks" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tks' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tks' %}" class="default-label-img pointer-event-none" alt="TK Seasonal (TK S) Label">
                         </div>
                         <div id="tklabel-expanded-img-tkwg" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkwg' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkwg' %}" class="default-label-img pointer-event-none" alt="TK Weomen General (TK WG) Label">
                         </div>
                         <div id="tklabel-expanded-img-tkmg" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmg' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmg' %}" class="default-label-img pointer-event-none" alt="TK Men General (TK MG) Label">
                         </div>
                         <div id="tklabel-expanded-img-tkmr" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmr' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmr' %}" class="default-label-img pointer-event-none" alt="TK Men Restricted (TK MR) Label">
                         </div>
                         <div id="tklabel-expanded-img-tkwr" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkwr' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkwr' %}" class="default-label-img pointer-event-none" alt="TK Women Restricted (TK WR) Label">
                         </div>
                         <div id="tklabel-expanded-img-tkcs" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcs' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcs' %}" class="default-label-img pointer-event-none" alt="TK Culturally Sensitive (TK CS) Label">
                         </div>
                         <div id="tklabel-expanded-img-tkss" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkss' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkss' %}" class="default-label-img pointer-event-none" alt="TK Secret Sacred (TK SS) Label">
                         </div>
 
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -562,19 +562,19 @@
                 <div class="flex-this">
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
                         <div id="tklabel-expanded-img-tko" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tko' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tko' %}" class="default-label-img pointer-event-none" alt="TK Outreach (TK O) Label">
                         </div>
                         <div id="tklabel-expanded-img-tknc" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tknc' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tknc' %}" class="default-label-img pointer-event-none" alt="TK Non-Commercial (TK NC) Label">
                         </div>
                         <div id="tklabel-expanded-img-tkoc" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkoc' %}" class="default-label-img pointer-event-none">
-                        </div>
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkoc' %}" class="default-label-img  pointer-event-none" alt="TK Open to Commercialization (TK OC) Label">
+                        </div> 
                         <div id="tklabel-expanded-img-tkco" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkco' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkco' %}" class="default-label-img  pointer-event-none" alt="TK Community Use Only (TK CO) Label">
                         </div>
                         <div id="tklabel-expanded-img-tkcb" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcb' %}" class="default-label-img pointer-event-none">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcb' %}" class="default-label-img pointer-event-none" alt="TK Open to Collaboration (TK CB) Label">
                         </div>
 
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -677,15 +677,15 @@
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
         
                         <div id="bclabel-expanded-img-bcp" class="bc-img-div hide">
-                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcp' %}" class="default-label-img">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcp' %}" alt="BC Provenance (BC P) Label">
                         </div>
         
                         <div id="bclabel-expanded-img-bcmc" class="bc-img-div hide">
-                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcmc' %}" class="default-label-img">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcmc' %}"  alt="BC Multiple Communities (BC MC) Label">
                         </div>
         
                         <div id="bclabel-expanded-img-bccl" class="bc-img-div hide">
-                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccl' %}" class="default-label-img">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccl' %}"  alt="BC Clan (BC CL) Label">
                         </div>
         
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -751,11 +751,11 @@
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
         
                         <div id="bclabel-expanded-img-bccv" class="bc-img-div hide">
-                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccv' %}" class="default-label-img">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccv' %}" alt="BC Consent Verified (BC CV) Label">
                         </div>
         
                         <div id="bclabel-expanded-img-bccnv" class="bc-img-div hide">
-                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccnv' %}" class="default-label-img">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccnv' %}" alt="BC Consent Non-Verified (BC CNV) Label">
                         </div>
         
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -840,23 +840,23 @@
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
 
                         <div id="bclabel-expanded-img-bcr" class="bc-img-div hide">
-                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcr' %}" class="default-label-img">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcr' %}" alt="BC Research Use (BC R) Label">
                         </div>
 
                         <div id="bclabel-expanded-img-bccb" class="bc-img-div hide">
-                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccb' %}">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccb' %}" alt="BC Open to Collaboration (BC CB) Label">
                         </div>
 
                         <div id="bclabel-expanded-img-bcoc" class="bc-img-div hide">
-                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcoc' %}" class="default-label-img">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcoc' %}" alt="BC Open to Commercialization (BC OC) Label">
                         </div>
 
                         <div id="bclabel-expanded-img-bco" class="bc-img-div hide">
-                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bco' %}" class="default-label-img">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bco' %}" alt="BC Outreach (BC O) Label">
                         </div>
 
                         <div id="bclabel-expanded-img-bcnc" class="bc-img-div hide">
-                            <img class="pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcnc' %}" class="default-label-img">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcnc' %}" alt="BC Non-Commercial (BC NC) Label">
                         </div>
                     </div>
 

--- a/templates/partials/_notices.html
+++ b/templates/partials/_notices.html
@@ -254,7 +254,7 @@
             </div>
         </div>
         <div class="flex-this">
-            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-overall-notice.png' %}" width="119px" alt=""></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-overall-notice.png' %}" width="119px" alt="Icon for Collection Care Notice. Abstract design with the letter L and C in the dotted black circle."></div>
             <div class="flex-this column margin-left-16">
                 <div class="w-80">
                     <p>

--- a/templates/partials/_project-actions.html
+++ b/templates/partials/_project-actions.html
@@ -264,7 +264,13 @@
                             </div>
                             <div>
                                 <div class="margin-top-16">
+                                    {% if notice.notice_type == 'biocultural' %}
+                                    <img class="pointer-event-none" loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="black square with white letters BC in the middle">
+                                    {% elif notice.notice_type == 'traditional_knowledge' %}
                                     <img class="pointer-event-none" loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="black square with white letters TK in the middle">
+                                    {% else  %}
+                                    <img class="pointer-event-none" loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="black square with an unfinished square in the middle in white">
+                                    {% endif %}
                                 </div>
                                 <p>
                                     {{ notice.default_text }} <br><br>

--- a/templates/partials/_project-contributor-view.html
+++ b/templates/partials/_project-contributor-view.html
@@ -44,7 +44,7 @@
 
                     {% if notice.notice_type == 'attribution_incomplete' %}
                         <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                            <div class="w-15 pad-top-1"><img loading="lazy" src="{{ notice.img_url }}" width="78" height="78"></div>
+                            <div class="w-15 pad-top-1"><img loading="lazy" src="{{ notice.img_url }}" alt="black square with an unfinished square in the middle in white" width="78" height="78"></div>
                             <div class="w-80 pad-top-1">
                                 <h3 class="no-top-margin">Attribution Incomplete Notice</h3>
                                 <p>{{ notice.default_text}}</p>

--- a/templates/partials/infocards/_institution-card.html
+++ b/templates/partials/infocards/_institution-card.html
@@ -35,7 +35,7 @@
                     </div>
                     {% if institution.otc_institution_url.all %}
                         <div class="flex-this flex-end">
-                            <img class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="60px">
+                            <img class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="60px" alt="black square with white rectangle being held by two hands in the middle">
                         </div>
                     {% endif %}
                 {% endif %}

--- a/templates/partials/infocards/_researcher-card.html
+++ b/templates/partials/infocards/_researcher-card.html
@@ -1,65 +1,81 @@
 {% load static %}
 <div class="dashcard show">
-    <div class="flex-this">
-
-        <div class="researcher-img-container">
-            <img loading="lazy" 
-                class="profile-img" 
-                src=" {% if researcher.image %} {{ researcher.image.url }} {% else %} {% static 'images/placeholders/researcher-place.jpg' %} {% endif %}" 
-                alt="{{ researcher.researcher_name }} image"
-            >
-        </div>
-        <div class="flex-this column dashcard-text-container">
-            <div><h3 class="dashcard-h3 darkteal-text">
-                {% firstof researcher.user.get_full_name researcher.user.username %}
-            </h3></div>
-            <div>
-                <p class="dashcard-subheader">
-                    Researcher | Location: {{ researcher.user.user_profile.get_location }}
-                </p>
-            </div>
-            <div><p class="dashcard-description description-sm">
-                {% if researcher.description %}{{ researcher.description }} {% else %} No description provided. {% endif %}
-            </p></div>
-        </div>
-
-        <div class="dashcard-btn-container">
-            <div class="margin-left-16 flex-this gap-1">
-                {% if '/registry/' in request.path %}
-                    <div class="margin-bottom-16">
-                        <a 
-                            class="primary-btn action-btn"
-                            href="{% url 'public-researcher' researcher.id %}"
-                        >View public page</a>                        
-                    </div>
-                    {% if researcher.otc_researcher_url.all %}
-                        <div class="flex-this flex-end">
-                            <img class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="60px">
-                        </div>
-                    {% endif %}
-                {% endif %}
-
-                <div class="margin-right-8">
-                    {% if '/dashboard/' in request.path %}
-                        {% if researcher.get_projects %}
-                            <a 
-                            class="primary-btn action-btn"
-                            href="{% url 'researcher-projects' researcher.id %}"
-                            >View account</a>
-                        {% else %}
-                            <a 
-                            class="primary-btn action-btn"
-                            href="{% url 'researcher-notices' researcher.id %}"
-                            >View account</a>
-                        {% endif %}
-                    {% endif %}
-                </div>
-                <!-- Notification -->
-                {% include 'snippets/notifications.html' with scope=researcher.id %}
-                <!-- Settings -->
-                <div><a href="{% url 'update-researcher' researcher.id %}" class="border-raduis50  darkteal-text primary-btn white-btn"><i class="no-margin fa fa-cog" aria-hidden="true"></i></a></div>
-            </div>
-        </div>
-
+  <div class="flex-this">
+    <div class="researcher-img-container">
+      <img
+        loading="lazy"
+        class="profile-img"
+        src=" {% if researcher.image %} {{ researcher.image.url }} {% else %} {% static 'images/placeholders/researcher-place.jpg' %} {% endif %}"
+        alt="{{ researcher.researcher_name }} image"
+      />
     </div>
+    <div class="flex-this column dashcard-text-container">
+      <div>
+        <h3 class="dashcard-h3 darkteal-text">
+          {% firstof researcher.user.get_full_name researcher.user.username %}
+        </h3>
+      </div>
+      <div>
+        <p class="dashcard-subheader">
+          Researcher | Location: {{ researcher.user.user_profile.get_location }}
+        </p>
+      </div>
+      <div>
+        <p class="dashcard-description description-sm">
+          {% if researcher.description %}{{ researcher.description }} {% else %}
+          No description provided. {% endif %}
+        </p>
+      </div>
+    </div>
+
+    <div class="dashcard-btn-container">
+      <div class="margin-left-16 flex-this gap-1">
+        {% if '/registry/' in request.path %}
+        <div class="margin-bottom-16">
+          <a
+            class="primary-btn action-btn"
+            href="{% url 'public-researcher' researcher.id %}"
+            >View public page</a
+          >
+        </div>
+        {% if researcher.otc_researcher_url.all %}
+        <div class="flex-this flex-end">
+          <img
+            class="pointer-event-none"
+            src="{% static 'images/notices/ci-open-to-collaborate.png' %}"
+            width="60px"
+            alt="black square with white rectangle being held by two hands in the middle"
+          />
+        </div>
+        {% endif %} {% endif %}
+
+        <div class="margin-right-8">
+          {% if '/dashboard/' in request.path %} {% if researcher.get_projects
+          %}
+          <a
+            class="primary-btn action-btn"
+            href="{% url 'researcher-projects' researcher.id %}"
+            >View account</a
+          >
+          {% else %}
+          <a
+            class="primary-btn action-btn"
+            href="{% url 'researcher-notices' researcher.id %}"
+            >View account</a
+          >
+          {% endif %} {% endif %}
+        </div>
+        <!-- Notification -->
+        {% include 'snippets/notifications.html' with scope=researcher.id %}
+        <!-- Settings -->
+        <div>
+          <a
+            href="{% url 'update-researcher' researcher.id %}"
+            class="border-raduis50 darkteal-text primary-btn white-btn"
+            ><i class="no-margin fa fa-cog" aria-hidden="true"></i
+          ></a>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/templates/public.html
+++ b/templates/public.html
@@ -223,7 +223,7 @@
                     {% endif %}
 
                     {% if attrnotice %} 
-                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="90px"></div>
+                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" alt="black square with an unfinished square in the middle in white" width="90px"></div>
                     {% endif %}
                     {% if not bcnotice and not tknotice and not attrnotice %} No Notices to display yet {% endif %}
                 </div>
@@ -329,7 +329,7 @@
                     {% endif %}
 
                     {% if attrnotice %} 
-                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="90px"></div>
+                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" alt="black square with an unfinished square in the middle in white" width="90px"></div>
                     {% endif %}
                     {% if not bcnotice and not tknotice and not attrnotice %} No Notices to display yet {% endif %}
                 </div>

--- a/templates/snippets/pdfs/community-labels.html
+++ b/templates/snippets/pdfs/community-labels.html
@@ -60,7 +60,7 @@
             {% for bclabel in bclabels %}
                 <tr>
                     <td class="image-td">
-                        <img loading="lazy" src="{{ bclabel.img_url }}" width="200px">
+                        <img loading="lazy" src="{{ bclabel.img_url }}" width="200px" alt="{{ bclabel.name }} Label">
                     </td>
                     <td class="text-td">
                         <h1 class="no-bottom-margin">{{ bclabel.name }}</h1>
@@ -78,7 +78,7 @@
             {% for tklabel in tklabels %}
                 <tr>
                     <td class="image-td">
-                        <img loading="lazy" src="{{ tklabel.img_url }}" width="200px">
+                        <img loading="lazy" src="{{ tklabel.img_url }}" width="200px" alt="{{ tklabel.name }} Label">
                     </td>
                     <td class="text-td">
                         <h1 class="no-bottom-margin">{{ tklabel.name }}</h1>

--- a/templates/snippets/pdfs/project-pdf.html
+++ b/templates/snippets/pdfs/project-pdf.html
@@ -126,7 +126,7 @@
                         {% if notice.notice_type == 'biocultural' %}
                             <tr>
                                 <td class="image-td">
-                                    <img loading="lazy" src="{{ notice.img_url }}" width="200px">
+                                    <img loading="lazy" src="{{ notice.img_url }}" width="200px" alt="black square with white letters BC in the middle">
                                 </td>
                                 <td class="text-td">
                                     <h1 class="no-bottom-margin">Biocultural Notice</h1>
@@ -137,7 +137,7 @@
                         {% if notice.notice_type == 'traditional_knowledge' %}
                             <tr>
                                 <td class="image-td">
-                                    <img loading="lazy" src="{{ notice.img_url }}" width="200px">
+                                    <img loading="lazy" src="{{ notice.img_url }}" width="200px" alt="black square with white letters TK in the middle">
                                 </td>
                                 <td class="text-td">
                                     <h1 class="no-bottom-margin">Traditional Knowledge Notice</h1>
@@ -148,7 +148,7 @@
                         {% if notice.notice_type == 'attribution_incomplete' %}
                             <tr>
                                 <td class="image-td">
-                                    <img loading="lazy" src="{{ notice.img_url }}" width="200px">
+                                    <img loading="lazy" src="{{ notice.img_url }}" width="200px" alt="black square with an unfinished square in the middle in white">
                                 </td>
                                 <td class="text-td">
                                     <h1 class="no-bottom-margin">Attribution Incomplete Notice</h1>
@@ -164,7 +164,7 @@
                 {% for bclabel in project.bc_labels.all %}
                     <tr>
                         <td class="image-td">
-                            <img loading="lazy" src="{{ bclabel.img_url }}" width="200px">
+                            <img loading="lazy" src="{{ bclabel.img_url }}" alt="{{ bclabel.name }} Label" width="200px">
                         </td>
                         <td class="text-td">
                             <h1 class="no-bottom-margin">{{ bclabel.name }} ({{ bclabel.community.community_name }})</h1>
@@ -185,7 +185,7 @@
                 {% for tklabel in project.tk_labels.all %}
                     <tr>
                         <td class="image-td">
-                            <img loading="lazy" src="{{ tklabel.img_url }}" width="200px">
+                            <img loading="lazy" src="{{ tklabel.img_url }}" alt="{{ tklabel.name }} Label" width="200px">
                         </td>
                         <td class="text-td">
                             <h1 class="no-bottom-margin">{{ tklabel.name }} ({{ tklabel.community.community_name }})</h1>

--- a/templates/snippets/project_notices.html
+++ b/templates/snippets/project_notices.html
@@ -62,7 +62,7 @@
         </div>
 
         <div class="flex-this column center-text margin-left-16 align-center">
-            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="73px"></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" alt="black square with an unfinished square in the middle in white" width="73px"></div>
             <div><p id="title-attr-notice" class="grey-text">Attribution Incomplete <br> Notice</p></div>
             <div class="notice-checkbox-container">
 


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8685tnmg0)**
  
- Description: An error was found in one of the templates. Not sure if this is the only place this is set.
Template: localcontexts_db\templates\partials\_project-actions.html - line 266
```
<div class="margin-top-16">
  <img loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="black square with white letters TK in the middle">
  </div>

```
Issue: alt text is set as for a TK notice but the image might be any of the disclosure notices. The before pics are from select-label page.

**Solution:**
 Added Alt text for all image tag with src of notice's or label's and handled the alt text in the template.

**Before:**
![alttext(1)](https://github.com/localcontexts/localcontextshub/assets/145371882/27e44ec1-6fd2-4213-b247-d7951619bd8d)

![alttext(2)](https://github.com/localcontexts/localcontextshub/assets/145371882/a414c2c1-a449-4798-9f1d-b7ac5a141fb7)

**After:**
![alttext(1) after](https://github.com/localcontexts/localcontextshub/assets/145371882/787de5be-38d7-4221-b798-80ede57cab97)

![alttextafter(2)](https://github.com/localcontexts/localcontextshub/assets/145371882/16869d48-9860-4500-a495-a2d18a42e153)

