### PR TITLE
86873unfh-remove-account-contact-name

### DIFF
--- a/communities/forms.py
+++ b/communities/forms.py
@@ -153,11 +153,9 @@ class CommunityModelForm(forms.ModelForm):
 class UpdateCommunityForm(forms.ModelForm):
     class Meta:
         model = Community
-        fields = ['contact_name', 'contact_email', 'description', 'community_entity', 'city_town', 'state_province_region', 'country', 'image']
+        fields = ['description', 'community_entity', 'city_town', 'state_province_region', 'country', 'image']
         widgets = {
             'community_entity': forms.TextInput(attrs={'class': 'w-100'}),
-            'contact_name': forms.TextInput(attrs={'class': 'w-100'}),
-            'contact_email': forms.EmailInput(attrs={'class': 'w-100'}),
             'state_province_region': forms.TextInput(attrs={'class': 'w-100'}),
             'city_town': forms.TextInput(attrs={'class': 'w-100'}),
             'description': forms.Textarea(attrs={'rows': 3, 'class': 'w-100'}),

--- a/institutions/forms.py
+++ b/institutions/forms.py
@@ -81,10 +81,8 @@ class ConfirmInstitutionForm(forms.ModelForm):
 class UpdateInstitutionForm(forms.ModelForm):
     class Meta:
         model = Institution
-        fields = ['contact_name', 'contact_email', 'city_town', 'state_province_region', 'country', 'image', 'description']
+        fields = ['city_town', 'state_province_region', 'country', 'image', 'description']
         widgets = {
-            'contact_name': forms.TextInput(attrs={'class': 'w-100'}),
-            'contact_email': forms.EmailInput(attrs={'class': 'w-100'}),
             'state_province_region': forms.TextInput(attrs={'class': 'w-100'}),
             'city_town': forms.TextInput(attrs={'class': 'w-100'}),
             'country': forms.TextInput(attrs={'class': 'w-100'}),

--- a/templates/accounts/update-profile.html
+++ b/templates/accounts/update-profile.html
@@ -106,14 +106,14 @@
 
             {% include 'partials/_alerts.html' %}
 
-            <div class="flex-this space-between w-100">
-                <div class="margin-bottom-16 margin-top-16 w-40">
-                    <button class="primary-btn action-btn margin-top-2 default-btn-width">Save</button>
-                </div>
+            <div class="w-100">
                 <p>
-                    <small class="grey-text">Providing your personal information is optional.
+                    <small>Providing your personal information is optional.
                         By providing it, you consent for it to be shown to other Hub users, see the <a href="https://localcontexts.org/privacy-policy/" class="darkteal-text underline-hover" target="_blank" rel="noopener">Privacy Policy <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.</small>
-                </p>    
+                </p>  
+                <div class="margin-bottom-16 margin-top-16">
+                    <button class="primary-btn action-btn margin-top-2">Save changes <i class="fa fa-arrow-right"></i></button>
+                </div>  
             </div>
 
         </form>

--- a/templates/partials/_update-account.html
+++ b/templates/partials/_update-account.html
@@ -13,7 +13,7 @@
         <div class="side-nav-container">
             <a href="{% if community %}{% url 'update-community' community.id %}{% endif %}{% if institution %}{% url 'update-institution' institution.id %}{% endif %}{% if researcher %}{% url 'update-researcher' researcher.id %}{% endif %}">
                 <div class="flex-this side-nav-item {% if 'update' in request.path %} selected {% else %} grey-text {% endif %}">
-                    <div class="w-20 margin-right-8"><i class="fa fa-user fa-3x" aria-hidden="true"></i></div>
+                    <div class="w-20 margin-left-8 margin-top-8"><i class="fa-solid fa-circle-user fa-3x"></i></div>
                     <div class="w-80">
                         <p class="no-top-margin">
                             {% if community %}

--- a/templates/partials/_update-account.html
+++ b/templates/partials/_update-account.html
@@ -17,10 +17,10 @@
                     <div class="w-80">
                         <p class="no-top-margin">
                             {% if community %}
-                                <strong>Community Account</strong><br>Image, location, description
+                                <strong>Community Account</strong><br>Image, description, location
                             {% endif %}
                             {% if institution %}
-                                <strong>Institution Account</strong><br>Image, location, description
+                                <strong>Institution Account</strong><br>Image, description, location
                             {% endif %}
                             {% if researcher %}
                                 <strong>Researcher Account</strong><br>Contact email, primary institution, description
@@ -32,22 +32,87 @@
         </div>
 
         <div class="flex-this column w-80">
-            <div class="flex-this space-between w-70">
-                <div><h3 class="no-top-margin">Account Information</h3></div>
-                <div>Account ID: 
-                    {% if community %} {{ community.id }} {% endif %}
-                    {% if institution %} {{ institution.id }} {% endif %}
-                    {% if researcher %} {{ researcher.id }} {% endif %}
-                </div>
-            </div>
 
-            <div class="w-70">
+            <div class="w-70 margin-left-16">
+
+                <div class="flex-this space-between">
+                    <div><h3 class="no-top-margin">Account Information</h3></div>
+                    <div>Account ID: 
+                        {% if community %} {{ community.id }} {% endif %}
+                        {% if institution %} {{ institution.id }} {% endif %}
+                        {% if researcher %} {{ researcher.id }} {% endif %}
+                    </div>
+                </div>
+
                 <form 
                     method="POST" 
                     action="{% if community %}{% url 'update-community' community.id %}{% endif %}{% if institution %}{% url 'update-institution' institution.id %}{% endif %}{% if researcher %}{% url 'update-researcher' researcher.id %}{% endif %}" 
                     enctype="multipart/form-data">
                     {% csrf_token %}
 
+                    <!-- Account Image -->
+                    <div>
+                        <div class="hide">{{ update_form.image }}</div>
+
+                        <div id="defaultPlaceholderUrl" data-url="{% static 'images/placeholders/community-place.jpg' %}"></div>
+
+                        <div class="flex-this space-between margin-bottom-16">
+                            <div class="w-50">
+                                {% if community %}
+                                    <div id="imagePreviewContainer" class="img-preview__container__rectangle">
+                                        {% if not community.image %} 
+                                            <img src="{% static 'images/placeholders/community-place.jpg' %}">
+                                        {% else %}
+                                            <img src="{{ update_form.instance.image.url }}" alt="{{ update_form.instance.community_name }} image">
+                                        {% endif %}                                        
+                                    </div>
+                                {% endif %}
+
+                                {% if institution %}
+                                    <div id="imagePreviewContainer" class="img-preview__container__rectangle">
+                                        {% if not institution.image %} 
+                                            <img src="{% static 'images/placeholders/institution-place.jpg' %}">
+                                        {% else %}
+                                            <img src="{{ update_form.instance.image.url }}" alt="{{ update_form.instance.institution_name }} image">
+                                        {% endif %}                                        
+                                    </div>
+                                {% endif %}
+
+                                {% if researcher %}
+                                    <div id="imagePreviewContainer" class="img-preview__container__square">
+                                        {% if not researcher.image %} 
+                                            <img src="{% static 'images/placeholders/researcher-place.jpg' %}">
+                                        {% else %}
+                                            <img src="{{ update_form.instance.image.url }}" alt="researcher account image">
+                                        {% endif %}
+                                    </div>
+                                {% endif %}
+                            </div>
+
+                            <div class="flex-this">
+                                <div>
+                                    <button id="altImageUploadBtn" class="primary-btn action-btn margin-right-8">Upload image <i class="fa-solid fa-upload"></i></button> 
+                                </div>
+                                <div>
+                                    <button id="clearImageBtn" class="primary-btn white-btn" name="clear_image">Clear image</button>
+                                </div>
+                            </div>                                
+                        </div>
+
+                        {% if update_form.image.errors %}
+                            <div class="msg-red w-50"><small>{{ update_form.image.errors.as_text }}</small></div> 
+                        {% endif %}
+                    </div>
+
+                    <div class="w-100 margin-bottom-8">
+                        {{ update_form.description.label }} <br>
+                        {{ update_form.description }}
+                        {% if update_form.description.errors %}
+                            <div class="msg-red w-80"><small>{{ update_form.description.errors.as_text }}</small></div> 
+                        {% endif %}
+                    </div>
+
+                    <!-- Community entity -->
                     {% if community %}
                         <div class="w-100 margin-bottom-8">
                             <label> Community Entity </label><br>                                           
@@ -58,6 +123,7 @@
                         </div>
                     {% endif %}
 
+                    <!-- Primary institution -->
                     {% if researcher %}
                         <div class="margin-bottom-8">
                             <label for="primary_institution"> Primary Institution </label><br>
@@ -74,17 +140,14 @@
                             <div class="msg-red w-50"><small>{{ update_form.website.errors.as_text }}</small></div> 
                         {% endif %}
                     {% endif %}
-
-                    <div class="w-100 margin-bottom-8">
-                        {{ update_form.description.label }} <br>
-                        {{ update_form.description }}
-                        {% if update_form.description.errors %}
-                            <div class="msg-red w-80"><small>{{ update_form.description.errors.as_text }}</small></div> 
-                        {% endif %}
-                    </div>
                     
+                    <!-- Location -->
                     {% if institution or community %}
                         <div class="w-100 margin-bottom-8">
+                            <div class="w-100 margin-bottom-8">
+                                {{ update_form.country.label }} <br>
+                                {{ update_form.country }}
+                            </div>
                             <div class="flex-this">
                                 <div class="w-50 margin-right-1">
                                     <label>State, Province, or Region</label> <br>
@@ -102,68 +165,9 @@
                                 <div class="msg-red w-50"><small>{{ update_form.city_town.errors.as_text }}</small></div> 
                             {% endif %}
                         </div>
-
-                        <div class="w-100 margin-bottom-8">
-                            {{ update_form.country.label }} <br>
-                            {{ update_form.country }}
-                        </div>
                     {% endif %}
 
-                    <div class="margin-top-16">
-                        <div class="hide">{{ update_form.image }}</div>
-
-                        <div id="defaultPlaceholderUrl" data-url="{% static 'images/placeholders/community-place.jpg' %}"></div>
-
-                        <div class="flex-this space-between">
-                            <div class="w-50">
-
-                                    {% if community %}
-                                        <div id="imagePreviewContainer" class="img-preview__container__rectangle">
-                                            {% if not community.image %} 
-                                                <img src="{% static 'images/placeholders/community-place.jpg' %}">
-                                            {% else %}
-                                                <img src="{{ update_form.instance.image.url }}" alt="{{ update_form.instance.community_name }} image">
-                                            {% endif %}                                        
-                                        </div>
-                                    {% endif %}
-
-                                    {% if institution %}
-                                        <div id="imagePreviewContainer" class="img-preview__container__rectangle">
-                                            {% if not institution.image %} 
-                                                <img src="{% static 'images/placeholders/institution-place.jpg' %}">
-                                            {% else %}
-                                                <img src="{{ update_form.instance.image.url }}" alt="{{ update_form.instance.institution_name }} image">
-                                            {% endif %}                                        
-                                        </div>
-                                    {% endif %}
-
-                                    {% if researcher %}
-                                        <div id="imagePreviewContainer" class="img-preview__container__square">
-                                            {% if not researcher.image %} 
-                                                <img src="{% static 'images/placeholders/researcher-place.jpg' %}">
-                                            {% else %}
-                                                <img src="{{ update_form.instance.image.url }}" alt="researcher account image">
-                                            {% endif %}
-                                        </div>
-                                    {% endif %}
-
-                            </div>
-
-                            <div class="flex-this">
-                                <div>
-                                    <button id="altImageUploadBtn" class="primary-btn green-btn margin-right-8">Upload Image <i class="fa-solid fa-upload"></i></button> 
-                                </div>
-                                <div>
-                                    <button id="clearImageBtn" class="primary-btn white-btn" name="clear_image">Clear Image</button>
-                                </div>
-                            </div>                                
-                        </div>
-
-                        {% if update_form.image.errors %}
-                            <div class="msg-red w-50"><small>{{ update_form.image.errors.as_text }}</small></div> 
-                        {% endif %}
-                    </div>
-
+                    <!-- Researcher account contact -->
                     {% if researcher %}
                         <div><h3>Account Contact</h3></div>
                         <div class="w-100 margin-bottom-16">
@@ -187,90 +191,93 @@
                         </div>
                     {% endif %}
 
+                    <!-- Researcher: ORCiD -->
+                    {% if researcher %}
                     <div>
-                        {% if researcher %}
-                            <div><h3>ORCiD</h3></div>
-                            <div class="w-100 margin-bottom-16">
-                                {% if researcher.orcid %}
-                                <div class="flex-this space-between">
-                                    <div>
-                                        <div itemscope itemtype="https://schema.org/Person">
-                                            <a 
-                                                class="darkteal-text underline-hover" 
-                                                itemprop="sameAs" 
-                                                target="orcid.widget" 
-                                                rel="me noopener noreferrer" 
-                                                style="vertical-align:top;"
-                                                {% if 'https://sandbox.orcid.org/' in researcher.orcid or 'https://orcid.org/' in researcher.orcid %}
-                                                    content="{{ researcher.orcid }}" 
-                                                    href="{{ researcher.orcid }}" 
-                                                {% elif 'X' in researcher.orcid %}
-                                                    content="https://sandbox.orcid.org/{{ researcher.orcid }}" 
-                                                    href="https://sandbox.orcid.org/{{ researcher.orcid }}"
-                                                {% else %}
-                                                    content="https://orcid.org/{{ researcher.orcid }}" 
-                                                    href="https://orcid.org/{{ researcher.orcid }}" 
-                                                {% endif %}
-                                            >
-                                                <img loading="lazy" src="https://orcid.org/sites/default/files/images/orcid_16x16.png" style="width:1em;margin-right:.5em;" alt="ORCID iD icon">
-                                                {% if 'https://sandbox.orcid.org/' in researcher.orcid or 'https://orcid.org/' in researcher.orcid %}
-                                                    {{ researcher.orcid }}
-                                                {% elif 'X' in researcher.orcid %}
-                                                    https://sandbox.orcid.org/{{ researcher.orcid }} 
-                                                {% else %}
-                                                    https://orcid.org/{{ researcher.orcid }}
-                                                {% endif %}
-                                            </a>
-                                        </div>                                
-                                    </div>
-
-                                    <div>
-                                        <a class="primary-btn white-btn" href="{% url 'disconnect-orcid' %}">Disconnect ORCiD</a>
-                                    </div> 
+                        <div><h3>ORCiD</h3></div>
+                        <div class="w-100 margin-bottom-16">
+                            {% if researcher.orcid %}
+                            <div class="flex-this space-between">
+                                <div>
+                                    <div itemscope itemtype="https://schema.org/Person">
+                                        <a 
+                                            class="darkteal-text underline-hover" 
+                                            itemprop="sameAs" 
+                                            target="orcid.widget" 
+                                            rel="me noopener noreferrer" 
+                                            style="vertical-align:top;"
+                                            {% if 'https://sandbox.orcid.org/' in researcher.orcid or 'https://orcid.org/' in researcher.orcid %}
+                                                content="{{ researcher.orcid }}" 
+                                                href="{{ researcher.orcid }}" 
+                                            {% elif 'X' in researcher.orcid %}
+                                                content="https://sandbox.orcid.org/{{ researcher.orcid }}" 
+                                                href="https://sandbox.orcid.org/{{ researcher.orcid }}"
+                                            {% else %}
+                                                content="https://orcid.org/{{ researcher.orcid }}" 
+                                                href="https://orcid.org/{{ researcher.orcid }}" 
+                                            {% endif %}
+                                        >
+                                            <img loading="lazy" src="https://orcid.org/sites/default/files/images/orcid_16x16.png" style="width:1em;margin-right:.5em;" alt="ORCID iD icon">
+                                            {% if 'https://sandbox.orcid.org/' in researcher.orcid or 'https://orcid.org/' in researcher.orcid %}
+                                                {{ researcher.orcid }}
+                                            {% elif 'X' in researcher.orcid %}
+                                                https://sandbox.orcid.org/{{ researcher.orcid }} 
+                                            {% else %}
+                                                https://orcid.org/{{ researcher.orcid }}
+                                            {% endif %}
+                                        </a>
+                                    </div>                                
                                 </div>
 
-                            {% else %}
-                                <div class="flex-this space-between">
-                                    <div class="w-50"><p>We encourage you to have an ORCiD ID. <br>You can <a class="darkteal-text underline-hover" href="https://orcid.org/" target="_blank" rel="noopener">read more about ORCiD here</a>.</p></div>
-                                    <!-- Show ORCiD widget based on hostname -->
-                                    <div 
-                                        id="orcidWidget" 
-                                        {% if env == "PROD" %}
-                                            data-clientid='APP-3AGU5OQX7M7UKIMD' 
-                                            data-env="production" 
-                                            data-redirecturi="https://localcontextshub.org/researchers/connect-orcid/"
-                                        {% elif env == "SANDBOX" %}
-                                            data-clientid='APP-M1RE2U9DY1B6MNYD' 
-                                            data-env="sandbox" 
-                                            data-redirecturi="https://sandbox.localcontextshub.org/researchers/connect-orcid/"
-                                        {% elif env == "DEV" %}
-                                            data-clientid='APP-M1RE2U9DY1B6MNYD' 
-                                            data-env="develop" 
-                                            data-redirecturi="https://local-contexts-hub-develop.uc.r.appspot.com/researchers/connect-orcid/"
-                                        {% endif %}
-                                    >
-                                    </div>
-                                </div>
-                        
-                                {% if env == "DEV" or env == "SANDBOX" %}
-                                    <small class="bold">Please note that since this is a test site, the ORCiD used will be the <a class="darkteal-text underline-hover" href="https://sandbox.orcid.org/">sandbox version</a>.</small><br>
-                                {% endif %}  
-                            {% endif %}
-                                
+                                <div>
+                                    <a class="primary-btn white-btn" href="{% url 'disconnect-orcid' %}">Disconnect ORCiD</a>
+                                </div> 
                             </div>
-                        {% endif %}                        
+
+                        {% else %}
+                            <div class="flex-this space-between">
+                                <div class="w-50"><p>We encourage you to have an ORCiD ID. <br>You can <a class="darkteal-text underline-hover" href="https://orcid.org/" target="_blank" rel="noopener">read more about ORCiD here</a>.</p></div>
+                                <!-- Show ORCiD widget based on hostname -->
+                                <div 
+                                    id="orcidWidget" 
+                                    {% if env == "PROD" %}
+                                        data-clientid='APP-3AGU5OQX7M7UKIMD' 
+                                        data-env="production" 
+                                        data-redirecturi="https://localcontextshub.org/researchers/connect-orcid/"
+                                    {% elif env == "SANDBOX" %}
+                                        data-clientid='APP-M1RE2U9DY1B6MNYD' 
+                                        data-env="sandbox" 
+                                        data-redirecturi="https://sandbox.localcontextshub.org/researchers/connect-orcid/"
+                                    {% elif env == "DEV" %}
+                                        data-clientid='APP-M1RE2U9DY1B6MNYD' 
+                                        data-env="develop" 
+                                        data-redirecturi="https://local-contexts-hub-develop.uc.r.appspot.com/researchers/connect-orcid/"
+                                    {% endif %}
+                                >
+                                </div>
+                            </div>
+                    
+                            {% if env == "DEV" or env == "SANDBOX" %}
+                                <small class="bold">Please note that since this is a test site, the ORCiD used will be the <a class="darkteal-text underline-hover" href="https://sandbox.orcid.org/">sandbox version</a>.</small><br>
+                            {% endif %}  
+                        {% endif %}
+                            
+                        </div>                            
                     </div>
+
+                    {% endif %}                        
 
                     {% include 'partials/_alerts.html' %}
 
-                    <div class="flex-this space-between w-100">
-                        <div class="margin-top-16 w-40">
-                            <button class="primary-btn action-btn margin-top-2  default-btn-width">Save</button>
-                        </div>
+                    <div>
                         <p>
                             <small class="grey-text">Providing your personal information is optional.
                                 By providing it, you consent for it to be shown to other Hub users, see the <a href="https://localcontexts.org/privacy-policy/" class="darkteal-text underline-hover" target="_blank" rel="noopener">Privacy Policy <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.</small>
                         </p> 
+                        <div class="margin-top-16 w-50">
+                            <button class="primary-btn action-btn margin-top-2">Save changes <i class="fa fa-arrow-right"></i></button>
+                        </div>
+
                     </div>
                 </form>
             </div>

--- a/templates/partials/_update-account.html
+++ b/templates/partials/_update-account.html
@@ -271,13 +271,12 @@
 
                     <div>
                         <p>
-                            <small class="grey-text">Providing your personal information is optional.
+                            <small>Providing your personal information is optional.
                                 By providing it, you consent for it to be shown to other Hub users, see the <a href="https://localcontexts.org/privacy-policy/" class="darkteal-text underline-hover" target="_blank" rel="noopener">Privacy Policy <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.</small>
                         </p> 
                         <div class="margin-top-16 w-50">
                             <button class="primary-btn action-btn margin-top-2">Save changes <i class="fa fa-arrow-right"></i></button>
                         </div>
-
                     </div>
                 </form>
             </div>

--- a/templates/partials/_update-account.html
+++ b/templates/partials/_update-account.html
@@ -17,10 +17,10 @@
                     <div class="w-80">
                         <p class="no-top-margin">
                             {% if community %}
-                                <strong>Community Account</strong><br>Contact name, email, location, description
+                                <strong>Community Account</strong><br>Image, location, description
                             {% endif %}
                             {% if institution %}
-                                <strong>Institution Account</strong><br>Contact name, email, {% if not institution.is_ror %} location, {% endif %} description
+                                <strong>Institution Account</strong><br>Image, location, description
                             {% endif %}
                             {% if researcher %}
                                 <strong>Researcher Account</strong><br>Contact email, primary institution, description
@@ -164,27 +164,9 @@
                         {% endif %}
                     </div>
 
-                    <div><h3>Account Contact</h3></div>
-                    <div class="w-100 margin-bottom-16">
-                        {% if community or institution %}
-                            <div class="flex-this">
-                                <div class="w-50 margin-right-1">
-                                    <label> Name </label><br>                                           
-                                    {{ update_form.contact_name }}
-                                </div>
-                                <div class="w-50">
-                                    <label> Email </label><br>                                       
-                                    {{ update_form.contact_email }}
-                                </div>                            
-                            </div>
-                            {% if update_form.contact_name.errors %}
-                                <div class="msg-red w-50"><small>{{ update_form.contact_name.errors.as_text }}</small></div> 
-                            {% endif %}
-                            {% if update_form.contect_email.errors %}
-                                <div class="msg-red w-50"><small>{{ update_form.contect_email.errors.as_text }}</small></div> 
-                            {% endif %}
-                        {% endif %}
-                        {% if researcher %}
+                    {% if researcher %}
+                        <div><h3>Account Contact</h3></div>
+                        <div class="w-100 margin-bottom-16">
                             <div>
                                 <label for="contact_email"> Contact Email </label><br> 
                                 {{ update_form.contact_email }}
@@ -202,8 +184,8 @@
                                     <div class="msg-red w-50"><small>{{ update_form.contact_email_public.errors.as_text }}</small></div> 
                                 {% endif %}
                             </div>  
-                        {% endif %}
-                    </div>
+                        </div>
+                    {% endif %}
 
                     <div>
                         {% if researcher %}

--- a/templates/partials/infocards/_researcher-card.html
+++ b/templates/partials/infocards/_researcher-card.html
@@ -50,8 +50,7 @@
         {% endif %} {% endif %}
 
         <div class="margin-right-8">
-          {% if '/dashboard/' in request.path %} {% if researcher.get_projects
-          %}
+          {% if '/dashboard/' in request.path %} {% if researcher.get_projects %}
           <a
             class="primary-btn action-btn"
             href="{% url 'researcher-projects' researcher.id %}"

--- a/templates/settings-base.html
+++ b/templates/settings-base.html
@@ -12,7 +12,7 @@
             <div class="side-nav-container">
                 <a class="side-nav-a" href="{% url 'update-profile' %}">
                     <div class="side-nav-item {% if 'update-profile' in request.path %} selected {% else %} grey-text {% endif %}">
-                        <div><i class="fa fa-user" aria-hidden="true"></i></div>
+                        <div class="w-20 margin-left-8 margin-top-8"><i class="fa-solid fa-circle-user fa-3x"></i></div>
                         <div>
                             <p class="no-top-margin"><strong>Profile</strong><br>Contact name, email, location</p>
                         </div>  


### PR DESCRIPTION
**Issues:**
- The contact name/email in community/institution account settings is the contact for confirming the accounts, not to contact the account itself.
- UI needed to be updated to be more in line with what we have in Figma.
- When creating a researcher, then going to the dashboard, an error was thrown because of a malformed template tag.

**Before:**
![Screenshot 2024-01-24 at 2 57 46 PM](https://github.com/localcontexts/localcontextshub/assets/41635757/01b11b34-3eee-4755-a607-57122fb5b4c3)
![Screenshot 2024-01-24 at 2 58 34 PM](https://github.com/localcontexts/localcontextshub/assets/41635757/b57b416b-139d-4c9a-b723-9f99ec64a677)

**Solution:**
- Removed the inputs for contact name/email from forms.py and the templates, updated the settings UI
- Fixed malformed template tag error.

**After:**

![Screenshot 2024-01-24 at 3 00 43 PM](https://github.com/localcontexts/localcontextshub/assets/41635757/a9f76461-10a9-4bfc-81a8-5b4ddfcf6b94)
![Screenshot 2024-01-24 at 3 01 27 PM](https://github.com/localcontexts/localcontextshub/assets/41635757/231acd62-c459-4e16-b060-69a6ad2c7db8)
