### PR TITLE
#868771r4z project_privacy migration error

### DIFF
--- a/projects/models.py
+++ b/projects/models.py
@@ -29,11 +29,11 @@ class Project(models.Model):
         ('Exhibition', 'Exhibition'),
         ('Other', 'Other'),
     )
-    PRIVACY_LEVEL = {
+    PRIVACY_LEVEL = (
         ('Public', 'Public'),
         ('Contributor', 'Contributor'),
         ('Private', 'Private'),
-    }
+    )
     unique_id = models.UUIDField(default=uuid.uuid4, editable=False, unique=True, null=True, db_index=True, verbose_name="Unique ID (UUID)")
     project_creator = models.ForeignKey(User, null=True, on_delete=models.CASCADE, related_name="project_creator")
     project_page = models.URLField(blank=True, null=True)


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/868771r4z)**
  
- Description: Every time someone runs python manage.py makemigrations a migration file gets created that says the project_privacy  field has been updated when it has not. It creates multiple migrations for the same thing that then gets in the way of other subsequent migrations.

**Solution:**
- The PRIVACY_LEVEL is provided as Set which is unordered in python so changed that to list.

**Before:**
![migration (before)](https://github.com/localcontexts/localcontextshub/assets/145371882/e3ee67c7-1737-4b29-a690-9b9a5201bded)

**After:**
![migration(after)](https://github.com/localcontexts/localcontextshub/assets/145371882/805d20fb-6e8d-4a3b-88c6-c287709e6d19)
