### PR TITLE
8686zykfm disable sandbox emails and 86874v5y5 disable Contact Us on public account pages

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -493,7 +493,7 @@ def newsletter_subscription(request):
                     email = request.POST['email']
                     emailb64 = urlsafe_base64_encode(force_bytes(email))
                     variables = manage_mailing_list(request, first_name, emailb64)
-                    add_to_mailing_list(str(email), str(name), str(variables))
+                    add_to_newsletter_mailing_list(str(email), str(name), str(variables))
                     message_text = mark_safe('Thank&nbsp;you&nbsp;an&nbsp;email&nbsp;has&nbsp;been&nbsp;sent')
                     messages.add_message(request, messages.SUCCESS, message_text)
                     return render(request, 'accounts/newsletter-subscription.html', {'emailb64': emailb64})
@@ -551,7 +551,7 @@ def newsletter_unsubscription(request, emailb64):
                         return redirect('newsletter-unsubscription', emailb64=emailb64)
                     elif 'topic' in request.POST:
                         variables = manage_mailing_list(request, first_name, email)
-                        add_to_mailing_list(str(email), str(name), str(variables))
+                        add_to_newsletter_mailing_list(str(email), str(name), str(variables))
                         messages.add_message(request, messages.SUCCESS, 'Your preferences have been updated.')
                         return redirect('newsletter-unsubscription', emailb64=emailb64)
                     else:

--- a/communities/views.py
+++ b/communities/views.py
@@ -181,6 +181,7 @@ def confirm_community(request):
 
 def public_community_view(request, pk):
     try: 
+        environment = dev_prod_or_local(request.get_host())
         community = Community.objects.get(id=pk)
         bclabels = BCLabel.objects.filter(community=community, is_approved=True)
         tklabels = TKLabel.objects.filter(community=community, is_approved=True)
@@ -209,7 +210,7 @@ def public_community_view(request, pk):
                         message = form.cleaned_data['message']
                         to_email = community.community_creator.email
 
-                        send_contact_email(to_email, from_name, from_email, message, community)
+                        send_contact_email(request, to_email, from_name, from_email, message, community)
                         messages.add_message(request, messages.SUCCESS, 'Message sent!')
                         return redirect('public-community', community.id)
                     else:
@@ -243,6 +244,7 @@ def public_community_view(request, pk):
                 'bclabels' : bclabels,
                 'tklabels' : tklabels,
                 'projects' : projects,
+                'env': environment,
             }
             return render(request, 'public.html', context)
 
@@ -254,6 +256,7 @@ def public_community_view(request, pk):
             'form': form, 
             'join_form': join_form,
             'user_communities': user_communities,
+            'env': environment,
         }
         return render(request, 'public.html', context)
     except:
@@ -364,7 +367,8 @@ def community_members(request, pk):
         'form': form,
         'join_requests_count': join_requests_count,
         'users': users,
-        'invite_form': SignUpInvitationForm()
+        'invite_form': SignUpInvitationForm(),
+        'env': dev_prod_or_local(request.get_host()),
     }
     return render(request, 'communities/members.html', context)
 

--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -89,7 +89,7 @@ def send_mailing_list_email(mailing_list, subject, template, tag=None):
         send_tagged_mailgun_template_email(email, subject, template, data, tag)
 
 # Add members to newsletter mailing list (updates users already on the mailing list)
-def add_to_mailing_list(email, name, variables):
+def add_to_newsletter_mailing_list(email, name, variables):
     # Example: send_simple_email('someone@domain.com', 'Hello', 'This is a test email')
     return requests.post(
 		"https://api.mailgun.net/v3/lists/newsletter@localcontextshub.org/members",
@@ -125,7 +125,7 @@ def unsubscribe_from_mailing_list(email, name):
 '''
 
 def manage_researcher_mailing_list(email, subscribed):
-    # subscribed will be a boolean
+    # subscribed: boolean
     return requests.post(
 		"https://api.mailgun.net/v3/lists/researchers@localcontextshub.org/members",
 		auth = ("api", settings.MAILGUN_API_KEY),
@@ -148,7 +148,7 @@ def send_hub_admins_application_email(request, organization, data):
 
         template = render_to_string('snippets/emails/internal/institution-application.html', { 'data' : data })
 
-    # if admin group exists:
+    # Send to support if in production
     if dev_prod_or_local(request.get_host()) == 'PROD':
         email = 'support@localcontexts.org'
         
@@ -214,96 +214,107 @@ def send_welcome_email(request, user):
     url = get_site_url(request, 'login')
     send_mailgun_template_email(user.email, subject, 'welcome', {"login_url": url})
 
-# TEST THIS
 # Email to invite user to join the hub
 def send_invite_user_email(request, data):
-    subject = 'You have been invited to join the Local Contexts Hub'
-    name = get_users_name(data.sender)
-    url = get_site_url(request, 'register')
-    variables = {"register_url": url, "name": name, "message": data.message}
-    send_mailgun_template_email(data.email, subject, 'invite_new_user', variables)
+    environment = dev_prod_or_local(request.get_host())
+
+    if not environment == "SANDBOX":
+        subject = 'You have been invited to join the Local Contexts Hub'
+        name = get_users_name(data.sender)
+        url = get_site_url(request, 'register')
+        variables = {"register_url": url, "name": name, "message": data.message}
+        send_mailgun_template_email(data.email, subject, 'invite_new_user', variables)
 
 # Anywhere JoinRequest instance is created, 
 # will email community or institution creator that someone wants to join the organization
 def send_join_request_email_admin(request, join_request, organization):
-    name = get_users_name(request.user)
-    login_url = get_site_url(request, 'login')
+    environment = dev_prod_or_local(request.get_host())
 
-    # Check if organization instance is community model
-    if isinstance(organization, Community):
-        subject = f'{name} has requested to join {organization.community_name}'
-        send_to_email = organization.community_creator.email
-        org_name = organization.community_name
-    if isinstance(organization, Institution):
-        subject = f'{name} has requested to join {organization.institution_name}'
-        send_to_email = organization.institution_creator.email
-        org_name = organization.institution_name
+    if not environment == "SANDBOX":
+        name = get_users_name(request.user)
+        login_url = get_site_url(request, 'login')
 
-    data = { 
-            'user': name, 
-            'org_name': org_name,
-            'message': join_request.message,
-            'role': join_request.role,
-            'requester_email': request.user.email,
-            'login_url': login_url
-        }
-    send_mailgun_template_email(send_to_email, subject, 'join_request', data)
+        # Check if organization instance is community model
+        if isinstance(organization, Community):
+            subject = f'{name} has requested to join {organization.community_name}'
+            send_to_email = organization.community_creator.email
+            org_name = organization.community_name
+        if isinstance(organization, Institution):
+            subject = f'{name} has requested to join {organization.institution_name}'
+            send_to_email = organization.institution_creator.email
+            org_name = organization.institution_name
+
+        data = { 
+                'user': name, 
+                'org_name': org_name,
+                'message': join_request.message,
+                'role': join_request.role,
+                'requester_email': request.user.email,
+                'login_url': login_url
+            }
+        send_mailgun_template_email(send_to_email, subject, 'join_request', data)
 
 # REGISTRY Contact organization email
-def send_contact_email(to_email, from_name, from_email, message, account):
-    subject = f"{from_name} has sent you a message via Local Contexts Hub"
-    from_string = f"{from_name} <{from_email}>"
+def send_contact_email(request, to_email, from_name, from_email, message, account):
+    environment = dev_prod_or_local(request.get_host())
 
-    if isinstance(account, Institution):
-        account_name = account.institution_name
-    if isinstance(account, Community):
-        account_name = account.community_name
-    if isinstance(account, Researcher):
-        account_name = 'your researcher account'
+    if not environment == "SANDBOX":
+        subject = f"{from_name} has sent you a message via Local Contexts Hub"
+        from_string = f"{from_name} <{from_email}>"
 
-    data = { "from_name": from_name, "message": message, "account_name": account_name }
+        if isinstance(account, Institution):
+            account_name = account.institution_name
+        if isinstance(account, Community):
+            account_name = account.community_name
+        if isinstance(account, Researcher):
+            account_name = 'your researcher account'
 
-    return requests.post(
-        settings.MAILGUN_BASE_URL,
-        auth=("api", settings.MAILGUN_API_KEY),
-        data={
-            "from": from_string,
-            "to": to_email,
-            "subject": subject,
-            "template": "registry_contact",
-            "t:variables": json.dumps(data)
-            })
+        data = { "from_name": from_name, "message": message, "account_name": account_name }
+
+        return requests.post(
+            settings.MAILGUN_BASE_URL,
+            auth=("api", settings.MAILGUN_API_KEY),
+            data={
+                "from": from_string,
+                "to": to_email,
+                "subject": subject,
+                "template": "registry_contact",
+                "t:variables": json.dumps(data)
+                })
 
 """
     MEMBER INVITE EMAILS
 """
 
 def send_member_invite_email(request, data, account):
-    name = get_users_name(data.sender)
-    login_url = get_site_url(request, 'login')
+    environment = dev_prod_or_local(request.get_host())
 
-    if isinstance(account, Institution):
-        org_name = account.institution_name
-    if isinstance(account, Community):
-        org_name = account.community_name
-    
-    if data.role == 'admin':
-        role = 'Administrator'
-    elif data.role == 'editor':
-        role = 'Editor'
-    elif data.role == 'viewer':
-        role = 'Viewer'
+    if not environment == "SANDBOX":
+        name = get_users_name(data.sender)
+        login_url = get_site_url(request, 'login')
 
-    variables = {
-        'name': name,
-        'username': data.sender.username,
-        'role': role,
-        'message': data.message,
-        'org_name': org_name,
-        'login_url':login_url
-    }
-    subject = f'You have been invited to join {org_name}'
-    send_mailgun_template_email(data.receiver.email, subject, 'member_invite', variables)
+        if isinstance(account, Institution):
+            org_name = account.institution_name
+        if isinstance(account, Community):
+            org_name = account.community_name
+        
+        if data.role == 'admin':
+            role = 'Administrator'
+        elif data.role == 'editor':
+            role = 'Editor'
+        elif data.role == 'viewer':
+            role = 'Viewer'
+
+        variables = {
+            'name': name,
+            'username': data.sender.username,
+            'role': role,
+            'message': data.message,
+            'org_name': org_name,
+            'login_url':login_url
+        }
+        subject = f'You have been invited to join {org_name}'
+        send_mailgun_template_email(data.receiver.email, subject, 'member_invite', variables)
 
 
 """
@@ -312,24 +323,27 @@ def send_member_invite_email(request, data, account):
 
 # A notice has been applied by researcher or institution
 def send_email_notice_placed(request, project, community, account):
-    # Can pass instance of institution or researcher as account
-    login_url = get_site_url(request, 'login')
+    environment = dev_prod_or_local(request.get_host())
 
-    if isinstance(account, Institution):
-        subject = f'{account.institution_name} has notified you about a Project'
-        placed_by = account.institution_name
-    if isinstance(account, Researcher):
-        placed_by = get_users_name(account.user) + '(Researcher)'
-        subject = f'{placed_by} has notified you about a Project'
+    if not environment == "SANDBOX":
+        # Can pass instance of institution or researcher as account
+        login_url = get_site_url(request, 'login')
 
-    data = {
-        'project_title': project.title, 
-        'project_description': project.description, 
-        'placed_by': placed_by,
-        'community_name': community.community_name,
-        'login_url': login_url
-    }
-    send_mailgun_template_email(community.community_creator.email, subject, 'notice_placed', data)
+        if isinstance(account, Institution):
+            subject = f'{account.institution_name} has notified you about a Project'
+            placed_by = account.institution_name
+        if isinstance(account, Researcher):
+            placed_by = get_users_name(account.user) + '(Researcher)'
+            subject = f'{placed_by} has notified you about a Project'
+
+        data = {
+            'project_title': project.title, 
+            'project_description': project.description, 
+            'placed_by': placed_by,
+            'community_name': community.community_name,
+            'login_url': login_url
+        }
+        send_mailgun_template_email(community.community_creator.email, subject, 'notice_placed', data)
 
 
 """
@@ -338,160 +352,175 @@ def send_email_notice_placed(request, project, community, account):
 
 # When Labels have been applied to a Project
 def send_email_labels_applied(request, project, community):
-    login_url = get_site_url(request, 'login')
-    subject = 'A community has applied Labels to your Project'
-    data = {
-        'community_name': community.community_name,
-        'project_title': project.title,
-        'login_url': login_url
-    }
-    send_mailgun_template_email(project.project_creator.email, subject, 'labels_applied', data)
+    environment = dev_prod_or_local(request.get_host())
+
+    if not environment == "SANDBOX":
+        login_url = get_site_url(request, 'login')
+        subject = 'A community has applied Labels to your Project'
+        data = {
+            'community_name': community.community_name,
+            'project_title': project.title,
+            'login_url': login_url
+        }
+        send_mailgun_template_email(project.project_creator.email, subject, 'labels_applied', data)
 
 
 # Label has been approved or not
 def send_email_label_approved(request, label, note_id):
-    approver_name = get_users_name(label.approved_by)
-    login_url = get_site_url(request, 'login')
+    environment = dev_prod_or_local(request.get_host())
 
-    if label.is_approved:
-        subject = 'Your Label has been approved'
-        approved = True
-        note = False
-        label_note = False
-    else:
-        subject = 'Your Label has suggested edits'
-        approved = False
-        note = True
-        label_note = LabelNote.objects.get(id=note_id).note
+    if not environment == "SANDBOX":
+        approver_name = get_users_name(label.approved_by)
+        login_url = get_site_url(request, 'login')
 
-    data = {
-        'approver_name': approver_name,
-        'label_name': label.name,
-        'approved': approved,
-        'community_name': label.community.community_name,
-        'note': note,
-        'label_note': label_note,
-        'login_url': login_url
-    }
-    send_mailgun_template_email(label.created_by.email, subject, 'label_approved', data)
+        if label.is_approved:
+            subject = 'Your Label has been approved'
+            approved = True
+            note = False
+            label_note = False
+        else:
+            subject = 'Your Label has suggested edits'
+            approved = False
+            note = True
+            label_note = LabelNote.objects.get(id=note_id).note
+
+        data = {
+            'approver_name': approver_name,
+            'label_name': label.name,
+            'approved': approved,
+            'community_name': label.community.community_name,
+            'note': note,
+            'label_note': label_note,
+            'login_url': login_url
+        }
+        send_mailgun_template_email(label.created_by.email, subject, 'label_approved', data)
 
 # You are now a member of institution/community email
 def send_membership_email(request, account, receiver, role):
-    login_url = get_site_url(request, 'login')
-    
-    if role == 'admin' or role == 'Admin':
-        role_str = 'Administrator'
-    elif role == 'editor':
-        role_str = 'Editor'
-    elif role == 'viewer':
-        role_str = 'Viewer'
-    else:
-        role_str = role
+    environment = dev_prod_or_local(request.get_host())
 
-    community = False
-    institution = False
+    if not environment == "SANDBOX":
+        login_url = get_site_url(request, 'login')
+        
+        if role == 'admin' or role == 'Admin':
+            role_str = 'Administrator'
+        elif role == 'editor':
+            role_str = 'Editor'
+        elif role == 'viewer':
+            role_str = 'Viewer'
+        else:
+            role_str = role
 
-    if isinstance(account, Community):
-        subject = f'You are now a member of {account.community_name}'
-        account_name = account.community_name
-        community = True
-    if isinstance(account, Institution):
-        subject = f'You are now a member of {account.institution_name}'
-        account_name = account.institution_name
-        institution = True
+        community = False
+        institution = False
 
-    data = {
-        'role_str': role_str,
-        'account_name': account_name,
-        'login_url': login_url,
-        'community': community,
-        'institution': institution
-    }
-    send_mailgun_template_email(receiver.email, subject, 'member_info', data)
+        if isinstance(account, Community):
+            subject = f'You are now a member of {account.community_name}'
+            account_name = account.community_name
+            community = True
+        if isinstance(account, Institution):
+            subject = f'You are now a member of {account.institution_name}'
+            account_name = account.institution_name
+            institution = True
+
+        data = {
+            'role_str': role_str,
+            'account_name': account_name,
+            'login_url': login_url,
+            'community': community,
+            'institution': institution
+        }
+        send_mailgun_template_email(receiver.email, subject, 'member_info', data)
 
 def send_contributor_email(request, account, proj_id, is_adding):
-    from projects.models import Project
-    project = Project.objects.select_related('project_creator').get(unique_id=proj_id)
-    creator_account = ''
-    account_name = ''
+    environment = dev_prod_or_local(request.get_host())
 
-    created_by = project.project_creator_project.all()[0]
-    if created_by.institution:
-        creator_account = created_by.institution.institution_name
-    elif created_by.community:
-        creator_account = created_by.community.community_name
-    elif created_by.researcher:
-        creator_account = 'Researcher'
+    if not environment == "SANDBOX":
+        from projects.models import Project
+        project = Project.objects.select_related('project_creator').get(unique_id=proj_id)
+        creator_account = ''
+        account_name = ''
 
-    register_url = get_site_url(request, 'register')
-    project_creator = get_users_name(project.project_creator)
-    login_url = get_site_url(request, 'login')
+        created_by = project.project_creator_project.all()[0]
+        if created_by.institution:
+            creator_account = created_by.institution.institution_name
+        elif created_by.community:
+            creator_account = created_by.community.community_name
+        elif created_by.researcher:
+            creator_account = 'Researcher'
 
-    if is_adding:        
-        if isinstance(account, Community):
-            to_email = account.community_creator.email
-            subject = "Your community has been added as a contributor on a Project"
-            account_name = account.community_name
-        if isinstance(account, Institution):
-            to_email = account.institution_creator.email
-            subject = "Your institution has been added as a contributor on a Project"
-            account_name = account.institution_name
-        if isinstance(account, Researcher):
-            to_email = account.user.email
-            subject = "Your researcher account has been added as a contributor on a Project"
-            account_name = get_users_name(account.user)
+        register_url = get_site_url(request, 'register')
+        project_creator = get_users_name(project.project_creator)
+        login_url = get_site_url(request, 'login')
 
-    else:
-        subject = "Changes have been made to a Project you're contributing to"
-        
-        if isinstance(account, Community):
-            to_email = account.community_creator.email
-        if isinstance(account, Institution):
-            to_email = account.institution_creator.email
-        if isinstance(account, Researcher):
-            to_email = account.user.email
+        if is_adding:        
+            if isinstance(account, Community):
+                to_email = account.community_creator.email
+                subject = "Your community has been added as a contributor on a Project"
+                account_name = account.community_name
+            if isinstance(account, Institution):
+                to_email = account.institution_creator.email
+                subject = "Your institution has been added as a contributor on a Project"
+                account_name = account.institution_name
+            if isinstance(account, Researcher):
+                to_email = account.user.email
+                subject = "Your researcher account has been added as a contributor on a Project"
+                account_name = get_users_name(account.user)
 
-    data = {
-        'is_adding': is_adding,
-        'project_url': project.project_page,
-        'register_url': register_url,
-        'login_url': login_url,
-        'project_creator': project_creator, 
-        'project_title': project.title,
-        'account_name': account_name,
-        'creator_account': creator_account
-    }
-    send_mailgun_template_email(to_email, subject, 'contributor', data)
+        else:
+            subject = "Changes have been made to a Project you're contributing to"
+            
+            if isinstance(account, Community):
+                to_email = account.community_creator.email
+            if isinstance(account, Institution):
+                to_email = account.institution_creator.email
+            if isinstance(account, Researcher):
+                to_email = account.user.email
+
+        data = {
+            'is_adding': is_adding,
+            'project_url': project.project_page,
+            'register_url': register_url,
+            'login_url': login_url,
+            'project_creator': project_creator, 
+            'project_title': project.title,
+            'account_name': account_name,
+            'creator_account': creator_account
+        }
+        send_mailgun_template_email(to_email, subject, 'contributor', data)
     
 
 def send_project_person_email(request, to_email, proj_id, account):
-    from projects.models import Project
-    registered = User.objects.filter(email=to_email).exists()
-    project = Project.objects.select_related('project_creator').get(unique_id=proj_id)
+    environment = dev_prod_or_local(request.get_host())
 
-    project_creator = get_users_name(project.project_creator)
-    register_url = get_site_url(request, 'register')
-    subject = 'You have been added as a contributor on a Local Contexts Hub Project'
+    if not environment == "SANDBOX":
+        from projects.models import Project
+        registered = User.objects.filter(email=to_email).exists()
+        project = Project.objects.select_related('project_creator').get(unique_id=proj_id)
 
-    if isinstance(account, Community):
-        account_name = account.community_name
-    if isinstance(account, Institution):
-        account_name = account.institution_name
-    if isinstance(account, Researcher):
-        account_name = 'Researcher'
+        project_creator = get_users_name(project.project_creator)
+        register_url = get_site_url(request, 'register')
+        subject = 'You have been added as a contributor on a Local Contexts Hub Project'
 
-    if '/create-project/' in request.path:
+        if isinstance(account, Community):
+            account_name = account.community_name
+        if isinstance(account, Institution):
+            account_name = account.institution_name
+        if isinstance(account, Researcher):
+            account_name = 'Researcher'
 
-        data = {
-            'project_person': True,
-            'registered': registered,
-            'project_url': project.project_page,
-            'register_url': register_url,
-            'project_creator': project_creator, 
-            'project_title': project.title,
-            'account_name': account_name
-        }
-        send_mailgun_template_email(to_email, subject, 'contributor_project_person', data)
+        if '/create-project/' in request.path:
+
+            data = {
+                'project_person': True,
+                'registered': registered,
+                'project_url': project.project_page,
+                'register_url': register_url,
+                'project_creator': project_creator, 
+                'project_title': project.title,
+                'account_name': account_name
+            }
+            send_mailgun_template_email(to_email, subject, 'contributor_project_person', data)
 
 """
     ADD MAILGUN TEMPLATE AND MAJOR UPDATES

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -160,6 +160,7 @@ def confirm_institution(request, institution_id):
 
 def public_institution_view(request, pk):
     try:
+        environment = dev_prod_or_local(request.get_host())
         institution = Institution.objects.get(id=pk)
 
         # Do notices exist
@@ -190,7 +191,7 @@ def public_institution_view(request, pk):
                         message = form.cleaned_data['message']
                         to_email = institution.institution_creator.email
                         
-                        send_contact_email(to_email, from_name, from_email, message, institution)
+                        send_contact_email(request, to_email, from_name, from_email, message, institution)
                         messages.add_message(request, messages.SUCCESS, 'Message sent!')
                         return redirect('public-institution', institution.id)
                     else:
@@ -225,6 +226,7 @@ def public_institution_view(request, pk):
                 'tknotice': tknotice,
                 'attrnotice': attrnotice,
                 'otc_notices': otc_notices,
+                'env': environment,
             }
             return render(request, 'public.html', context)
 
@@ -238,6 +240,7 @@ def public_institution_view(request, pk):
             'tknotice': tknotice,
             'attrnotice': attrnotice,
             'otc_notices': otc_notices,
+            'env': environment,
         }
         return render(request, 'public.html', context)
     except:
@@ -408,6 +411,7 @@ def institution_members(request, pk):
         'join_requests_count': join_requests_count,
         'users': users,
         'invite_form': SignUpInvitationForm(),
+        'env': dev_prod_or_local(request.get_host()),
     }    
     return render(request, 'institutions/members.html', context)
 

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -96,7 +96,7 @@ def public_researcher_view(request, pk):
                         message = form.cleaned_data['message']
                         to_email = researcher.contact_email
 
-                        send_contact_email(to_email, from_name, from_email, message, researcher)
+                        send_contact_email(request, to_email, from_name, from_email, message, researcher)
                         messages.add_message(request, messages.SUCCESS, 'Message sent!')
                         return redirect('public-researcher', researcher.id)
                     else:
@@ -114,6 +114,7 @@ def public_researcher_view(request, pk):
                 'tknotice': tknotice,
                 'attrnotice': attrnotice,
                 'otc_notices': otc_notices,
+                'env': dev_prod_or_local(request.get_host()),
             }
             return render(request, 'public.html', context)
 
@@ -125,6 +126,7 @@ def public_researcher_view(request, pk):
             'attrnotice': attrnotice,
             'otc_notices': otc_notices,
             'form': form, 
+            'env': dev_prod_or_local(request.get_host()),
         }
         return render(request, 'public.html', context)
     except:

--- a/templates/partials/_members.html
+++ b/templates/partials/_members.html
@@ -681,11 +681,13 @@
                             </div>
 
                             <div class="w-50 margin-top-2 right-text">
-                                <small>Looking for someone who isn't on this list? <br>
-                                    <a onclick="openInviteUserModalView()" class="darkteal-text pointer">
-                                        Invite them to Local Contexts Hub
-                                    </a>
-                                </small>
+                                {% if not env == "SANDBOX" %}
+                                    <small>Looking for someone who isn't on this list? <br>
+                                        <a onclick="openInviteUserModalView()" class="darkteal-text pointer">
+                                            Invite them to Local Contexts Hub
+                                        </a>
+                                    </small>
+                                {% endif %}
                             </div>
                         </div>
 
@@ -695,29 +697,31 @@
         </div>
 
         <!-- INVITE NEW USER MODAL VIEW -->
-        <div id="inviteUserModalView" class="modal-defaults add-member-modal flex-this column w-100 hide">
+        {% if not env == "SANDBOX" %}
+            <div id="inviteUserModalView" class="modal-defaults add-member-modal flex-this column w-100 hide">
 
-            <h3>Invite New User</h3>
-            <form method="POST" action="{% url 'invite' %}">
-                {% csrf_token %}
+                <h3>Invite New User</h3>
+                <form method="POST" action="{% url 'invite' %}">
+                    {% csrf_token %}
 
-                <label for="email"> Email Address </label><br>
-                {{ invite_form.email }}<br>
+                    <label for="email"> Email Address </label><br>
+                    {{ invite_form.email }}<br>
 
-                <label for="message"> Output Message (Optional) </label><br>
-                {{ invite_form.message }}<br>
+                    <label for="message"> Output Message (Optional) </label><br>
+                    {{ invite_form.message }}<br>
 
-                <div class="flex-this row">
-                    <div class="flex-this row w-50 flex-start">
-                        <button onclick="openAddModalView()" type="button" class="primary-btn white-btn margin-top-2">Back</button>
+                    <div class="flex-this row">
+                        <div class="flex-this row w-50 flex-start">
+                            <button onclick="openAddModalView()" type="button" class="primary-btn white-btn margin-top-2">Back</button>
+                        </div>
+                        <div class="flex-this row w-50 flex-end">
+                            <button type="submit" class="primary-btn action-btn margin-top-2">Send Invitation</button>
+                        </div>
                     </div>
-                    <div class="flex-this row w-50 flex-end">
-                        <button type="submit" class="primary-btn action-btn margin-top-2">Send Invitation</button>
-                    </div>
-                </div>
-            </form>
+                </form>
 
-        </div>
+            </div>
+        {% endif %}
     </span>
 </div>
 

--- a/templates/partials/_update-account.html
+++ b/templates/partials/_update-account.html
@@ -167,104 +167,103 @@
                         </div>
                     {% endif %}
 
-                    <!-- Researcher account contact -->
                     {% if researcher %}
-                        <div><h3>Account Contact</h3></div>
-                        <div class="w-100 margin-bottom-16">
-                            <div>
-                                <label for="contact_email"> Contact Email </label><br> 
-                                {{ update_form.contact_email }}
-                            </div>                                   
+                        <!-- Researcher account contact, disabled in sandbox -->
+                        {% if not env == "SANDBOX" %}
+                            <div><h3>Account Contact</h3></div>
+                            <div class="w-100 margin-bottom-16">
+                                <div>
+                                    <label for="contact_email"> Contact Email </label><br> 
+                                    {{ update_form.contact_email }}
+                                </div>                                   
 
-                            {% if update_form.contact_email.errors %}
-                                <div class="msg-red w-50"><small>{{ update_form.contact_email.errors.as_text }}</small></div> 
-                            {% endif %}
-
-                            <div class="margin-top-16">
-                                {{ update_form.contact_email_public.label }}
-                                {{ update_form.contact_email_public }}
-
-                                {% if update_form.contact_email_public.errors %}
-                                    <div class="msg-red w-50"><small>{{ update_form.contact_email_public.errors.as_text }}</small></div> 
+                                {% if update_form.contact_email.errors %}
+                                    <div class="msg-red w-50"><small>{{ update_form.contact_email.errors.as_text }}</small></div> 
                                 {% endif %}
-                            </div>  
-                        </div>
-                    {% endif %}
 
-                    <!-- Researcher: ORCiD -->
-                    {% if researcher %}
-                    <div>
-                        <div><h3>ORCiD</h3></div>
-                        <div class="w-100 margin-bottom-16">
-                            {% if researcher.orcid %}
-                            <div class="flex-this space-between">
-                                <div>
-                                    <div itemscope itemtype="https://schema.org/Person">
-                                        <a 
-                                            class="darkteal-text underline-hover" 
-                                            itemprop="sameAs" 
-                                            target="orcid.widget" 
-                                            rel="me noopener noreferrer" 
-                                            style="vertical-align:top;"
-                                            {% if 'https://sandbox.orcid.org/' in researcher.orcid or 'https://orcid.org/' in researcher.orcid %}
-                                                content="{{ researcher.orcid }}" 
-                                                href="{{ researcher.orcid }}" 
-                                            {% elif 'X' in researcher.orcid %}
-                                                content="https://sandbox.orcid.org/{{ researcher.orcid }}" 
-                                                href="https://sandbox.orcid.org/{{ researcher.orcid }}"
-                                            {% else %}
-                                                content="https://orcid.org/{{ researcher.orcid }}" 
-                                                href="https://orcid.org/{{ researcher.orcid }}" 
-                                            {% endif %}
-                                        >
-                                            <img loading="lazy" src="https://orcid.org/sites/default/files/images/orcid_16x16.png" style="width:1em;margin-right:.5em;" alt="ORCID iD icon">
-                                            {% if 'https://sandbox.orcid.org/' in researcher.orcid or 'https://orcid.org/' in researcher.orcid %}
-                                                {{ researcher.orcid }}
-                                            {% elif 'X' in researcher.orcid %}
-                                                https://sandbox.orcid.org/{{ researcher.orcid }} 
-                                            {% else %}
-                                                https://orcid.org/{{ researcher.orcid }}
-                                            {% endif %}
-                                        </a>
-                                    </div>                                
-                                </div>
+                                <div class="margin-top-16">
+                                    {{ update_form.contact_email_public.label }}
+                                    {{ update_form.contact_email_public }}
 
-                                <div>
-                                    <a class="primary-btn white-btn" href="{% url 'disconnect-orcid' %}">Disconnect ORCiD</a>
-                                </div> 
-                            </div>
-
-                        {% else %}
-                            <div class="flex-this space-between">
-                                <div class="w-50"><p>We encourage you to have an ORCiD ID. <br>You can <a class="darkteal-text underline-hover" href="https://orcid.org/" target="_blank" rel="noopener">read more about ORCiD here</a>.</p></div>
-                                <!-- Show ORCiD widget based on hostname -->
-                                <div 
-                                    id="orcidWidget" 
-                                    {% if env == "PROD" %}
-                                        data-clientid='APP-3AGU5OQX7M7UKIMD' 
-                                        data-env="production" 
-                                        data-redirecturi="https://localcontextshub.org/researchers/connect-orcid/"
-                                    {% elif env == "SANDBOX" %}
-                                        data-clientid='APP-M1RE2U9DY1B6MNYD' 
-                                        data-env="sandbox" 
-                                        data-redirecturi="https://sandbox.localcontextshub.org/researchers/connect-orcid/"
-                                    {% elif env == "DEV" %}
-                                        data-clientid='APP-M1RE2U9DY1B6MNYD' 
-                                        data-env="develop" 
-                                        data-redirecturi="https://local-contexts-hub-develop.uc.r.appspot.com/researchers/connect-orcid/"
+                                    {% if update_form.contact_email_public.errors %}
+                                        <div class="msg-red w-50"><small>{{ update_form.contact_email_public.errors.as_text }}</small></div> 
                                     {% endif %}
-                                >
-                                </div>
+                                </div>  
                             </div>
-                    
-                            {% if env == "DEV" or env == "SANDBOX" %}
-                                <small class="bold">Please note that since this is a test site, the ORCiD used will be the <a class="darkteal-text underline-hover" href="https://sandbox.orcid.org/">sandbox version</a>.</small><br>
-                            {% endif %}  
                         {% endif %}
-                            
-                        </div>                            
-                    </div>
 
+                        <!-- Researcher: ORCiD -->
+                        <div>
+                            <div><h3>ORCiD</h3></div>
+                            <div class="w-100 margin-bottom-16">
+                                {% if researcher.orcid %}
+                                <div class="flex-this space-between">
+                                    <div>
+                                        <div itemscope itemtype="https://schema.org/Person">
+                                            <a 
+                                                class="darkteal-text underline-hover" 
+                                                itemprop="sameAs" 
+                                                target="orcid.widget" 
+                                                rel="me noopener noreferrer" 
+                                                style="vertical-align:top;"
+                                                {% if 'https://sandbox.orcid.org/' in researcher.orcid or 'https://orcid.org/' in researcher.orcid %}
+                                                    content="{{ researcher.orcid }}" 
+                                                    href="{{ researcher.orcid }}" 
+                                                {% elif 'X' in researcher.orcid %}
+                                                    content="https://sandbox.orcid.org/{{ researcher.orcid }}" 
+                                                    href="https://sandbox.orcid.org/{{ researcher.orcid }}"
+                                                {% else %}
+                                                    content="https://orcid.org/{{ researcher.orcid }}" 
+                                                    href="https://orcid.org/{{ researcher.orcid }}" 
+                                                {% endif %}
+                                            >
+                                                <img loading="lazy" src="https://orcid.org/sites/default/files/images/orcid_16x16.png" style="width:1em;margin-right:.5em;" alt="ORCID iD icon">
+                                                {% if 'https://sandbox.orcid.org/' in researcher.orcid or 'https://orcid.org/' in researcher.orcid %}
+                                                    {{ researcher.orcid }}
+                                                {% elif 'X' in researcher.orcid %}
+                                                    https://sandbox.orcid.org/{{ researcher.orcid }} 
+                                                {% else %}
+                                                    https://orcid.org/{{ researcher.orcid }}
+                                                {% endif %}
+                                            </a>
+                                        </div>                                
+                                    </div>
+
+                                    <div>
+                                        <a class="primary-btn white-btn" href="{% url 'disconnect-orcid' %}">Disconnect ORCiD</a>
+                                    </div> 
+                                </div>
+
+                            {% else %}
+                                <div class="flex-this space-between">
+                                    <div class="w-50"><p>We encourage you to have an ORCiD ID. <br>You can <a class="darkteal-text underline-hover" href="https://orcid.org/" target="_blank" rel="noopener">read more about ORCiD here</a>.</p></div>
+                                    <!-- Show ORCiD widget based on hostname -->
+                                    <div 
+                                        id="orcidWidget" 
+                                        {% if env == "PROD" %}
+                                            data-clientid='APP-3AGU5OQX7M7UKIMD' 
+                                            data-env="production" 
+                                            data-redirecturi="https://localcontextshub.org/researchers/connect-orcid/"
+                                        {% elif env == "SANDBOX" %}
+                                            data-clientid='APP-M1RE2U9DY1B6MNYD' 
+                                            data-env="sandbox" 
+                                            data-redirecturi="https://sandbox.localcontextshub.org/researchers/connect-orcid/"
+                                        {% elif env == "DEV" %}
+                                            data-clientid='APP-M1RE2U9DY1B6MNYD' 
+                                            data-env="develop" 
+                                            data-redirecturi="https://local-contexts-hub-develop.uc.r.appspot.com/researchers/connect-orcid/"
+                                        {% endif %}
+                                    >
+                                    </div>
+                                </div>
+                        
+                                {% if env == "DEV" or env == "SANDBOX" %}
+                                    <small class="bold">Please note that since this is a test site, the ORCiD used will be the <a class="darkteal-text underline-hover" href="https://sandbox.orcid.org/">sandbox version</a>.</small><br>
+                                {% endif %}  
+                            {% endif %}
+                                
+                            </div>                            
+                        </div>
                     {% endif %}                        
 
                     {% include 'partials/_alerts.html' %}

--- a/templates/public.html
+++ b/templates/public.html
@@ -28,32 +28,44 @@
                             {% endif %}                            
                         </div>
                         <div class="margin-left-16">
-                            <a id="openContactModalBtn" class="primary-btn action-btn">Contact Us</a>
+                            {% if env == "SANDBOX" %}
+                                <div class="btn-with-helptext">
+                                    <a class="primary-btn disabled-btn">Contact Us</a>
+                                    <span class="btn-help-text">
+                                        Contacting other accounts is not available in the Sandbox.
+                                    </span>
+                                </div>
+                            {% else %}
+                                <a id="openContactModalBtn" class="primary-btn action-btn">Contact Us</a>
+                            {% endif %}
                         </div>
                     </div>
 
-                    <div id="contactModal" class="modal hide">
-                        <div class="modal-defaults contact-modal flex-this column w-100">
-                            <div class="w-100">
-                                <div class="flex-this space-between">
-                                    <div class="w-80">
-                                        <h2 class="primary-black-text no-top-margin">Contact form</h2>  
-                                        <p>This message will be sent to the administrator of {{ community.community_name }}.</p>  
+                    {% if not env == "SANDBOX" %}
+                        <div id="contactModal" class="modal hide">
+                            <div class="modal-defaults contact-modal flex-this column w-100">
+                                <div class="w-100">
+                                    <div class="flex-this space-between">
+                                        <div class="w-80">
+                                            <h2 class="primary-black-text no-top-margin">Contact form</h2>  
+                                            <p>This message will be sent to the administrator of {{ community.community_name }}.</p>  
+                                        </div>
+                                        <div>
+                                            <div class="close-modal-btn"><i class="fa-regular fa-xmark fa-xl"></i></div>
+                                        </div>
                                     </div>
-                                    <div>
-                                        <div class="close-modal-btn"><i class="fa-regular fa-xmark fa-xl"></i></div>
-                                    </div>
-                                </div>
 
-                                <form id="sendMsgForm" method="POST" action="">
-                                    {% csrf_token %}
-                                    {{ form.as_p }}
-                                    <input type="hidden" name="contact_btn">
-                                    <button class="primary-btn action-btn" id="sendMsgBtn">Send message <i class="fa fa-envelope" aria-hidden="true"></i></button>
-                                </form>    
+                                    <form id="sendMsgForm" method="POST" action="">
+                                        {% csrf_token %}
+                                        {{ form.as_p }}
+                                        <input type="hidden" name="contact_btn">
+                                        <button class="primary-btn action-btn" id="sendMsgBtn">Send message <i class="fa fa-envelope" aria-hidden="true"></i></button>
+                                    </form>    
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    {% endif %}
+
                 {% else %}
                     <div class="loc bold margin-bottom-16">
                         <small>
@@ -148,32 +160,44 @@
                         </div>
                         
                         <div class="margin-left-16">
-                            <a id="openContactModalBtn" class="primary-btn action-btn">Contact Us</a>
+                            {% if env == "SANDBOX" %}
+                                <div class="btn-with-helptext">
+                                    <a class="primary-btn disabled-btn">Contact Us</a>
+                                    <span class="btn-help-text">
+                                        Contacting other accounts is not available in the Sandbox.
+                                    </span>
+                                </div>
+                            {% else %}
+                                <a id="openContactModalBtn" class="primary-btn action-btn">Contact Us</a>
+                            {% endif %}
                         </div>
                     </div>
 
-                    <div id="contactModal" class="modal hide">
-                        <div class="modal-defaults contact-modal flex-this column w-100">
-                            <div class="w-100">
-                                <div class="flex-this space-between">
-                                    <div class="w-70">
-                                        <h2 class="primary-black-text no-top-margin">Contact form</h2>  
-                                        <p>This message will be sent to the administrator of {{ institution.institution_name }}.</p>  
+                    {% if not env == "SANDBOX" %}
+                        <div id="contactModal" class="modal hide">
+                            <div class="modal-defaults contact-modal flex-this column w-100">
+                                <div class="w-100">
+                                    <div class="flex-this space-between">
+                                        <div class="w-70">
+                                            <h2 class="primary-black-text no-top-margin">Contact form</h2>  
+                                            <p>This message will be sent to the administrator of {{ institution.institution_name }}.</p>  
+                                        </div>
+                                        <div>
+                                            <div class="close-modal-btn"><i class="fa-regular fa-xmark fa-xl"></i></div>
+                                        </div>
                                     </div>
-                                    <div>
-                                        <div class="close-modal-btn"><i class="fa-regular fa-xmark fa-xl"></i></div>
-                                    </div>
-                                </div>
 
-                                <form id="sendMsgForm" method="POST" action="">
-                                    {% csrf_token %}
-                                    {{ form.as_p }}
-                                    <input type="hidden" name="contact_btn">
-                                    <button class="primary-btn action-btn" id="sendMsgBtn">Send message <i class="fa fa-envelope" aria-hidden="true"></i></button>
-                                </form>    
+                                    <form id="sendMsgForm" method="POST" action="">
+                                        {% csrf_token %}
+                                        {{ form.as_p }}
+                                        <input type="hidden" name="contact_btn">
+                                        <button class="primary-btn action-btn" id="sendMsgBtn">Send message <i class="fa fa-envelope" aria-hidden="true"></i></button>
+                                    </form>    
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    {% endif %}
+
                 {% else %}
                     <div class="loc bold margin-bottom-16">
                         <small>
@@ -265,34 +289,49 @@
             {% if request.user.is_authenticated %}
                 {% if researcher.contact_email_public %}
                     {% if not researcher.user == request.user %}
+
                         <div class="margin-left-16">
-                            <a id="openContactModalBtn" class="primary-btn action-btn">Contact Me</a>
+                            {% if env == "SANDBOX" %}
+                                <div class="btn-with-helptext">
+                                    <a class="primary-btn disabled-btn">Contact Me</a>
+                                    <span class="btn-help-text">
+                                        Contacting other accounts is not available in the Sandbox.
+                                    </span>
+                                </div>
+
+                            {% else %}
+                                <a id="openContactModalBtn" class="primary-btn action-btn">Contact Me</a>
+                            {% endif %}
                         </div>
+                        
                     {% endif %}
                 {% endif %}
                 
-                <div id="contactModal" class="modal hide">
-                    <div class="modal-defaults contact-modal flex-this column w-100">
-                        <div class="w-100">
-                            <div class="flex-this space-between">
-                                <div>
-                                    <h2 class="primary-black-text no-top-margin">Contact form</h2>  
-                                    <p>This message will be sent to {% firstof researcher.user.get_full_name researcher.user.username %}.</p>  
+                {% if not env == "SANDBOX" %}
+                    <div id="contactModal" class="modal hide">
+                        <div class="modal-defaults contact-modal flex-this column w-100">
+                            <div class="w-100">
+                                <div class="flex-this space-between">
+                                    <div>
+                                        <h2 class="primary-black-text no-top-margin">Contact form</h2>  
+                                        <p>This message will be sent to {% firstof researcher.user.get_full_name researcher.user.username %}.</p>  
+                                    </div>
+                                    <div>
+                                        <div class="close-modal-btn"><i class="fa-regular fa-xmark fa-xl"></i></div>
+                                    </div>
                                 </div>
-                                <div>
-                                    <div class="close-modal-btn"><i class="fa-regular fa-xmark fa-xl"></i></div>
-                                </div>
-                            </div>
 
-                            <form id="sendMsgForm" method="POST" action="">
-                                {% csrf_token %}
-                                {{ form.as_p }}
-                                <input type="hidden" name="contact_btn">
-                                <button class="primary-btn action-btn" id="sendMsgBtn">Send message <i class="fa fa-envelope" aria-hidden="true"></i></button>
-                            </form>    
+                                <form id="sendMsgForm" method="POST" action="">
+                                    {% csrf_token %}
+                                    {{ form.as_p }}
+                                    <input type="hidden" name="contact_btn">
+                                    <button class="primary-btn action-btn" id="sendMsgBtn">Send message <i class="fa fa-envelope" aria-hidden="true"></i></button>
+                                </form>    
+                            </div>
                         </div>
                     </div>
-                </div>
+                {% endif %}
+
             {% endif %}
 
         </div>


### PR DESCRIPTION
Basic idea is to eventually move the sandbox into more of a demo hub and disable email sending to avoid user confusion.

**Includes:** 

- Task [8686zykfm](https://app.clickup.com/t/8686zykfm) for disabling sandbox emails. (Modified `emails.py`).

- Task [86874v5y5](https://app.clickup.com/t/86874v5y5) disabling the Contact Us functionality on public pages for the sandbox environment only.

**Before:**
![Screenshot 2024-01-26 at 3 12 04 PM](https://github.com/localcontexts/localcontextshub/assets/41635757/4a2d6c85-a940-48e2-8f7f-5b998d98475a)

**After:**
<img width="1296" alt="Screenshot 2024-01-26 at 2 31 47 PM" src="https://github.com/localcontexts/localcontextshub/assets/41635757/f52da956-60a7-4283-89bf-acf254d210c1">



- Non-hub user invitation functionality in sandbox environment only (no CU task associated with this).

**Before:**
<img width="1286" alt="Screenshot 2024-01-26 at 3 06 42 PM" src="https://github.com/localcontexts/localcontextshub/assets/41635757/dda66499-da1d-4157-8ec9-a1bfdedf2046">

**After:** 
<img width="1286" alt="Screenshot 2024-01-26 at 3 07 44 PM" src="https://github.com/localcontexts/localcontextshub/assets/41635757/cc6ea348-5824-4c2b-b971-75ed000cfcf4">

- Researcher contact info removed from settings for sandbox environment only.

**Before:**
![Screenshot 2024-01-26 at 3 19 09 PM](https://github.com/localcontexts/localcontextshub/assets/41635757/cfe3c9cd-c642-4932-a4b4-e6f9f8c41bba)

**After:**
![Screenshot 2024-01-26 at 3 19 47 PM](https://github.com/localcontexts/localcontextshub/assets/41635757/6cecb95e-db09-4b86-80c2-0bdebefcb99f)
