### PR TITLE
86874wgv4 Resolved Registry UI bug

### DIFF
--- a/templates/partials/infocards/_community-card.html
+++ b/templates/partials/infocards/_community-card.html
@@ -25,10 +25,12 @@
         <div class="dashcard-btn-container">
             <div class="margin-left-16 flex-this gap-1">
                 {% if '/registry/' in request.path %}
-                    <a 
-                        class="primary-btn action-btn"
-                        href="{% url 'public-community' community.id %}" 
-                    >View public page</a>
+                    <div class="margin-left-16"> 
+                        <a 
+                            class="primary-btn action-btn"
+                            href="{% url 'public-community' community.id %}" 
+                        >View public page</a>
+                    </div> 
                 {% endif %}
 
                 <div class="margin-right-8">                 
@@ -46,13 +48,15 @@
                         <a class="primary-btn action-btn" href="{% url 'select-label' community.id %}">View account</a>
                     {% endif %}
                 </div>
-                <!-- Notification -->
-                {% include 'snippets/notifications.html' with scope=community %}
-                <!-- Settings -->
-                {% if request.user == community.community_creator or member_role == 'admin' %}
-                    <div>
-                        <a href="{% url 'update-community' community.id %}" class=" border-raduis50 darkteal-text primary-btn white-btn"><i class=" no-margin fa fa-cog" aria-hidden="true"></i></a>
-                    </div>
+                {% if '/dashboard/' in request.path %}
+                    <!-- Notification -->
+                    {% include 'snippets/notifications.html' with scope=community %}
+                    <!-- Settings -->
+                    {% if request.user == community.community_creator or member_role == 'admin' %}
+                        <div>
+                            <a href="{% url 'update-community' community.id %}" class=" border-raduis50 darkteal-text primary-btn white-btn"><i class=" no-margin fa fa-cog" aria-hidden="true"></i></a>
+                        </div>
+                    {% endif %}
                 {% endif %}
             </div>
         </div>

--- a/templates/partials/infocards/_institution-card.html
+++ b/templates/partials/infocards/_institution-card.html
@@ -25,22 +25,23 @@
         </div>
 
         <div class="dashcard-btn-container">
-            <div class="margin-left-16 flex-this gap-1">
-                {% if '/registry/' in request.path %}
-                    <div class="margin-bottom-16">
-                        <a 
-                            class="primary-btn action-btn"
-                            href="{% url 'public-institution' institution.id %}"                    
-                        >View public page</a>                        
-                    </div>
-                    {% if institution.otc_institution_url.all %}
-                        <div class="flex-this flex-end">
-                            <img class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="60px" alt="black square with white rectangle being held by two hands in the middle">
+            {% if '/registry/' in request.path %}
+                <div class="margin-left-16">
+                        <div class="margin-bottom-16">
+                            <a 
+                                class="primary-btn action-btn"
+                                href="{% url 'public-institution' institution.id %}"                    
+                            >View public page</a>                        
                         </div>
-                    {% endif %}
-                {% endif %}
-
-                <div class="margin-right-8">
+                        {% if institution.otc_institution_url.all %}
+                            <div class="flex-this flex-end">
+                                <img class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="60px" alt="black square with white rectangle being held by two hands in the middle">
+                            </div>
+                        {% endif %}
+                    </div>
+            {% endif %}
+            <div class="margin-left-16 flex-this gap-1">
+                <div>
                     {% if '/dashboard/' in request.path %}
                         {% if institution_projects %}
                             {% if request.user in institution.get_distinct_creators  %}
@@ -62,13 +63,15 @@
                         {% endif %}
                     {% endif %}
                 </div>
-                <!-- Notification -->
-                {% include 'snippets/notifications.html' with scope=institution %}
-                <!-- Settings -->
-                {% if request.user == institution.institution_creator or member_role == 'admin'%}
-                    <div>
-                        <a href="{% url 'update-institution' institution.id%}" class="border-raduis50 darkteal-text primary-btn white-btn"><i class="no-margin fa fa-cog" aria-hidden="true"></i></a>
-                    </div>
+                {% if '/dashboard/' in request.path %}
+                    <!-- Notification -->
+                    {% include 'snippets/notifications.html' with scope=institution %}
+                    <!-- Settings -->
+                    {% if request.user == institution.institution_creator or member_role == 'admin'%}
+                        <div>
+                            <a href="{% url 'update-institution' institution.id%}" class="border-raduis50 darkteal-text primary-btn white-btn"><i class="no-margin fa fa-cog" aria-hidden="true"></i></a>
+                        </div>
+                    {% endif %}
                 {% endif %}
                
             </div>

--- a/templates/partials/infocards/_researcher-card.html
+++ b/templates/partials/infocards/_researcher-card.html
@@ -64,6 +64,7 @@
           >
           {% endif %} {% endif %}
         </div>
+        {% if '/dashboard/' in request.path %}
         <!-- Notification -->
         {% include 'snippets/notifications.html' with scope=researcher.id %}
         <!-- Settings -->
@@ -74,6 +75,7 @@
             ><i class="no-margin fa fa-cog" aria-hidden="true"></i
           ></a>
         </div>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/86874wgv4)**
  
- Description: Going to the Registry, View Public Page buttons UI looks off. For the registry, we should not be able to see the notifications for other accounts, nor their settings. Only the View Public Page should be visible.

**Solution:**
- Updated the HTML to solve the UI bug

**Before:**
![Registerybefore(1)](https://github.com/localcontexts/localcontextshub/assets/145371882/cdca6500-bf59-412d-a7b1-5bba1b0ce15a)

![Registerybefore(2)](https://github.com/localcontexts/localcontextshub/assets/145371882/e283babf-e570-42f1-b2e6-1e064b6cc206)

**After:**

![registryUIafter](https://github.com/localcontexts/localcontextshub/assets/145371882/76dde3da-3475-425f-b59f-544bf953f7d0)

![registryUIafter(2)](https://github.com/localcontexts/localcontextshub/assets/145371882/2f7ef1ad-731a-456f-b1ce-ab1a8b95f4c6)
