### PR TITLE
868735yar Resolved Bug for the labels audiofile

### DIFF
--- a/templates/communities/edit-label.html
+++ b/templates/communities/edit-label.html
@@ -43,8 +43,12 @@
                             <div class="hide">{{ form.audiofile }}</div>
                             <button id="customLabelAudioFileUploadBtn" class="primary-btn green-btn">
                                 {% if bclabel.audiofile or tklabel.audiofile %}
-                                    {% firstof bclabel.audiofile.name|get_filename tklabel.audiofile.name|get_filename %}
-                                    <i class="fa-solid fa-check"></i>
+                                    {% if bclabel.audiofile %}
+                                        {{ bclabel.audiofile.name|get_filename }}
+                                    {% elif tklabel.audiofile %}
+                                        {{ tklabel.audiofile.name|get_filename }}
+                                    {% endif %}
+                                <i class="fa-solid fa-check"></i>
                                 {% else %}
                                     Upload audio file 
                                     <i class="fa-solid fa-upload"></i>

--- a/templates/communities/view-label.html
+++ b/templates/communities/view-label.html
@@ -108,6 +108,7 @@
                     {% if tklabel %} {% if tklabel.version %} <span class="bold">Version </span> - {{ tklabel.version }}{% endif %} <br> {% endif %}
 
                     {% if bclabel.audiofile %}<div><audio src="{{ bclabel.audiofile.url }}" controls></audio></div>{% endif %}
+                    {% if tklabel.audiofile %}<div><audio src="{{ tklabel.audiofile.url }}" controls></audio></div>{% endif %}
                     <br>                    
                 </p>
 


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/868735yar)**
  
- Description: Right now you can see the audio file when you edit the Label and when you first click on a customized Label. When you go to View Label page, the audio player does not appear anywhere, although it should. Also the edit label was not working for tklabel.

**Solution:**
- Updated the HTML to solve the UI bug.
- Updated the logic to avoid error on edit label page.


**Before:**

https://github.com/localcontexts/localcontextshub/assets/145371882/f7ecc21d-7d1a-4a31-801a-b747850e761d


**After:**


https://github.com/localcontexts/localcontextshub/assets/145371882/c38bbe3c-4d80-4bbb-9337-955f2c1270d5


