### PR TITLE
868700w74-ui-grey-text-default-links

### DIFF
--- a/localcontexts/static/css/main.css
+++ b/localcontexts/static/css/main.css
@@ -67,6 +67,13 @@ ol ol {
 
 a { text-decoration: none; }
 
+.default-a {
+    color: #007585;
+    font-weight: bold;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
 /* FORM INPUTS */
 label {
     font-size: 16px;

--- a/localcontexts/static/css/register.css
+++ b/localcontexts/static/css/register.css
@@ -132,14 +132,6 @@
     position: relative;
 }
 
-.checkbox-label p {
-    margin: 0;
-}
-
-.checkbox-label span {
-    color: #7d7d7d;
-}
-
 /* For validate and connect pages */
 .centered-content {
     padding-top: 2%;

--- a/templates/503.html
+++ b/templates/503.html
@@ -8,7 +8,7 @@
                 <div>
                     <p>
                         Local Contexts Hub is currently undergoing maintenance and is temporarily unavailable.<br>
-                        See <a class="darkteal-text underline-hover" href="https://localcontexts.org/lc-hub-service-schedule/" target="_blank" rel="noopener">here</a> for service schedule.
+                        See <a class="default-a" href="https://localcontexts.org/lc-hub-service-schedule/" target="_blank" rel="noopener">here</a> for service schedule.
                         <br><br>  
                         <strong>Status Code: 503 Service Unavailable</strong>
                     </p>

--- a/templates/accounts/apikey.html
+++ b/templates/accounts/apikey.html
@@ -8,7 +8,7 @@
 
     {% if has_key %}
         <div class="w-70 margin-bottom-2">
-            <p class="no-top-margin">Your API key enables access to the Local Contexts Hub data via the API and must be kept secret. For more informaiton see our <a class="darkteal-text underline-hover" href="https://localcontexts.org/api-guide/" target="_blank">API Guide</a>.
+            <p class="no-top-margin">Your API key enables access to the Local Contexts Hub data via the API and must be kept secret. For more information see our <a class="default-a" href="https://localcontexts.org/api-guide/" target="_blank">API Guide</a>.
             <p class="no-top-margin">Your API key is listed below.</p>
         </div>
 
@@ -81,7 +81,7 @@
                 {% csrf_token %}
 
                 <div class="w-70 margin-bottom-2">
-                    <p class="no-top-margin">Your API key enables access to the Local Contexts Hub data via the API and must be kept secret. For more informaiton see our <a class="darkteal-text underline-hover" href="https://localcontexts.org/api-guide/" target="_blank">API Guide</a>.</p>
+                    <p class="no-top-margin">Your API key enables access to the Local Contexts Hub data via the API and must be kept secret. For more information see our <a class="default-a" href="https://localcontexts.org/api-guide/" target="_blank">API Guide</a>.</p>
                     <p class="no-top-margin">You do not have an API key. Click the button below to generate one.</p>
                     <button type="submit" class="primary-btn action-btn margin-top-2" name="generatebtn">Generate API Key <i class="fa fa-arrow-right"></i></button>
                 </div>

--- a/templates/accounts/create-profile.html
+++ b/templates/accounts/create-profile.html
@@ -50,17 +50,18 @@
             </div>
 
         </div>
-        <div class="flex-this space-between w-100">
-            <p class="w-70">
-                <small class="grey-text">
-                    Providing your personal information is optional.
-                    By providing it, you consent for it to be shown to other Hub users, see the <a href="https://localcontexts.org/privacy-policy/" class="darkteal-text underline-hover" target="_blank" rel="noopener">Privacy Policy <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.
-                </small>
-            </p>
-            <div class="margin-top-16">
-                <button class="primary-btn action-btn margin-top-2">Continue <i class="fa fa-arrow-right"></i></button>
-            </div>              
+
+        <div class="w-80 margin-top-8">
+            <small>
+                Providing your personal information is optional.
+                By providing it, you consent for it to be shown to other Hub users, see the 
+                <a href="https://localcontexts.org/privacy-policy/" class="default-a" target="_blank" rel="noopener">Privacy Policy <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.
+            </small>                
         </div>
+
+        <div class="flex-this flex-end">
+            <button class="primary-btn action-btn margin-top-2">Continue <i class="fa fa-arrow-right"></i></button>
+        </div>              
  
 
     </form>

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -6,7 +6,7 @@
             <h2 class="margin-bottom-2">Welcome back!</h2>
             <p>Please sign in to use the Local Contexts Hub</p>                    
         </div>
-        <div><p class="grey-text">Not signed up yet?<a href="{% url 'register' %}" class="darkteal-text underline-hover"> Register</a></p></div>                    
+        <div><p>Not signed up yet? <a href="{% url 'register' %}" class="default-a">Register</a></p></div>                    
     </div>
 
     <div class="form-container flex-this column w-90">
@@ -26,7 +26,7 @@
             </div>
             <div class="flex-this space-between pad-top-1-5"> 
                 <div>
-                    <a href="{% url 'reset_password'%}" class="darkteal-text underline-hover bold">Forgot your password?</a>
+                    <a href="{% url 'reset_password'%}" class="default-a">Forgot your password?</a>
                 </div>  
                 <div><button class="primary-btn action-btn margin-top-2 default-btn-width">Sign in</button></div>
             </div>

--- a/templates/accounts/member-invitations.html
+++ b/templates/accounts/member-invitations.html
@@ -23,7 +23,7 @@
  
                                     <div class="dashcard-btn-container">
                                         <div class="margin-right-16 margin-top-8">
-                                            <a href="{% url 'delete-member-invitation' invite.id %}" class="darkteal-text underline-hover">Delete invite</a>
+                                            <a href="{% url 'delete-member-invitation' invite.id %}" class="default-a">Delete invite</a>
                                         </div>
                                         <div>
                                             <form method="POST" action="">
@@ -82,7 +82,7 @@
                                     <div><h3 class="dashcard-h3 darkteal-text">{{ invite.community }}</h3></div>
                                     <div class="dashcard-btn-container">
                                         <div class="margin-right-16 margin-top-8">
-                                            <a href="{% url 'delete-member-invitation' invite.id %}" class="darkteal-text underline-hover margin-right-8 margin-top-8">Delete invite</a>
+                                            <a href="{% url 'delete-member-invitation' invite.id %}" class="default-a margin-right-8 margin-top-8">Delete invite</a>
                                         </div>
                                         <div>
                                             <form method="POST" action="">

--- a/templates/accounts/newsletter-subscription.html
+++ b/templates/accounts/newsletter-subscription.html
@@ -19,7 +19,7 @@
                             Each issue of the Local Contexts Newsletter includes updates on some of the real-life applications of the Labels and Notices, news,
                             upcoming events, and much more. New issues of the Newsletter will be released seasonally, aligning with the ebbs and flows of our natural
                             world and relations around the world. <br><br>
-                            See past issues on the Local Contexts <a href="https://localcontexts.org/support/downloadable-resources/" class="darkteal-text underline-hover">website</a>.
+                            See past issues on the Local Contexts <a href="https://localcontexts.org/support/downloadable-resources/" class="default-a">website</a>.
                         </p>               
                     </div>
 

--- a/templates/accounts/newsletter-unsubscription.html
+++ b/templates/accounts/newsletter-unsubscription.html
@@ -8,7 +8,7 @@
                         <div>
                             <img class="w-25 h-25" src="{% static 'images/logos/sm-logo-registry.png' %}" alt="">
                             <h1 class="no-top-margin">Update Newsletter Preferences</h1>
-                            <p>Preferences for <a class="darkteal-text underline-hover" href="mailto:{{ email }}">{{ email }}</a></p>
+                            <p>Preferences for <a class="default-a" href="mailto:{{ email }}">{{ email }}</a></p>
                         </div>
 
                         <form method="POST" action="" enctype="multipart/form-data">
@@ -52,7 +52,7 @@
                     {% else %}
                         <div>
                             <h1 class="no-top-margin">You have been successfully unsubscribed.</h1>
-                            <p>If this was a mistake and you would like to subscribe again, click <a class="darkteal-text underline-hover" href="{% url 'newsletter-subscription' %}">here</a>.</p>               
+                            <p>If this was a mistake and you would like to subscribe again, click <a class="default-a" href="{% url 'newsletter-subscription' %}">here</a>.</p>               
                         </div>
                     {% endif %}
                 </div>

--- a/templates/accounts/password-reset-done.html
+++ b/templates/accounts/password-reset-done.html
@@ -4,7 +4,7 @@
     <div class="flex-this column w-90">
         <h2 class="margin-bottom-2">Password reset complete</h2>
         <p class="no-top-margin">
-            Your password has been reset successfully. You can now <a class="darkteal-text underline-hover" href="{% url 'login' %}">login</a>.
+            Your password has been reset successfully. You can now <a class="default-a" href="{% url 'login' %}">login</a>.
         </p>                               
     </div>
 {% endblock %}

--- a/templates/accounts/preparation.html
+++ b/templates/accounts/preparation.html
@@ -27,7 +27,7 @@
 
             <br><br>
             Until the account is confirmed, certain features will not be available. This confirmation must be completed within 90 days, or the account will be suspended. If you have any questions, please contact us. 
-            If you are trying out the Hub, please join our <a class="darkteal-text underline-hover" href="https://sandbox.localcontextshub.org" target="_blank" rel="noopener">sandbox site <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>. 
+            If you are trying out the Hub, please join our <a class="default-a" href="https://sandbox.localcontextshub.org" target="_blank" rel="noopener">sandbox site <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>. 
 
         </p>            
     </div>
@@ -48,7 +48,7 @@
 
         <div class="w-90 flex-this flex-end">
             <div class="margin-right-8">
-                <a class="primary-btn white-btn" href="{% url 'dashboard' %}">Complete step later <i class="fa fa-arrow-right"></i></a>
+                <a class="primary-btn white-btn" href="{% url 'dashboard' %}">Complete step later</a>
             </div>
             <div>
                 <a 

--- a/templates/accounts/register.html
+++ b/templates/accounts/register.html
@@ -10,7 +10,7 @@
 
 <div class="flex-this space-between w-90">
     <div><h2>Register with Local Contexts</h2></div>
-    <div><p class="grey-text">Already signed up?<a href="{% url 'login' %}" class="darkteal-text"> Sign in</a></p></div>
+    <div><p>Already signed up? <a href="{% url 'login' %}" class="default-a">Sign in</a></p></div>
 </div>
 
 <div class="form-container flex-this column w-90">
@@ -66,15 +66,15 @@
                 <div class="text-align-right margin-right-1">
                     <input type="checkbox" name="terms-agreement" required>
                 </div>
-                <div class="checkbox-label w-100">
+                <div class="no-margin w-100">
                     <p>
                         <span>Creating an account means you agree with the</span> 
-                        <a href="https://localcontexts.org/indigenous-data-sovereignty/" target="_blank" rel="noopener" class="darkteal-text underline-hover">
+                        <a href="https://localcontexts.org/indigenous-data-sovereignty/" target="_blank" rel="noopener" class="default-a">
                             Indigenous Data Sovereignty Agreement,
                         </a>
-                        <a href="https://localcontexts.org/privacy-policy/" target="_blank" rel="noopener" class="darkteal-text underline-hover">Privacy Policy</a>
+                        <a href="https://localcontexts.org/privacy-policy/" target="_blank" rel="noopener" class="default-a">Privacy Policy</a>
                         <span>and the</span> 
-                        <a href="https://localcontexts.org/terms-conditions/" target="_blank" rel="noopener" class="darkteal-text underline-hover">Terms and Conditions</a>
+                        <a href="https://localcontexts.org/terms-conditions/" target="_blank" rel="noopener" class="default-a">Terms and Conditions</a>
                     </p>
                 </div>
             </div>

--- a/templates/communities/add-community-boundary.html
+++ b/templates/communities/add-community-boundary.html
@@ -108,7 +108,7 @@
             please reach out to Native Land Digital for assistance.
         </p>
         <div id="navigate-to-option">
-            Or <a class="darkteal-text underline-hover" href="{% url 'upload-boundary-file' %}">upload shape file</a>
+            Or <a class="default-a" href="{% url 'upload-boundary-file' %}">upload shape file</a>
         </div>
 
         <div id="region-container">

--- a/templates/communities/apply-labels.html
+++ b/templates/communities/apply-labels.html
@@ -100,9 +100,9 @@
         <p class="no-top-margin w-70">
             {% if bclabels or tklabels %}
                 Your community can apply Labels to Projects, please choose from your customized Labels below.<br>
-                If you would like to customize more Labels, you can do so <a class="darkteal-text underline-hover" href="{% url 'select-label' community.id %}">here</a>.
+                If you would like to customize more Labels, you can do so <a class="default-a" href="{% url 'select-label' community.id %}">here</a>.
             {% else %}
-                It looks like currently you do not have any Labels customized. To customize a new Label, click <a class="darkteal-text underline-hover" href="{% url 'select-label' community.id %}">here</a>.
+                It looks like currently you do not have any Labels customized. To customize a new Label, click <a class="default-a" href="{% url 'select-label' community.id %}">here</a>.
             {% endif %}
 
             {% include 'partials/_alerts.html' %}

--- a/templates/communities/community-boundary.html
+++ b/templates/communities/community-boundary.html
@@ -51,7 +51,7 @@
                             <div class="communityBoundaryText">
                                 Native Land Digital is an Indigenous led mapping tool that maps
                                 Indigenous territories, treaties and languages around the world.
-                                <a class="darkteal-text underline-hover" target="_blank" href="https://native-land.ca/">See more information here</a>
+                                <a class="default-a" target="_blank" href="https://native-land.ca/">See more information here</a>
                             </div>
                         </div>
 

--- a/templates/communities/create-community.html
+++ b/templates/communities/create-community.html
@@ -8,7 +8,7 @@
         <div> Or <a class="darkteal-text" href="{% url 'connect-community' %}">request to join an existing community</a> </div> 
     </div>
 
-    <p class="no-top-margin">Community accounts created in Local Contexts can be discoverable in the Local Contexts registery, the information displayed will be the information you provide on behalf of the community below. Read more about our privacy standards <a class="darkteal-text underline-hover" href="https://localcontexts.org/privacy-policy/" target="_blank" rel="noopener">here <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.</p>
+    <p class="no-top-margin">Community accounts created in Local Contexts can be discoverable in the Local Contexts registery, the information displayed will be the information you provide on behalf of the community below. Read more about our privacy standards <a class="default-a" href="https://localcontexts.org/privacy-policy/" target="_blank" rel="noopener">here <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.</p>
     
     <form action="" method="POST" class="flex-this column w-100">
         {% csrf_token %}

--- a/templates/communities/select-label.html
+++ b/templates/communities/select-label.html
@@ -278,7 +278,7 @@
                 The TK Label text is intended to be customized by each community – giving the Labels specificity and context. 
                 The title of each TK Label can be translated into one or more languages and displayed in addition to the default Label title. 
                 The TK Label icons are not to be altered.  This is to ensure national and international recognition and integrity across content 
-                and collection management systems, online repositories, websites, and physical exhibits, learn more about <a class="darkteal-text underline-hover" href="https://localcontexts.org/labels/traditional-knowledge-labels/" target="_blank" rel="noopener">TK Labels</a>.
+                and collection management systems, online repositories, websites, and physical exhibits, learn more about <a class="default-a" href="https://localcontexts.org/labels/traditional-knowledge-labels/" target="_blank" rel="noopener">TK Labels <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.
                 <br><br>
                 Click on a Label to view more information*
             </p>
@@ -641,7 +641,7 @@
                 The title of each BC Label can be translated into one or more languages and displayed in addition to the default Label title. 
                 The BC Label icons are not to be altered.  This is to ensure national and international recognition and integrity across content and collection management systems, 
                 online repositories, websites, and physical exhibits. 
-                Learn more about <a class="darkteal-text underline-hover" href="https://localcontexts.org/labels/biocultural-labels/" target="_blank" rel="noopener">BC Labels</a>.
+                Learn more about <a class="default-a" href="https://localcontexts.org/labels/biocultural-labels/" target="_blank" rel="noopener">BC Labels <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.
                 <br><br>
                 Click on a Label to view more information*
             </p>

--- a/templates/communities/upload-boundary-file.html
+++ b/templates/communities/upload-boundary-file.html
@@ -107,7 +107,7 @@
             You can create shape files on third-party websites like QGIS, LINK2, and LINK3.
         </p>
         <div id="navigate-to-option">
-            Or <a class="darkteal-text underline-hover" href="{% url 'add-community-boundary' %}">search NLD database</a>
+            Or <a class="default-a" href="{% url 'add-community-boundary' %}">search NLD database</a>
         </div>
 
         <div id="browse-files-container">

--- a/templates/communities/view-label.html
+++ b/templates/communities/view-label.html
@@ -147,7 +147,7 @@
                 {% if bclabel.version or tklabel.version %}
                     {% if bclabel.version > 1 or tklabel.version > 1 %}
                         <div class="flex-this flex-end margin-bottom-8">
-                            <small id="openLabelHistoryBtn" class="darkteal-text underline-hover pointer block right-text">View Label History <i class="fa fa-angle-down" aria-hidden="true"></i></small>
+                            <small id="openLabelHistoryBtn" class="default-a block right-text">View Label History <i class="fa fa-angle-down" aria-hidden="true"></i></small>
                         </div>
                         <div id="labelHistoryDiv" class="hide margin-bottom-8">
                                 <p>

--- a/templates/institutions/create-custom-institution.html
+++ b/templates/institutions/create-custom-institution.html
@@ -3,13 +3,13 @@
 <div class="flex-this column account-registration-container">
     <div class="flex-this space-between">
         <div><h2 class="no-top-margin margin-bottom-8">Institution Account</h2></div>
-        <div>Or <a class="darkteal-text underline-hover" href="{% url 'connect-institution' %}">request to join an existing institution</a>  </div>
+        <div>Or <a class="default-a" href="{% url 'connect-institution' %}">request to join an existing institution</a>  </div>
     </div>
 
     <p class="no-bottom-margin no-top-margin">
         The institution details provided below will default to a public display in the Local Contexts Registry.
         Providing your details will give consent to publicly being listed on the Registry.
-        Read more about our privacy standards <a class="darkteal-text underline-hover" href="https://localcontexts.org/privacy-policy/" target="_blank" rel="noopener">here <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>
+        Read more about our privacy standards <a class="default-a" href="https://localcontexts.org/privacy-policy/" target="_blank" rel="noopener">here <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>
     </p>
 
 
@@ -23,7 +23,7 @@
 
         <div>
             <p class="blue-highlight">
-                If your institution is listed on <a class="darkteal-text underline-hover" href="https://ror.org/" target="_blank" rel="noopener">ROR <i class="fa-regular fa-arrow-up-right-from-square fa-2xs"></i></a>, please fill out <a href="{% url 'create-institution' %}" class="darkteal-text underline-hover pointer">this form instead</a>.
+                If your institution is listed on <a class="default-a" href="https://ror.org/" target="_blank" rel="noopener">ROR <i class="fa-regular fa-arrow-up-right-from-square fa-2xs"></i></a>, please fill out <a href="{% url 'create-institution' %}" class="default-a">this form instead</a>.
             </p>
         </div>
 

--- a/templates/institutions/create-institution.html
+++ b/templates/institutions/create-institution.html
@@ -3,13 +3,13 @@
 <div class="flex-this column account-registration-container">
     <div class="flex-this space-between">
         <div><h2 class="no-top-margin margin-bottom-8">Institution Account</h2></div>
-        <div>Or <a class="darkteal-text underline-hover" href="{% url 'connect-institution' %}">request to join an existing institution</a>  </div>
+        <div>Or <a class="default-a" href="{% url 'connect-institution' %}">request to join an existing institution</a>  </div>
     </div>
 
     <p class="no-bottom-margin no-top-margin">
         The institution details provided below will default to a public display in the Local Contexts Registry.
         Providing your details will give consent to publicly being listed on the Registry.
-        Read more about our privacy standards <a class="darkteal-text underline-hover" href="https://localcontexts.org/privacy-policy/" target="_blank" rel="noopener">here <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>
+        Read more about our privacy standards <a class="default-a" href="https://localcontexts.org/privacy-policy/" target="_blank" rel="noopener">here <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>
     </p>
 
     <form id="createInstitutionForm" action="" method="POST" class="flex-this column w-100">
@@ -21,7 +21,7 @@
             <div id="suggestionsContainer"></div>
         </div>
         <div>
-            <p class="blue-highlight">These institutions come from <a class="darkteal-text underline-hover" href="https://ror.org/" target="_blank" rel="noopener">ROR <i class="fa-regular fa-arrow-up-right-from-square fa-2xs"></i></a>. If your institution is not listed here, <a href="{% url 'create-custom-institution' %}" class="darkteal-text underline-hover pointer">fill out this form</a>.</p>
+            <p class="blue-highlight">These institutions come from <a class="default-a" href="https://ror.org/" target="_blank" rel="noopener">ROR <i class="fa-regular fa-arrow-up-right-from-square fa-2xs"></i></a>. If your institution is not listed here, <a href="{% url 'create-custom-institution' %}" class="default-a">fill out this form</a>.</p>
         </div>
 
 

--- a/templates/partials/_connect-organization.html
+++ b/templates/partials/_connect-organization.html
@@ -9,7 +9,7 @@
                     Account
                 </h2>
             </div>
-            <div class="margin-top-16">Or <a class="darkteal-text underline-hover" href="{% url 'select-account' %}">choose another account</a></div>
+            <div class="margin-top-16">Or <a class="default-a" href="{% url 'select-account' %}">choose another account</a></div>
         </div>
         <p class="w-90">
             Search the registry of {% if community %} communities {% endif %}{% if institution %} institutions {% endif %} that have accounts on the Local Contexts Hub. 
@@ -54,7 +54,7 @@
      <div class="flex-this space-between margin-top-1">
          <div>
              <a 
-                class="darkteal-text underline-hover" 
+                class="default-a" 
                 {% if community %}
                 href="{% url 'create-community' %}"
                 {% endif %}
@@ -67,7 +67,7 @@
             </a>
         </div>
         <div class="flex-this">
-            <div class="margin-right-16 flex-this align-center"><small class="block"><a href="{% url 'dashboard' %}" class="darkteal-text underline-hover bold">Skip this for now</a></small></div>
+            <div class="margin-right-16 flex-this align-center"><small class="block"><a href="{% url 'dashboard' %}" class="default-a">Skip this for now</a></small></div>
             <div><button id="openJoinRequestModalBtn" class="primary-btn action-btn margin-top-2 ">Next <i class="fa fa-arrow-right"></i></button></div>
         </div>
      </div>
@@ -128,7 +128,7 @@
 
                 <div class="flex-this space-between w-100">
                     <p class="w-70 no-top-margin">
-                        <small class="grey-text">By sending this request, you consent for your message and email address to be shared with account administrators.</small>
+                        <small>By sending this request, you consent for your message and email address to be shared with account administrators.</small>
                     </p>
                     <div>
                         <button class="primary-btn action-btn margin-top-2">Send request</button>

--- a/templates/partials/_notices.html
+++ b/templates/partials/_notices.html
@@ -55,7 +55,7 @@
                 <p>
                     <span class="bold">How can I use this Notice?</span><br>
                     Access the Hub API or click the “Download Notice” button on this page to use the Open to Collaborate Notice. For detailed information about the Engagement Notice and how to apply it, 
-                    <a class="darkteal-text underline-hover" href="https://localcontexts.org/support/downloadable-resources/" target="_blank" rel="noopener">see our usage guide <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>. 
+                    <a class="default-a" href="https://localcontexts.org/support/downloadable-resources/" target="_blank" rel="noopener">see our usage guide <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>. 
                     <br><br>
                     If you add the Notice to a website, click the “Add Link” button and enter the information about where your Notice is displayed. If you have applied the Notice in multiple places, you can add multiple links.
                     <br><br>
@@ -72,13 +72,13 @@
                             {% for url in urls %}
                                 <li class="margin-bottom-8">
                                     <div class="flex-this w-70 space-between">
-                                        <a class="darkteal-text underline-hover block" href="{{ url.0 }}" target="_blank" rel="noopener">{{ url.1 }} <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>
+                                        <a class="default-a block" href="{{ url.0 }}" target="_blank" rel="noopener">{{ url.1 }} <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>
                                         {% if researcher %}
-                                            <a class="darkteal-text underline-hover block" href="{% url 'researcher-delete-otc' researcher.id url.2 %}"> <i class="fa fa-trash" aria-hidden="true"></i></a>
+                                            <a class="default-a block" href="{% url 'researcher-delete-otc' researcher.id url.2 %}"> <i class="fa fa-trash" aria-hidden="true"></i></a>
                                         {% endif %}     
                                         {% if institution %}
                                             {% if member_role == 'admin' or member_role == 'editor' %}
-                                                <a class="darkteal-text underline-hover block" href="{% url 'institution-delete-otc' institution.id url.2 %}"> <i class="fa fa-trash" aria-hidden="true"></i></a>
+                                                <a class="default-a block" href="{% url 'institution-delete-otc' institution.id url.2 %}"> <i class="fa fa-trash" aria-hidden="true"></i></a>
                                             {% endif %}
                                         {% endif %}                                   
                                     </div>
@@ -129,7 +129,7 @@
         <p>
             <span class="bold">How can I use these Notices?</span><br>
             To apply the Disclosure Notices, you will create a Project to describe the context. After creating a Project, you can use the Hub API or download from the Project page to use the Notice(s). For detailed information about the Disclosure Notices and how to apply them, 
-            <a class="darkteal-text underline-hover" href="https://localcontexts.org/support/downloadable-resources/" target="_blank" rel="noopener">see our usage guide <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.
+            <a class="default-a" href="https://localcontexts.org/support/downloadable-resources/" target="_blank" rel="noopener">see our usage guide <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.
         </p>        
     </div>
 
@@ -166,7 +166,7 @@
                         <p>
                             <span class="bold">Notice Text</span><br>                        
                             The TK Notice is a visible notification that there are accompanying cultural rights and responsibilities that need further attention for any future sharing and use of this material. The TK Notice may indicate that TK Labels are in development and their implementation is being negotiated. For more information about the TK Notice click 
-                            <a class="darkteal-text underline-hover" href="https://localcontexts.org/notice/tk-notice/" target="_blank" rel="noopener">here <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.
+                            <a class="default-a" href="https://localcontexts.org/notice/tk-notice/" target="_blank" rel="noopener">here <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.
                         </p>         
                     </div>
                 </div>
@@ -188,7 +188,7 @@
                         <p>
                             <span class="bold">Notice Text</span><br>
                             The BC Notice is a visible notification that there are accompanying cultural rights and responsibilities that need further attention for any future sharing and use of this material or data. The BC Notice recognizes the rights of Indigenous peoples to permission the use of information, collections, data and digital sequence information generated from the biodiversity or genetic resources associated with traditional lands, waters, and territories. The BC Notice may indicate that BC (Biocultural) Labels are in development and their implementation is being negotiated. For more information about the BC Notice click 
-                            <a class="darkteal-text underline-hover" href="https://localcontexts.org/notice/bc-notice/" target="_blank" rel="noopener">here <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.
+                            <a class="default-a" href="https://localcontexts.org/notice/bc-notice/" target="_blank" rel="noopener">here <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.
                         </p>         
                     </div>
                 </div>
@@ -272,7 +272,7 @@
                         Within the downloaded zip file are folders for each Notice containing its text, png, svg, QR code, and printable labels. Also included in the zip file is a poster with the Overall Notice. For transparency and staff awareness, we highly recommend that the poster with the Overall Notice is displayed in collections storage where the CC Notices are in use. 
                         <br><br>
                         For detailed information about the CC Notices and how to apply them, 
-                        <a class="darkteal-text underline-hover" href="https://localcontexts.org/support/downloadable-resources/" target="_blank" rel="noopener">see our usage guide <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.
+                        <a class="default-a" href="https://localcontexts.org/support/downloadable-resources/" target="_blank" rel="noopener">see our usage guide <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.
                     </p>
                 </div>
 

--- a/templates/partials/_project-actions.html
+++ b/templates/partials/_project-actions.html
@@ -59,7 +59,7 @@
                     <div><p>
                             <em>
                                 <a 
-                                    class="darkteal-text underline-hover" 
+                                    class="default-a" 
                                     {% if community %}
                                         href="{% url 'community-project-actions' community.id project.source_project_uuid %}"
                                     {% endif %}
@@ -103,7 +103,7 @@
                             <ul>
                                 {% for url in project.urls %}
                                     <li>
-                                        <a href="{{ url }}" class="darkteal-text underline-hover word-break" target="_blank" rel="noopener">{{ url }} <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>
+                                        <a href="{{ url }}" class="default-a word-break" target="_blank" rel="noopener">{{ url }} <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>
                                     </li>
                                 {% endfor %}
                             </ul>
@@ -121,7 +121,7 @@
                                     <li>
                                         <div class="flex-this space-between">
                                             <div>
-                                                <a href="{% url 'public-community' account.id %}" class="darkteal-text underline-hover">{{ account.community_name }}</a> | Community 
+                                                <a href="{% url 'public-community' account.id %}" class="default-a">{{ account.community_name }}</a> | Community 
                                             </div>
                                             {% if account == community and not account == creator.community %} 
                                                 <div>
@@ -138,7 +138,7 @@
                                     <li>
                                         <div class="flex-this space-between">
                                             <div>
-                                                <a href="{% url 'public-institution' account.id %}" class="darkteal-text underline-hover">{{ account.institution_name }}</a> | Institution 
+                                                <a href="{% url 'public-institution' account.id %}" class="default-a">{{ account.institution_name }}</a> | Institution 
                                             </div>
                                             {% if account == institution and not account == creator.institution %} 
                                                 <div>
@@ -160,7 +160,7 @@
                                                         <img loading="lazy" src="https://orcid.org/sites/default/files/images/orcid_16x16.png" style="margin-top:2.5px;" alt="ORCID iD icon">
                                                     </a>
                                                 {% endif %}
-                                                <a href="{% url 'public-researcher' account.id %}" class="darkteal-text underline-hover">{% firstof account.user.get_full_name account.user.username %}</a> | Researcher
+                                                <a href="{% url 'public-researcher' account.id %}" class="default-a">{% firstof account.user.get_full_name account.user.username %}</a> | Researcher
                                             </div>
                                             {% if account == researcher and not account == creator.researcher %} 
                                                 <div>
@@ -299,7 +299,7 @@
                         <div class="label-group">
                             <div class="flex-this space-between">
                                 <div>
-                                    <a class="darkteal-text underline-hover bold" href="{% url 'public-community' community.id %}">{{ community.community_name }}</a> <br>
+                                    <a class="default-a" href="{% url 'public-community' community.id %}">{{ community.community_name }}</a> <br>
                                     <p class="italic">
                                         <i class="fa-solid fa-tag"></i> {{ labels.bc_label_count|add:labels.tk_label_count }} Labels applied
                                     </p>                                
@@ -960,7 +960,7 @@
                 {% if statuses %}
                     {% for status in statuses %}
                         <div class="border-bottom-grey">
-                            <div><p><span class="bold"><a href="{% url 'public-community' status.community.id %}" class="darkteal-text underline-hover">{{ status.community }}</a> </span></p></div>
+                            <div><p><span class="bold"><a href="{% url 'public-community' status.community.id %}" class="default-a">{{ status.community }}</a> </span></p></div>
                             <div>
                                 <p><em> Project status: </em>
                                     {% if status.seen and status.status == None %} Seen

--- a/templates/partials/_project-contributor-view.html
+++ b/templates/partials/_project-contributor-view.html
@@ -69,7 +69,7 @@
                             {% include 'bclabels/which-label.html' %}
                         </div>
                         <div class="pad-left-2">
-                            <p>Label shared by <a href="{% url 'public-community' bclabel.community.id %}" class="darkteal-text underline-hover">{{ bclabel.community.community_name }}</a> </p>
+                            <p>Label shared by <a href="{% url 'public-community' bclabel.community.id %}" class="default-a">{{ bclabel.community.community_name }}</a> </p>
                             <p class="bold"> {{ bclabel.name }} </p>
                             {% if bclabel.audiofile %} <div><audio src="{{ bclabel.audiofile.url }}" controls></audio></div>{% endif %}
                             <p>{{ bclabel.label_text}}</p>
@@ -90,7 +90,7 @@
                             {% include 'tklabels/which-label.html' %}
                         </div>
                         <div class="pad-left-2">
-                            <p>Label shared by <a href="{% url 'public-community' tklabel.community.id %}" class="darkteal-text underline-hover">{{ tklabel.community.community_name }}</a> </p>
+                            <p>Label shared by <a href="{% url 'public-community' tklabel.community.id %}" class="default-a">{{ tklabel.community.community_name }}</a> </p>
                             <p class="bold"> {{ tklabel.name }} </p>
                             {% if tklabel.audiofile %} <div><audio src="{{ tklabel.audiofile.url }}" controls></audio></div>{% endif %}
                             <p>{{ tklabel.label_text}}</p>

--- a/templates/partials/_update-account.html
+++ b/templates/partials/_update-account.html
@@ -214,7 +214,7 @@
                                     <div>
                                         <div itemscope itemtype="https://schema.org/Person">
                                             <a 
-                                                class="darkteal-text underline-hover" 
+                                                class="default-a" 
                                                 itemprop="sameAs" 
                                                 target="orcid.widget" 
                                                 rel="me noopener noreferrer" 
@@ -249,7 +249,7 @@
 
                             {% else %}
                                 <div class="flex-this space-between">
-                                    <div class="w-50"><p>We encourage you to have an ORCiD ID. <br>You can <a class="darkteal-text underline-hover" href="https://orcid.org/" target="_blank" rel="noopener">read more about ORCiD here</a>.</p></div>
+                                    <div class="w-50"><p>We encourage you to have an ORCiD ID. <br>You can <a class="default-a" href="https://orcid.org/" target="_blank" rel="noopener">read more about ORCiD here</a>.</p></div>
                                     <!-- Show ORCiD widget based on hostname -->
                                     <div 
                                         id="orcidWidget" 
@@ -271,7 +271,7 @@
                                 </div>
                         
                                 {% if env == "DEV" or env == "SANDBOX" %}
-                                    <small class="bold">Please note that since this is a test site, the ORCiD used will be the <a class="darkteal-text underline-hover" href="https://sandbox.orcid.org/">sandbox version</a>.</small><br>
+                                    <small class="bold">Please note that since this is a test site, the ORCiD used will be the <a class="default-a" href="https://sandbox.orcid.org/">sandbox version</a>.</small><br>
                                 {% endif %}  
                             {% endif %}
                                 
@@ -287,7 +287,7 @@
                         </div>
                         <p>
                             <small class="grey-text">Providing your personal information is optional.
-                                By providing it, you consent for it to be shown to other Hub users, see the <a href="https://localcontexts.org/privacy-policy/" class="darkteal-text underline-hover" target="_blank" rel="noopener">Privacy Policy <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.</small>
+                                By providing it, you consent for it to be shown to other Hub users, see the <a href="https://localcontexts.org/privacy-policy/" class="default-a" target="_blank" rel="noopener">Privacy Policy <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.</small>
                         </p> 
                     </div>
                 </form>

--- a/templates/partials/infocards/_community-dashcard.html
+++ b/templates/partials/infocards/_community-dashcard.html
@@ -6,7 +6,7 @@
         <div class="flex-this w-100 space-between">
             <div class="loc grey-text bold">
                 <small>
-                    <a href="{% url 'dashboard' %}" class="bold darkteal-text underline-hover">
+                    <a href="{% url 'dashboard' %}" class="default-a">
                         {% firstof request.user.get_full_name request.user %}
                     </a> 
                     >> {{ community.community_name }}                    

--- a/templates/partials/infocards/_institution-dashcard.html
+++ b/templates/partials/infocards/_institution-dashcard.html
@@ -6,7 +6,7 @@
         <div class="flex-this w-100 space-between">
             <div class="loc grey-text bold">
                 <small>
-                    <a href="{% url 'dashboard' %}" class="bold darkteal-text underline-hover">
+                    <a href="{% url 'dashboard' %}" class="default-a">
                         {% firstof request.user.first_name request.user %}
                     </a> 
                     >> {{ institution.institution_name }}                    

--- a/templates/partials/infocards/_researcher-dashcard.html
+++ b/templates/partials/infocards/_researcher-dashcard.html
@@ -6,7 +6,7 @@
         <div class="flex-this w-100 space-between">
             <div class="loc grey-text bold">
                 <small>
-                    <a href="{% url 'dashboard' %}" class="bold darkteal-text underline-hover">
+                    <a href="{% url 'dashboard' %}" class="default-a">
                         {% firstof request.user.first_name request.user %}
                     </a> 
                     >>                        
@@ -47,7 +47,7 @@
                     {% if researcher.orcid %}
                         <div itemscope itemtype="https://schema.org/Person">
                             <a 
-                                class="darkteal-text underline-hover" 
+                                class="default-a" 
                                 itemprop="sameAs" 
                                 target="orcid.widget" 
                                 rel="me noopener noreferrer" 

--- a/templates/partials/infocards/_user-dashcard.html
+++ b/templates/partials/infocards/_user-dashcard.html
@@ -52,19 +52,19 @@
         <div class="suggestion-box">
             <small class="block">
                 <span class="bold">Build your profile</span> so that other users on the hub can know more about you<br>
-                <a class="darkteal-text underline-hover bold" href="{% url 'update-profile' %}">Edit profile</a>
+                <a class="default-a" href="{% url 'update-profile' %}">Edit profile</a>
             </small>
         </div>
         <div class="suggestion-box">
             <small class="block">
                 <span class="bold">Create an account</span> for either a community, institution, or researcher<br>
-                <a class="darkteal-text underline-hover bold" href="{% url 'select-account' %}">Create an account</a>
+                <a class="default-a" href="{% url 'select-account' %}">Create an account</a>
             </small>
         </div>
         <div class="suggestion-box">
             <small class="block">
                 <span class="bold">Join an existing account</span> that you may already be connected to<br>
-                <a class="darkteal-text underline-hover bold" href="{% url 'registry' %}">Search the Local Contexts registry</a>
+                <a class="default-a" href="{% url 'registry' %}">Search the Local Contexts registry</a>
             </small>
         </div>
     </div>

--- a/templates/projects/embed-project.html
+++ b/templates/projects/embed-project.html
@@ -261,7 +261,7 @@
         <div class="flex-this wrap w-100">
             <div class="flex-this ">
                 <div class="margin-left-8 margin-right-8 padding-bottom-1 pad-top-1"><a href="https://localcontexts.org"><img style="width:30px;" src="https://localcontexts.org/wp-content/uploads/2023/04/White-Background.png" alt="Local Contexts Icon"></a></div>
-                <div class="auto-margin font-size-14"><a id="project-link" class="darkteal-text underline-hover bold" href="{{project.project_page}}">{{project.project_page}}</a></div>
+                <div class="auto-margin font-size-14"><a id="project-link" class="default-a" href="{{project.project_page}}">{{project.project_page}}</a></div>
             </div>
         </div>
     </body>

--- a/templates/public.html
+++ b/templates/public.html
@@ -5,7 +5,7 @@
         <div class="flex-this space-between">
             <div class="loc grey-text bold margin-bottom-16">
                 <small>
-                    <a href="{% url 'registry' %}" class="bold darkteal-text underline-hover">
+                    <a href="{% url 'registry' %}" class="default-a">
                         Local Contexts Registry
                     </a> 
                     >> {{ community.community_name }}  
@@ -23,7 +23,7 @@
                                 <div class="primary-btn disabled-btn">Request sent <i class="fa fa-check" aria-hidden="true"></i></div>
                             {% else %}
                                 <div class="margin-top-8 margin-bottom-8">
-                                    <a id="openRequestToJoinModalBtn" class="darkteal-text underline-hover pointer">Request to join</a>
+                                    <a id="openRequestToJoinModalBtn" class="default-a">Request to join</a>
                                 </div>
                             {% endif %}                            
                         </div>
@@ -55,7 +55,7 @@
                         </div>
                     </div>
                 {% else %}
-                    <div class="loc grey-text bold margin-bottom-16">
+                    <div class="loc bold margin-bottom-16">
                         <small>
                             You are a member of this community
                         </small>
@@ -64,7 +64,7 @@
             {% else %}
                 <div class="loc grey-text bold margin-bottom-16">
                     <small>
-                        <a href="{% url 'login' %}" class="bold darkteal-text underline-hover">
+                        <a href="{% url 'login' %}" class="default-a">
                             Login
                         </a> 
                         to contact
@@ -125,7 +125,7 @@
         <div class="flex-this space-between">
             <div class="loc grey-text bold  margin-bottom-16">
                 <small>
-                    <a href="{% url 'registry' %}" class="bold darkteal-text underline-hover">
+                    <a href="{% url 'registry' %}" class="default-a">
                         Local Contexts Registry
                     </a> 
                     >> {{ institution.institution_name }}
@@ -142,7 +142,7 @@
                                 <div class="primary-btn disabled-btn">Request sent <i class="fa fa-check" aria-hidden="true"></i></div>
                             {% else %}
                                 <div class="margin-top-8 margin-bottom-8">
-                                    <a id="openRequestToJoinModalBtn" class="darkteal-text underline-hover pointer">Request to join</a>
+                                    <a id="openRequestToJoinModalBtn" class="default-a">Request to join</a>
                                 </div>
                             {% endif %}                                
                         </div>
@@ -175,7 +175,7 @@
                         </div>
                     </div>
                 {% else %}
-                    <div class="loc grey-text bold margin-bottom-16">
+                    <div class="loc bold margin-bottom-16">
                         <small>
                             You are a member of this institution
                         </small>
@@ -184,7 +184,7 @@
             {% else %}
                 <div class="loc grey-text bold margin-bottom-16">
                     <small>
-                        <a href="{% url 'login' %}" class="bold darkteal-text underline-hover">
+                        <a href="{% url 'login' %}" class="default-a">
                             Login
                         </a> 
                         to contact
@@ -237,7 +237,7 @@
                         <ul>
                             {% for notice in otc_notices %}
                                 <li>
-                                    <a href="{{ notice.url }}" class="darkteal-text underline-hover">
+                                    <a href="{{ notice.url }}" class="default-a">
                                         {% if notice.name %} {{ notice.name }} {% else %}{{ notice.url }}{% endif %}
                                     </a>
                                 </li>
@@ -253,7 +253,7 @@
         <div class="flex-this space-between">
             <div class="loc grey-text bold margin-bottom-16">
                 <small>
-                    <a href="{% url 'registry' %}" class="bold darkteal-text underline-hover">
+                    <a href="{% url 'registry' %}" class="default-a">
                         Local Contexts Registry
                     </a> 
                     >>    
@@ -343,7 +343,7 @@
                         <ul>
                             {% for notice in otc_notices %}
                                 <li>
-                                    <a href="{{ notice.url }}" class="darkteal-text underline-hover">
+                                    <a href="{{ notice.url }}" class="default-a">
                                         {% if notice.name %} {{ notice.name }} {% else %}{{ notice.url }}{% endif %}
                                     </a>
                                 </li>
@@ -430,7 +430,7 @@
 
                                 <div class="flex-this space-between margin-top-8 w-100">
                                     <p class="w-70 no-top-margin">
-                                        <small class="grey-text">By sending this request, you consent for your message and email address to be shared with account administrators.</small>
+                                        <small>By sending this request, you consent for your message and email address to be shared with account administrators.</small>
                                     </p>
                                     <div>
                                         <input type="hidden" name="join_request">

--- a/templates/researchers/connect-researcher.html
+++ b/templates/researchers/connect-researcher.html
@@ -5,7 +5,7 @@
     <div class="flex-this column w-90">
         <div class="margin-bottom-1 flex-this space-between">
             <h2>Researcher Account</h2>  
-            <div class="margin-top-16">Or <a class="darkteal-text underline-hover" href="{% url 'select-account' %}">choose another account</a></div>
+            <div class="margin-top-16">Or <a class="default-a" href="{% url 'select-account' %}">choose another account</a></div>
         </div>
         <div>
             <p class="no-top-margin no-bottom-margin">A researcher is a person who carries out academic or scientific research independently or in an institution, such as archive, library, museum, historical society, gallery, data repository, or university.</p>
@@ -16,7 +16,7 @@
 
             <div>
                 <div class="flex-this space-between">
-                    <div class="w-50"><p>We encourage you to have an ORCiD ID. <br>You can <a class="darkteal-text underline-hover" href="https://orcid.org/" target="_blank" rel="noopener">read more about ORCiD here</a>.</p></div>
+                    <div class="w-50"><p>We encourage you to have an ORCiD ID. <br>You can <a class="default-a" href="https://orcid.org/" target="_blank" rel="noopener">read more about ORCiD here</a>.</p></div>
 
                     <!-- Show ORCiD widget based on hostname -->
                     <div 
@@ -39,7 +39,7 @@
                 </div>
 
                 {% if env == "DEV" or env == "SANDBOX" %}
-                    <small class="bold">Please note that since this is a test site, the ORCiD used will be the <a class="darkteal-text underline-hover" href="https://sandbox.orcid.org/">sandbox version</a>.</small><br>
+                    <small class="bold">Please note that since this is a test site, the ORCiD used will be the <a class="default-a" href="https://sandbox.orcid.org/">sandbox version</a>.</small><br>
                 {% endif %}            
             </div>
 

--- a/templates/snippets/pdfs/project-pdf.html
+++ b/templates/snippets/pdfs/project-pdf.html
@@ -109,7 +109,7 @@
                     <strong>Project Links</strong><br>
                     <ul>
                         {% for url in project.urls %}
-                            <li><a href="{{ url }}" class="darkteal-text underline-hover" target="_blank" rel="noopener">{{ url }} <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a></li>
+                            <li><a href="{{ url }}" class="default-a" target="_blank" rel="noopener">{{ url }} <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a></li>
                         {% endfor %}
                     </ul>
                 {% endif %}

--- a/templates/snippets/project_notices.html
+++ b/templates/snippets/project_notices.html
@@ -11,7 +11,7 @@
                 {% if researcher %}
                     href="{% url 'researcher-notices' researcher.id %}"
                 {% endif %}
-                class="darkteal-text underline-hover"
+                class="default-a"
             >go to the Notices page</a>.
         </p>
     </div>


### PR DESCRIPTION
Per Renee's request (see ClickUp Task)
- UI update for default a class for all links throughout the site.
- UI update some grey text disclaimers.

Will provide only one example because this was done on a lot of pages.

**Before:**
![Screenshot 2024-01-24 at 4 44 16 PM](https://github.com/localcontexts/localcontextshub/assets/41635757/14fdf447-40cc-4e0e-b719-a0d9e0e911f4)



**After: Links are now bold and underlined, disclaimer text black instead of grey.**
![Screenshot 2024-01-24 at 4 39 06 PM](https://github.com/localcontexts/localcontextshub/assets/41635757/0672266b-0ff0-45d2-874d-16f083eb667e)
