### PR TITLE
#8685tnmg0 alt text for notices and labels extended

### DIFF
--- a/communities/views.py
+++ b/communities/views.py
@@ -447,8 +447,7 @@ def select_label(request, pk):
     member_role = check_member_role(request.user, community)
     can_download = community.is_approved and dev_prod_or_local(request.get_host()) != 'SANDBOX'
     is_sandbox = dev_prod_or_local(request.get_host()) == 'SANDBOX'
-    data = labels_data
-    bclabels, tklabels = get_alt_text(data, bclabels, tklabels)
+    bclabels, tklabels = get_alt_text(labels_data, bclabels, tklabels)
 
     if request.method == "POST":
         bclabel_code = request.POST.get('bc-label-code')
@@ -1282,8 +1281,7 @@ def labels_pdf(request, pk):
     if community.is_approved:
         bclabels = BCLabel.objects.filter(community=community, is_approved=True)
         tklabels = TKLabel.objects.filter(community=community, is_approved=True)
-        data = labels_data
-        bclabels, tklabels = get_alt_text(data, bclabels, tklabels)
+        bclabels, tklabels = get_alt_text(labels_data, bclabels, tklabels)
 
         template_path = 'snippets/pdfs/community-labels.html'
         context = {'community': community, 'bclabels': bclabels, 'tklabels': tklabels,}

--- a/communities/views.py
+++ b/communities/views.py
@@ -20,6 +20,7 @@ from accounts.forms import ContactOrganizationForm, SignUpInvitationForm
 from localcontexts.utils import dev_prod_or_local
 from projects.utils import *
 from helpers.utils import *
+from tklabels.utils import data as labels_data
 from accounts.utils import get_users_name
 from notifications.utils import *
 from helpers.downloads import download_labels_zip
@@ -446,7 +447,7 @@ def select_label(request, pk):
     member_role = check_member_role(request.user, community)
     can_download = community.is_approved and dev_prod_or_local(request.get_host()) != 'SANDBOX'
     is_sandbox = dev_prod_or_local(request.get_host()) == 'SANDBOX'
-    data = get_labels_json()
+    data = labels_data
     bclabels, tklabels = get_alt_text(data, bclabels, tklabels)
 
     if request.method == "POST":
@@ -1281,7 +1282,7 @@ def labels_pdf(request, pk):
     if community.is_approved:
         bclabels = BCLabel.objects.filter(community=community, is_approved=True)
         tklabels = TKLabel.objects.filter(community=community, is_approved=True)
-        data = get_labels_json()
+        data = labels_data
         bclabels, tklabels = get_alt_text(data, bclabels, tklabels)
 
         template_path = 'snippets/pdfs/community-labels.html'

--- a/communities/views.py
+++ b/communities/views.py
@@ -446,6 +446,8 @@ def select_label(request, pk):
     member_role = check_member_role(request.user, community)
     can_download = community.is_approved and dev_prod_or_local(request.get_host()) != 'SANDBOX'
     is_sandbox = dev_prod_or_local(request.get_host()) == 'SANDBOX'
+    data = get_labels_json()
+    bclabels, tklabels = get_alt_text(data, bclabels, tklabels)
 
     if request.method == "POST":
         bclabel_code = request.POST.get('bc-label-code')
@@ -1279,6 +1281,8 @@ def labels_pdf(request, pk):
     if community.is_approved:
         bclabels = BCLabel.objects.filter(community=community, is_approved=True)
         tklabels = TKLabel.objects.filter(community=community, is_approved=True)
+        data = get_labels_json()
+        bclabels, tklabels = get_alt_text(data, bclabels, tklabels)
 
         template_path = 'snippets/pdfs/community-labels.html'
         context = {'community': community, 'bclabels': bclabels, 'tklabels': tklabels,}

--- a/helpers/downloads.py
+++ b/helpers/downloads.py
@@ -4,7 +4,8 @@ from projects.models import ProjectContributors
 from .models import Notice
 from django.shortcuts import redirect
 from django.http import HttpResponse
-from .utils import generate_zip, render_to_pdf, get_labels_json, get_alt_text
+from .utils import generate_zip, render_to_pdf, get_alt_text
+from tklabels.utils import data as labels_data
 import requests
 import os
 from django.shortcuts import render
@@ -98,7 +99,7 @@ def download_project_zip(project):
     baseURL = f'https://storage.googleapis.com/{settings.STORAGE_BUCKET}/'
     project_bclabels = project.bc_labels.all()
     project_tklabels = project.tk_labels.all()
-    data = get_labels_json()
+    data = labels_data
     project_bclabels, project_tklabels = get_alt_text(data, project_bclabels, project_tklabels)
     project_creator = project.project_creator_project.first()
     contributors = ProjectContributors.objects.prefetch_related('communities', 'institutions', 'researchers').get(project=project)

--- a/helpers/downloads.py
+++ b/helpers/downloads.py
@@ -99,8 +99,7 @@ def download_project_zip(project):
     baseURL = f'https://storage.googleapis.com/{settings.STORAGE_BUCKET}/'
     project_bclabels = project.bc_labels.all()
     project_tklabels = project.tk_labels.all()
-    data = labels_data
-    project_bclabels, project_tklabels = get_alt_text(data, project_bclabels, project_tklabels)
+    project_bclabels, project_tklabels = get_alt_text(labels_data, project_bclabels, project_tklabels)
     project_creator = project.project_creator_project.first()
     contributors = ProjectContributors.objects.prefetch_related('communities', 'institutions', 'researchers').get(project=project)
     project_people = project.additional_contributors.all()

--- a/helpers/downloads.py
+++ b/helpers/downloads.py
@@ -4,7 +4,7 @@ from projects.models import ProjectContributors
 from .models import Notice
 from django.shortcuts import redirect
 from django.http import HttpResponse
-from .utils import generate_zip, render_to_pdf
+from .utils import generate_zip, render_to_pdf, get_labels_json, get_alt_text
 import requests
 import os
 from django.shortcuts import render
@@ -98,6 +98,8 @@ def download_project_zip(project):
     baseURL = f'https://storage.googleapis.com/{settings.STORAGE_BUCKET}/'
     project_bclabels = project.bc_labels.all()
     project_tklabels = project.tk_labels.all()
+    data = get_labels_json()
+    project_bclabels, project_tklabels = get_alt_text(data, project_bclabels, project_tklabels)
     project_creator = project.project_creator_project.first()
     contributors = ProjectContributors.objects.prefetch_related('communities', 'institutions', 'researchers').get(project=project)
     project_people = project.additional_contributors.all()
@@ -105,7 +107,7 @@ def download_project_zip(project):
     notice_exists = Notice.objects.filter(project=project).exists()
 
     template_path = 'snippets/pdfs/project-pdf.html'
-    context = { 'project': project, 'project_creator': project_creator, 'contributors': contributors, 'project_people': project_people }
+    context = { 'project': project, 'project_creator': project_creator, 'contributors': contributors, 'project_people': project_people, 'project_bclabels': project_bclabels, 'project_tklabels': project_tklabels }
 
     files = []
 

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -383,3 +383,20 @@ def discoverable_project_view(project, user):
         discoverable = False
 
     return discoverable
+
+def get_alt_text(data, bclabels, tklabels):
+    for label in bclabels:
+        item = next((x for x in data['bcLabels'] if x['labelName'] == label.name), None)
+        if item is not None:
+            label.alt_text = item['labelAlternateText']
+        else:
+            label.alt_text = "BC label icon"  
+    
+    for label in tklabels:
+        item = next((x for x in data['tkLabels'] if x['labelName'] == label.name), None)
+        if item is not None:
+            label.alt_text = item['labelAlternateText']
+        else:
+            label.alt_text = "TK label icon" 
+    
+    return bclabels, tklabels  

--- a/localcontexts/static/json/Labels.json
+++ b/localcontexts/static/json/Labels.json
@@ -10,7 +10,8 @@
             "labelCategory": "provenance",
             "audioFileName": "BC-Provenance-Label-1.mp3",
             "imgFileName": "bc-provenance.png",
-            "svgFileName": "bc-provenance.svg"
+            "svgFileName": "bc-provenance.svg",
+            "labelAlternateText": "BC Provenance Label icon. Black tag shape with six perpendicular white lines of increasing width. On left side are three white dots."
         },
         {
             "id": 2,
@@ -22,7 +23,8 @@
             "labelCategory": "provenance",
             "audioFileName": "BC-Multiple-Communities-Label.mp3",
             "imgFileName": "bc-multiple-community.png",
-            "svgFileName": "bc-multiple-community.svg"
+            "svgFileName": "bc-multiple-community.svg",
+            "labelAlternateText": "BC Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square. On left side are three white dots."
         },
         {
             "id": 3,
@@ -34,7 +36,8 @@
             "labelCategory": "permission",
             "audioFileName": "BC-Open-to-Collaboration-Label.mp3",
             "imgFileName": "bc-open-to-collaboration.png",
-            "svgFileName": "bc-open-to-collaboration.svg"
+            "svgFileName": "bc-open-to-collaboration.svg",
+            "labelAlternateText": "BC Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top. On left side are three white dots."
         },
         {
             "id": 4,
@@ -46,7 +49,8 @@
             "labelCategory": "permission",
             "audioFileName": "BC-Open-to-Commercialization-Label.mp3",
             "imgFileName": "bc-open-to-commercialization.png",
-            "svgFileName": "bc-open-to-commercialization.svg"
+            "svgFileName": "bc-open-to-commercialization.svg",
+            "labelAlternateText": "BC Open to Commercialization Label icon. Black tag shape with a white dollar sign in center. On left side are three white dots."
         },
         {
             "id": 5,
@@ -58,7 +62,8 @@
             "labelCategory": "permission",
             "audioFileName": "BC-Research-Use-Label.mp3",
             "imgFileName": "bc-research-use.png",
-            "svgFileName": "bc-research-use.svg"
+            "svgFileName": "bc-research-use.svg",
+            "labelAlternateText": "BC Research Use Label icon. Black tag shape with four rectangles inside two concentric circles. On left side are three white dots."
         },
         {
             "id": 6,
@@ -70,7 +75,8 @@
             "labelCategory": "protocol",
             "audioFileName": "BC-Consent-Verified-Label-1.mp3",
             "imgFileName": "bc-consent-verified.png",
-            "svgFileName": "bc-consent-verified.svg"
+            "svgFileName": "bc-consent-verified.svg",
+            "labelAlternateText": "BC Consent Verified Label icon. Black tag shape with a white checkmark in center. On left side are three white dots."
         },
         {
             "id": 7,
@@ -82,7 +88,8 @@
             "labelCategory": "protocol",
             "audioFileName": "BC-Consent-Non-Verified.mp3",
             "imgFileName": "bc-consent-non-verified.png",
-            "svgFileName": "bc-consent-non-verified.svg"
+            "svgFileName": "bc-consent-non-verified.svg",
+            "labelAlternateText": "BC Consent Non-Verified Label icon. Black tag shape with a white checkmark and a diagonal line through it in the center. On left side are three white dots."
         },
         {
             "id": 8,
@@ -94,7 +101,8 @@
             "labelCategory": "provenance",
             "audioFileName": "BC-Clan.mp3",
             "imgFileName": "bc-clan.png",
-            "svgFileName": "bc-clan.svg"
+            "svgFileName": "bc-clan.svg",
+            "labelAlternateText": "BC Clan Label icon. Black tag shape with a circle made of small white dots in center. On left side are three larger white dots."
         },
         {
             "id": 9,
@@ -106,7 +114,8 @@
             "labelCategory": "permission",
             "audioFileName": "BC-Outreach.mp3",
             "imgFileName": "bc-outreach.png",
-            "svgFileName": "bc-outreach.svg"
+            "svgFileName": "bc-outreach.svg",
+            "labelAlternateText": "BC Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger. On left side are three white dots."
         },
         {
             "id": 10,
@@ -118,7 +127,8 @@
             "labelCategory": "permission",
             "audioFileName": "BC-Non-Commercial.mp3",
             "imgFileName": "bc-non-commercial.png",
-            "svgFileName": "bc-non-commercial.svg"
+            "svgFileName": "bc-non-commercial.svg",
+            "labelAlternateText": "BC Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center. On left side are three white dots."
         }
 
     ],
@@ -133,7 +143,8 @@
             "labelCategory": "provenance",
             "audioFileName": "TK-Attribution-Label.mp3",
             "imgFileName": "tk-attribution.png",
-            "svgFileName": "tk-attribution.svg"
+            "svgFileName": "tk-attribution.svg",
+            "labelAlternateText": "TK Attribution Label icon. Black tag shape with two stacked white arrows, one pointing left and one pointing right."
         },
         {
             "id": 2,
@@ -145,7 +156,8 @@
             "labelCategory": "provenance",
             "audioFileName": "TK-Clan-Label.mp3",
             "imgFileName": "tk-clan.png",
-            "svgFileName": "tk-clan.svg"
+            "svgFileName": "tk-clan.svg",
+            "labelAlternateText": "TK Clan Label icon. Black tag shape with a circle made of small white dots in the center."
         },
         {
             "id": 3,
@@ -157,7 +169,8 @@
             "labelCategory": "provenance",
             "audioFileName": "TK-Family-Label.mp3",
             "imgFileName": "tk-family.png",
-            "svgFileName": "tk-family.svg"
+            "svgFileName": "tk-family.svg",
+            "labelAlternateText": "TK Family Label icon. Black tag shape with a circle made of alternating small and big white dots in the center."
         },
         {
             "id": 4,
@@ -169,7 +182,8 @@
             "labelCategory": "provenance",
             "audioFileName": "TK-Multiple-Communities-Label.mp3",
             "imgFileName": "tk-multiple-communities.png",
-            "svgFileName": "tk-multiple-communities.svg"
+            "svgFileName": "tk-multiple-communities.svg",
+            "labelAlternateText": "TK Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square."
         },
         {
             "id": 5,
@@ -181,7 +195,8 @@
             "labelCategory": "provenance",
             "audioFileName": "TK-Community-Voice-Label.mp3",
             "imgFileName": "tk-community-voice.png",
-            "svgFileName": "tk-community-voice.svg"
+            "svgFileName": "tk-community-voice.svg",
+            "labelAlternateText": "TK Community Voice Label icon. Black tag shape with three different sized human figures in white and dialogue bubbles that overlap."
         },
         {
             "id": 6,
@@ -193,7 +208,8 @@
             "labelCategory": "provenance",
             "audioFileName": "TK-Creative.mp3",
             "imgFileName": "tk-creative.png",
-            "svgFileName": "tk-creative.svg"
+            "svgFileName": "tk-creative.svg",
+            "labelAlternateText": "TK Creative Label icon. Black tag shape with a white circle made up of eight small dots on one half, a solid line on the other half, and each half bifurcated with two bigger dots."
         },
         {
             "id": 7,
@@ -205,7 +221,8 @@
             "labelCategory": "protocol",
             "audioFileName": "TK-Verified-Label.mp3",
             "imgFileName": "tk-verified.png",
-            "svgFileName": "tk-verified.svg"
+            "svgFileName": "tk-verified.svg",
+            "labelAlternateText": "TK Verified Label icon. Black tag shape with a white checkmark in center."
         },
         {
             "id": 8,
@@ -217,7 +234,8 @@
             "labelCategory": "protocol",
             "audioFileName": "TK-Non-Verified-Label.mp3",
             "imgFileName": "tk-non-verified.png",
-            "svgFileName": "tk-non-verified.svg"
+            "svgFileName": "tk-non-verified.svg",
+            "labelAlternateText": "TK Non-Verified Label icon. Black tag shape with a white checkmark and diagonal line through it in center."
         },
         {
             "id": 9,
@@ -229,7 +247,8 @@
             "labelCategory": "protocol",
             "audioFileName": "TK-Seasonal-Label.mp3",
             "imgFileName": "tk-seasonal.png",
-            "svgFileName": "tk-seasonal.svg"
+            "svgFileName": "tk-seasonal.svg",
+            "labelAlternateText": "TK Seasonal Label icon. Black background with simple illustrations of a tree with bare branches and another tree with a circle representing leaves."
         },
         {
             "id": 10,
@@ -241,7 +260,8 @@
             "labelCategory": "protocol",
             "audioFileName": "TK-Women-General-Label.mp3",
             "imgFileName": "tk-women-general.png",
-            "svgFileName": "tk-women-general.svg"
+            "svgFileName": "tk-women-general.svg",
+            "labelAlternateText": "TK Women General Label icon. Black tag shape with a white figure made up of a triangle on bottom and circle on top."
         },
         {
             "id": 11,
@@ -253,7 +273,8 @@
             "labelCategory": "protocol",
             "audioFileName": "TK-Men-General-Label.mp3",
             "imgFileName": "tk-men-general.png",
-            "svgFileName": "tk-men-general.svg"
+            "svgFileName": "tk-men-general.svg",
+            "labelAlternateText": "TK Men General Label icon. Black tag shape with a white figure made up of a square on bottom and circle on top."
         },
         {
             "id": 12,
@@ -265,7 +286,8 @@
             "labelCategory": "protocol",
             "audioFileName": "TK-Men-Restricted-Label.mp3",
             "imgFileName": "tk-men-restricted.png",
-            "svgFileName": "tk-men-restricted.svg"
+            "svgFileName": "tk-men-restricted.svg",
+            "labelAlternateText": "TK Men Restricted Label icon. Black tag shape with two white figures made up of two squares on bottom and two circles on top with a double-sided arrow connecting both figures."
         },
         {
             "id": 13,
@@ -277,7 +299,8 @@
             "labelCategory": "protocol",
             "audioFileName": "TK-Women-Restricted-Label.mp3",
             "imgFileName": "tk-women-restricted.png",
-            "svgFileName": "tk-women-restricted.svg"
+            "svgFileName": "tk-women-restricted.svg",
+            "labelAlternateText": "TK Women Restricted Label icon. Black tag shape with two white figures made up of two triangles on bottom and two circles on top with a double-sided arrow connecting both figures."
         },
         {
             "id": 14,
@@ -289,7 +312,8 @@
             "labelCategory": "protocol",
             "audioFileName": "TK-Culturally-Sensitive-Label-1.mp3",
             "imgFileName": "tk-culturally-sensitive.png",
-            "svgFileName": "tk-culturally-sensitive.svg"
+            "svgFileName": "tk-culturally-sensitive.svg",
+            "labelAlternateText": "TK Culturally Sensitive Label icon. Black tag shape with four hands in a circle surrounding a white cube."
         },
         {
             "id": 15,
@@ -301,7 +325,8 @@
             "labelCategory": "protocol",
             "audioFileName": "TK-SecretSacred-Label.mp3",
             "imgFileName": "tk-secret-sacred.png",
-            "svgFileName": "tk-secret-sacred.svg"
+            "svgFileName": "tk-secret-sacred.svg",
+            "labelAlternateText": "TK Secret / Sacred Label icon. Black tag shape with a large white cube in center."
         },
         {
             "id": 16,
@@ -313,7 +338,8 @@
             "labelCategory": "permission",
             "audioFileName": "TK-Open-to-Commercialization-Label.mp3",
             "imgFileName": "tk-commercial.png",
-            "svgFileName": "tk-commercial.svg"
+            "svgFileName": "tk-commercial.svg",
+            "labelAlternateText": "TK Open to Commercialization Label icon. Black tag shape with a white dollar sign in center."
         },
         {
             "id": 17,
@@ -325,7 +351,8 @@
             "labelCategory": "permission",
             "audioFileName": "TK-Non-Commercial-Label.mp3",
             "imgFileName": "tk-non-commercial.png",
-            "svgFileName": "tk-non-commercial.svg"
+            "svgFileName": "tk-non-commercial.svg",
+            "labelAlternateText": "TK Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center."
         },
         {
             "id": 18,
@@ -337,7 +364,8 @@
             "labelCategory": "permission",
             "audioFileName": "TK-Community-Use-Only.mp3",
             "imgFileName": "tk-community-use-only.png",
-            "svgFileName": "tk-community-use-only.svg"
+            "svgFileName": "tk-community-use-only.svg",
+            "labelAlternateText": "TK Community Use Only Label icon. Black tag shape with four criss-crossed white lines in center."
         },
         {
             "id": 19,
@@ -349,7 +377,8 @@
             "labelCategory": "permission",
             "audioFileName": "TK-Outreach-Label.mp3",
             "imgFileName": "tk-outreach.png",
-            "svgFileName": "tk-outreach.svg"
+            "svgFileName": "tk-outreach.svg",
+            "labelAlternateText": "TK Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger."
         },
         {
             "id": 20,
@@ -361,7 +390,8 @@
             "labelCategory": "permission",
             "audioFileName": "TK-Open-to-Collab.mp3",
             "imgFileName": "tk-open-to-collaboration.png",
-            "svgFileName": "tk-open-to-collaboration.svg"
+            "svgFileName": "tk-open-to-collaboration.svg",
+            "labelAlternateText": "TK Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top."
         }
     ]
 }

--- a/templates/accounts/select-account.html
+++ b/templates/accounts/select-account.html
@@ -16,7 +16,7 @@
                         </span>
                     </div>                    
                 </div>
-                <div><img loading="lazy" class="tiny-label pointer-event-none" src="{% static 'images/tk-labels/tk-attribution.png' %}" alt="TK Attribution (TK A) Label"></div>
+                <div><img loading="lazy" class="tiny-label pointer-event-none" src="{% static 'images/tk-labels/tk-attribution.png' %}" alt="TK Attribution Label icon. Black tag shape with two stacked white arrows, one pointing left and one pointing right."></div>
                 <p><strong>Who?</strong> An Indigenous or local community entity or representative</p>
                 <p class="no-top-margin"><strong>What?</strong> Customize and apply TK and BC Labels, and create Projects</p>
                 <a href="{% url 'connect-community' %}"><div class="primary-btn white-btn-select"><span>Join</span></div></a>
@@ -31,8 +31,8 @@
                 </div>
                 <div class="flex-this">
                     <div class="margin-right-1"><img loading="lazy" 
-                    class="tiny-notice pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="black square with white letters TK in the middle"></div>
-                    <div class="margin-left-16"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" alt="black square with white rectangle being held by two hands in the middle"></div>
+                    class="tiny-notice pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="TK Notice icon. Black background with the top right corner folded and the letters “TK” in white in center."></div>
+                    <div class="margin-left-16"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" alt="Open to Collaborate Notice icon. Black square with the top right corner folded and two white hands reaching toward each other from top to bottom over a white horizontal rectangle. "></div>
                 </div>
                 <p><strong>Who?</strong> Cultural or research institution, data repository, and other organizations</p>
                 <p><strong>What?</strong> Create projects and generate Notices</p>
@@ -42,8 +42,8 @@
             <div class="account-card margin-left-1">
                 <p><strong>Researcher Account</strong></p>
                 <div class="flex-this">
-                    <div class="margin-right-1"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="black square with white letters TK in the middle"></div>
-                    <div class="margin-left-16"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" alt="black square with white letters BC in the middle"></div>
+                    <div class="margin-right-1"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="TK Notice icon. Black background with the top right corner folded and the letters “TK” in white in center."></div>
+                    <div class="margin-left-16"><img loading="lazy" class="tiny-notice pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" alt="BC Notice icon. Black background with the top right corner folded and the letters “BC” in white in center."></div>
                 </div>
                 <p><strong>Who?</strong> An individual who carries out academic or scientific research independently or in an institution </p>
                 <p><strong>What?</strong> Create projects and generate Notices</p>

--- a/templates/bclabels/mini-labels.html
+++ b/templates/bclabels/mini-labels.html
@@ -7,43 +7,43 @@
         
         {% if bclabel.label_type == 'commercialization'%}
             src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" 
-            alt="BC Open to Commercialization (BC OC) Label"
+            alt="BC Open to Commercialization Label icon. Black tag shape with a white dollar sign in center. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'provenance' %}
             src="{% static 'images/bc-labels/bc-provenance.png' %}"
-            alt="BC Provenance (BC P) Label"
+            alt="BC Provenance Label icon. Black tag shape with six perpendicular white lines of increasing width. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'collaboration' %}
             src="{% static 'images/bc-labels/bc-open-to-collaboration.png' %}" 
-            alt="BC Open to Collaboration (BC CB) Label"
+            alt="BC Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'consent_verified' %}
             src="{% static 'images/bc-labels/bc-consent-verified.png' %}" 
-            alt="BC Consent Verified (BC CV) Label"
+            alt="BC Consent Verified Label icon. Black tag shape with a white checkmark in center. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'multiple_community' %}
             src="{% static 'images/bc-labels/bc-multiple-community.png' %}" 
-            alt="BC Multiple Communities (BC MC) Label"
+            alt="BC Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'research' %}
             src="{% static 'images/bc-labels/bc-research-use.png' %}" 
-            alt="BC Research Use (BC R) Label"
+            alt="BC Research Use Label icon. Black tag shape with four rectangles inside two concentric circles. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'non_commercial' %}
             src="{% static 'images/bc-labels/bc-non-commercial.png' %}" 
-            alt="BC Non-Commercial (BC NC) Label"
+            alt="BC Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'consent_non_verified' %}
             src="{% static 'images/bc-labels/bc-consent-non-verified.png' %}" 
-            alt="BC Consent Non-Verified (BC CNV) Label"
+            alt="BC Consent Non-Verified Label icon. Black tag shape with a white checkmark and a diagonal line through it in the center. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'clan' %}
             src="{% static 'images/bc-labels/bc-clan.png' %}" 
-            alt="BC Clan (BC CL) Label"
+            alt="BC Clan Label icon. Black tag shape with a circle made of small white dots in center. On left side are three larger white dots."
         {% endif %}
         {% if bclabel.label_type == 'outreach' %}
             src="{% static 'images/bc-labels/bc-outreach.png' %}" 
-            alt="BC Outreach (BC O) Label"
+            alt="BC Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger. On left side are three white dots."
         {% endif %}
     >
 </div>

--- a/templates/bclabels/tiny-labels.html
+++ b/templates/bclabels/tiny-labels.html
@@ -7,43 +7,43 @@
         
         {% if bclabel.label_type == 'commercialization'%}
             src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" 
-            alt="BC Open to Commercialization (BC OC) Label"
+            alt="BC Open to Commercialization Label icon. Black tag shape with a white dollar sign in center. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'provenance' %}
             src="{% static 'images/bc-labels/bc-provenance.png' %}"
-            alt="BC Provenance (BC P) Label"
+            alt="BC Provenance Label icon. Black tag shape with six perpendicular white lines of increasing width. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'collaboration' %}
             src="{% static 'images/bc-labels/bc-open-to-collaboration.png' %}" 
-            alt="BC Open to Collaboration (BC CB) Label"
+            alt="BC Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'consent_verified' %}
             src="{% static 'images/bc-labels/bc-consent-verified.png' %}" 
-            alt="BC Consent Verified (BC CV) Label"
+            alt="BC Consent Verified Label icon. Black tag shape with a white checkmark in center. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'multiple_community' %}
             src="{% static 'images/bc-labels/bc-multiple-community.png' %}" 
-            alt="BC Multiple Communities (BC MC) Label"
+            alt="BC Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'research' %}
             src="{% static 'images/bc-labels/bc-research-use.png' %}" 
-            alt="BC Research Use (BC R) Label"
+            alt="BC Research Use Label icon. Black tag shape with four rectangles inside two concentric circles. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'non_commercial' %}
             src="{% static 'images/bc-labels/bc-non-commercial.png' %}" 
-            alt="BC Non-Commercial (BC NC) Label"
+            alt="BC Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'consent_non_verified' %}
             src="{% static 'images/bc-labels/bc-consent-non-verified.png' %}" 
-            alt="BC Consent Non-Verified (BC CNV) Label"
+            alt="BC Consent Non-Verified Label icon. Black tag shape with a white checkmark and a diagonal line through it in the center. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'clan' %}
             src="{% static 'images/bc-labels/bc-clan.png' %}" 
-            alt="BC Clan (BC CL) Label"
+            alt="BC Clan Label icon. Black tag shape with a circle made of small white dots in center. On left side are three larger white dots."
         {% endif %}
         {% if bclabel.label_type == 'outreach' %}
             src="{% static 'images/bc-labels/bc-outreach.png' %}" 
-            alt="BC Outreach (BC O) Label"
+            alt="BC Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger. On left side are three white dots."
         {% endif %}
     >
 </div>

--- a/templates/bclabels/which-label.html
+++ b/templates/bclabels/which-label.html
@@ -8,43 +8,44 @@
         
         {% if bclabel.label_type == 'commercialization'%}
             src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" 
-            alt="BC Open to Commercialization (BC OC) Label"
+            alt="BC Open to Commercialization Label icon. Black tag shape with a white dollar sign in center. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'provenance' %}
             src="{% static 'images/bc-labels/bc-provenance.png' %}"
-            alt="BC Provenance (BC P) Label"
+            alt="BC Provenance Label icon. Black tag shape with six perpendicular white lines of increasing width. On left side are three white dots.
+            "
         {% endif %}
         {% if bclabel.label_type == 'collaboration' %}
             src="{% static 'images/bc-labels/bc-open-to-collaboration.png' %}" 
-            alt="BC Open to Collaboration (BC CB) Label"
+            alt="BC Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'consent_verified' %}
             src="{% static 'images/bc-labels/bc-consent-verified.png' %}" 
-            alt="BC Consent Verified (BC CV) Label"
+            alt="BC Consent Verified Label icon. Black tag shape with a white checkmark in center. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'multiple_community' %}
             src="{% static 'images/bc-labels/bc-multiple-community.png' %}" 
-            alt="BC Multiple Communities (BC MC) Label"
+            alt="BC Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'research' %}
             src="{% static 'images/bc-labels/bc-research-use.png' %}" 
-            alt="BC Research Use (BC R) Label"
+            alt="BC Research Use Label icon. Black tag shape with four rectangles inside two concentric circles. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'non_commercial' %}
             src="{% static 'images/bc-labels/bc-non-commercial.png' %}" 
-            alt="BC Non-Commercial (BC NC) Label"
+            alt="BC Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'consent_non_verified' %}
             src="{% static 'images/bc-labels/bc-consent-non-verified.png' %}" 
-            alt="BC Consent Non-Verified (BC CNV) Label"
+            alt="BC Consent Non-Verified Label icon. Black tag shape with a white checkmark and a diagonal line through it in the center. On left side are three white dots."
         {% endif %}
         {% if bclabel.label_type == 'clan' %}
             src="{% static 'images/bc-labels/bc-clan.png' %}" 
-            alt="BC Clan (BC CL) Label"
+            alt="BC Clan Label icon. Black tag shape with a circle made of small white dots in center. On left side are three larger white dots."
         {% endif %}
         {% if bclabel.label_type == 'outreach' %}
             src="{% static 'images/bc-labels/bc-outreach.png' %}" 
-            alt="BC Outreach (BC O) Label"
+            alt="BC Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger. On left side are three white dots."
         {% endif %}
     >
 </div>

--- a/templates/communities/apply-labels.html
+++ b/templates/communities/apply-labels.html
@@ -71,13 +71,13 @@
                             {% for notice in project.project_notice.all %}
                                 {% if not notice.archived %}
                                     {% if notice.notice_type == 'biocultural' %}
-                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="62px" alt="black square with white letters BC in the middle"></div>
+                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="62px" alt="BC Notice icon. Black background with the top right corner folded and the letters “BC” in white in center."></div>
                                     {% endif %}
                                     {% if notice.notice_type == 'traditional_knowledge' %}
-                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="62px" alt="black square with white letters TK in the middle"></div>
+                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="62px" alt="TK Notice icon. Black background with the top right corner folded and the letters “TK” in white in center."></div>
                                     {% endif %}
                                     {% if notice.notice_type == 'attribution_incomplete' %}
-                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="62px" alt="black square with an unfinished square in the middle in white"></div>
+                                        <div class="margin-left-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="62px" alt="Attribution Incomplete Notice icon. Black square with the top right corner folded and a white square in center with left side in solid line and right side in dotted line."></div>
                                     {% endif %}
                                 {% endif %}
                             {% endfor %}

--- a/templates/communities/customize-label.html
+++ b/templates/communities/customize-label.html
@@ -25,173 +25,173 @@
                     {% if label_code == 'bcr' %}
                         id="bcr" 
                         src="{% static 'images/bc-labels/bc-research-use.png' %}"  
-                        alt="BC Research Use (BC R) Label" 
+                        alt="BC Research Use Label icon. Black tag shape with four rectangles inside two concentric circles. On left side are three white dots." 
                     {% endif %}
                     {% if label_code == 'bccv' %}
                         id="bccv" 
                         src="{% static 'images/bc-labels/bc-consent-verified.png' %}" 
-                        alt="BC Consent Verified (BC CV) Label"
+                        alt="BC Consent Verified Label icon. Black tag shape with a white checkmark in center. On left side are three white dots."
                     {% endif %}
                     {% if label_code == 'bcoc' %}
                         id="bcoc" 
                         src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" 
-                        alt="BC Open to Commercialization (BC OC) Label"
+                        alt="BC Open to Commercialization Label icon. Black tag shape with a white dollar sign in center. On left side are three white dots."
                     {% endif %}
                     {% if label_code == 'bccb' %}
                         id="bccb" 
                         src="{% static 'images/bc-labels/bc-open-to-collaboration.png' %}" 
-                        alt="BC Open to Collaboration (BC CB) Label"
+                        alt="BC Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top. On left side are three white dots."
                     {% endif %}
                     {% if label_code == 'bcmc' %}
                         id="bcmc" 
                         src="{% static 'images/bc-labels/bc-multiple-community.png' %}" 
-                        alt="BC Multiple Communities (BC MC) Label"
+                        alt="BC Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square. On left side are three white dots."
                     {% endif %}
                     {% if label_code == 'bcp' %}
                         id="bcp" 
                         src="{% static 'images/bc-labels/bc-provenance.png' %}" 
-                        alt="BC Provenance (BC P) Label"
+                        alt="BC Provenance Label icon. Black tag shape with six perpendicular white lines of increasing width. On left side are three white dots."
                     {% endif %}
                     {% if label_code == 'bccl' %}
                         id="bccl" 
                         src="{% static 'images/bc-labels/bc-clan.png' %}" 
-                        alt="BC Clan (BC CL) Label"
+                        alt="BC Clan Label icon. Black tag shape with a circle made of small white dots in center. On left side are three larger white dots."
                     {% endif %}
                     {% if label_code == 'bco' %}
                         id="bco" 
                         src="{% static 'images/bc-labels/bc-outreach.png' %}" 
-                        alt="BC Outreach (BC O) Label"
+                        alt="BC Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger. On left side are three white dots."
                     {% endif %}
                     {% if label_code == 'bccnv' %}
                         id="bccnv" 
                         src="{% static 'images/bc-labels/bc-consent-non-verified.png' %}" 
-                        alt="BC Consent Non-Verified (BC CNV) Label"
+                        alt="BC Consent Non-Verified Label icon. Black tag shape with a white checkmark and a diagonal line through it in the center. On left side are three white dots."
                     {% endif %}
                     {% if label_code == 'bcnc' %}
                         id="bcnc" 
                         src="{% static 'images/bc-labels/bc-non-commercial.png' %}" 
-                        alt="BC Non-Commercial (BC NC) Label"
+                        alt="BC Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center. On left side are three white dots."
                     {% endif %}
 
                     {% if label_code == 'tka' %}
                         id="tka" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-attribution.png' %}" 
-                        alt="TK Attribution (TK A) Label"
+                        alt="TK Attribution Label icon. Black tag shape with two stacked white arrows, one pointing left and one pointing right."
                     {% endif %}
                     {% if label_code == 'tkcl' %}
                         id="tkcl" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-clan.png' %}" 
-                        alt="TK Clan (TK CL) Label"
+                        alt="TK Clan Label icon. Black tag shape with a circle made of small white dots in the center."
                     {% endif %}
                     {% if label_code == 'tkf' %}
                         id="tkf" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-family.png' %}" 
-                        alt="TK Family (TK F) Label"
+                        alt="TK Family Label icon. Black tag shape with a circle made of alternating small and big white dots in the center."
                     {% endif %}
                     {% if label_code == 'tkmc' %}
                         id="tkmc" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-multiple-community.png' %}" 
-                        alt="TK Multiple Communities (TK MC) Label"
+                        alt="TK Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square."
                     {% endif %}
                     {% if label_code == 'tko' %}
                         id="tko" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-outreach.png' %}" 
-                        alt="TK Outreach (TK O) Label"
+                        alt="TK Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger."
                     {% endif %}
                     {% if label_code == 'tknv' %}
                         id="tknv" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-non-verified.png' %}" 
-                        alt="TK Non-Verified (TK NV) Label"
+                        alt="TK Non-Verified Label icon. Black tag shape with a white checkmark and diagonal line through it in center."
                     {% endif %}
                     {% if label_code == 'tkv' %}
                         id="tkv" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-verified.png' %}" 
-                        alt="TK Verified (TK V) Label"
+                        alt="TK Verified Label icon. Black tag shape with a white checkmark in center."
                     {% endif %}
                     {% if label_code == 'tknc' %}
                         id="tknc" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-non-commercial.png' %}" 
-                        alt="TK Non-Commercial (TK NC) Label"
+                        alt="TK Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center."
                     {% endif %}
                     {% if label_code == 'tkoc' %}
                         id="tkoc" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-commercial.png' %}" 
-                        alt="TK Open to Commercialization (TK OC) Label"
+                        alt="TK Open to Commercialization Label icon. Black tag shape with a white dollar sign in center."
                     {% endif %}
                     {% if label_code == 'tkcs' %}
                         id="tkcs" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-culturally-sensitive.png' %}" 
-                        alt="TK Culturally Sensitive (TK CS) Label"
+                        alt="TK Culturally Sensitive Label icon. Black tag shape with four hands in a circle surrounding a white cube."
                     {% endif %}
                     {% if label_code == 'tkcv' %}
                         id="tkcv" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-community-voice.png' %}" 
-                        alt="TK Community Voice (TK CV) Label" 
+                        alt="TK Community Voice Label icon. Black tag shape with three different sized human figures in white and dialogue bubbles that overlap." 
                     {% endif %}
                     {% if label_code == 'tkco' %}
                         id="tkco" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-community-use-only.png' %}" 
-                        alt="TK Community Use Only (TK CO) Label"
+                        alt="TK Community Use Only Label icon. Black tag shape with four criss-crossed white lines in center."
                     {% endif %}
                     {% if label_code == 'tks' %}
                         id="tks" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-seasonal.png' %}" 
-                        alt="TK Seasonal (TK S) Label"
+                        alt="TK Seasonal Label icon. Black background with simple illustrations of a tree with bare branches and another tree with a circle representing leaves."
                     {% endif %}
                     {% if label_code == 'tkwg' %}
                         id="tkwg" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-women-general.png' %}" 
-                        alt="TK Weomen General (TK WG) Label"
+                        alt="TK Women General Label icon. Black tag shape with a white figure made up of a triangle on bottom and circle on top."
                     {% endif %}
                     {% if label_code == 'tkmg' %}
                         id="tkmg" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-men-general.png' %}" 
-                        alt="TK Men General (TK MG) Label"
+                        alt="TK Men General Label icon. Black tag shape with a white figure made up of a square on bottom and circle on top."
                     {% endif %}
                     {% if label_code == 'tkmr' %}
                         id="tkmr" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-men-restricted.png' %}" 
-                        alt="TK Men Restricted (TK MR) Label"
+                        alt="TK Men Restricted Label icon. Black tag shape with two white figures made up of two squares on bottom and two circles on top with a double-sided arrow connecting both figures."
                     {% endif %}
                     {% if label_code == 'tkwr' %}
                         id="tkwr" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-women-restricted.png' %}" 
-                        alt="TK Women Restricted (TK WR) Label"
+                        alt="TK Women Restricted Label icon. Black tag shape with two white figures made up of two triangles on bottom and two circles on top with a double-sided arrow connecting both figures."
                     {% endif %}
                     {% if label_code == 'tkss' %}
                         id="tkss" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-secret-sacred.png' %}" 
-                        alt="TK Secret Sacred (TK SS) Label"
+                        alt="TK Secret / Sacred Label icon. Black tag shape with a large white cube in center."
                     {% endif %}
                     {% if label_code == 'tkcb' %}
                         id="tkcb" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-open-to-collaboration.png' %}" 
-                        alt="TK Open to Collaboration (TK CB) Label"
+                        alt="TK Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top."
                     {% endif %}
                     {% if label_code == 'tkcr' %}
                         id="tkcr" 
                         class="label-large" 
                         src="{% static 'images/tk-labels/tk-creative.png' %}" 
-                        alt="TK Creative (TK CR) Label"
+                        alt="TK Creative Label icon. Black tag shape with a white circle made up of eight small dots on one half, a solid line on the other half, and each half bifurcated with two bigger dots."
                     {% endif %}
                 >
             </div>

--- a/templates/communities/select-label.html
+++ b/templates/communities/select-label.html
@@ -412,7 +412,7 @@
                         <div class="toggle-txt-color grey-text"><p>TK Non-Verified <br> (TK NV) </p></div>
                     </div>
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tks" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-seasonal.png' %}" alt="TK Seasonal Label icon. Black background with simple illustrations of a tree with bare branches and another tree with a circle representing leaves.></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tks" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-seasonal.png' %}" alt="TK Seasonal Label icon. Black background with simple illustrations of a tree with bare branches and another tree with a circle representing leaves."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Seasonal <br> (TK S) </p></div>
                     </div>
     

--- a/templates/communities/select-label.html
+++ b/templates/communities/select-label.html
@@ -126,7 +126,7 @@
     {% for bclabel in bclabels %}
         <div id="open-div-{{ bclabel.unique_id }}" style="height: 0px; overflow: hidden;" class="div-toggle">
             <div class="full-label-card flex-this">
-                <div class="margin-right-16"><img src="{{bclabel.img_url}}" class="label-large pointer-event-none" alt="{{ bclabel.name }} Label"></div>
+                <div class="margin-right-16"><img src="{{bclabel.img_url}}" class="label-large pointer-event-none" alt="{{ bclabel.alt_text }}"></div>
                 <div>
                     <div class="flex-this space-between">
                         <div><h3 class="no-top-margin">{{ bclabel.name }}</h3></div>
@@ -185,7 +185,7 @@
         <div id="open-div-{{ tklabel.unique_id }}" style="height: 0px; overflow: hidden;" class="div-toggle">
             <div class="full-label-card flex-this">
                 <div class="margin-right-16">
-                    <img src="{{ tklabel.img_url }}" class="label-large  pointer-event-none" alt="{{ tklabel.name }} Label">
+                    <img src="{{ tklabel.img_url }}" class="label-large  pointer-event-none" alt="{{ tklabel.alt_text }}">
                 </div>
                 <div>
                     <div class="flex-this space-between">
@@ -297,34 +297,34 @@
 
                     <div class="center-text w-15 margin-right-1 margin-left-1">
                         <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))">
-                            <img loading="lazy" id="tka" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-attribution.png' %}" alt="TK Attribution (TK A) Label">
+                            <img loading="lazy" id="tka" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-attribution.png' %}" alt="TK Attribution Label icon. Black tag shape with two stacked white arrows, one pointing left and one pointing right.">
                         </div>
                         <div class="toggle-txt-color grey-text"><p>TK Attribution <br> (TK A) </p></div>
                     </div>
             
                     <div class="center-text w-15 margin-right-1 margin-left-1">
                         <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))">
-                            <img loading="lazy" id="tkcl" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-clan.png' %}" alt="TK Clan (TK CL) Label"></div>
+                            <img loading="lazy" id="tkcl" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-clan.png' %}" alt="TK Clan Label icon. Black tag shape with a circle made of small white dots in the center."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Clan <br> (TK CL)</p></div>
                     </div>
             
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkf" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-family.png' %}" alt="TK Family (TK F) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkf" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-family.png' %}" alt="TK Family Label icon. Black tag shape with a circle made of alternating small and big white dots in the center."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Family (TK F) </p></div>
                     </div>
             
                     <div class="center-text w-15 margin-right-1 margin-left-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmc" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-multiple-community.png' %}" alt="TK Multiple Communities (TK MC) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmc" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-multiple-community.png' %}" alt="TK Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Multiple <br>Communities <br> (TK MC)</p></div>
                     </div>
 
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcv" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-community-voice.png' %}" alt="TK Community Voice (TK CV) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcv" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-community-voice.png' %}" alt="TK Community Voice Label icon. Black tag shape with three different sized human figures in white and dialogue bubbles that overlap."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Community Voice <br> (TK CV) </p></div>
                     </div>
 
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcr" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-creative.png' %}" alt="TK Creative (TK CR) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcr" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-creative.png' %}" alt="TK Creative Label icon. Black tag shape with a white circle made up of eight small dots on one half, a solid line on the other half, and each half bifurcated with two bigger dots."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Creative <br> (TK CR) </p></div>
                     </div>
 
@@ -337,22 +337,22 @@
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
 
                         <div id="tklabel-expanded-img-tka" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tka' %}" class="default-label-img pointer-event-none" alt="TK Attribution (TK A) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tka' %}" class="default-label-img pointer-event-none" alt="TK Attribution Label icon. Black tag shape with two stacked white arrows, one pointing left and one pointing right.">
                         </div>
                         <div id="tklabel-expanded-img-tkcl" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcl' %}" class="default-label-img pointer-event-none" alt="TK Clan (TK CL) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcl' %}" class="default-label-img pointer-event-none" alt="TK Clan Label icon. Black tag shape with a circle made of small white dots in the center.">
                         </div>
                         <div id="tklabel-expanded-img-tkf" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkf' %}" class="default-label-img pointer-event-none" alt="TK Family (TK F) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkf' %}" class="default-label-img pointer-event-none" alt="TK Family Label icon. Black tag shape with a circle made of alternating small and big white dots in the center.">
                         </div>
                         <div id="tklabel-expanded-img-tkmc" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmc' %}" class="default-label-img pointer-event-none" alt="TK Multiple Communities (TK MC) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmc' %}" class="default-label-img pointer-event-none" alt="TK Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square.">
                         </div>
                         <div id="tklabel-expanded-img-tkcv" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcv' %}" class="default-label-img pointer-event-none" alt="TK Community Voice (TK CV) Label ">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcv' %}" class="default-label-img pointer-event-none" alt="TK Community Voice Label icon. Black tag shape with three different sized human figures in white and dialogue bubbles that overlap.">
                         </div>
                         <div id="tklabel-expanded-img-tkcr" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcr' %}" class="default-label-img pointer-event-none" alt="TK Creative (TK CR) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcr' %}" class="default-label-img pointer-event-none" alt="TK Creative Label icon. Black tag shape with a white circle made up of eight small dots on one half, a solid line on the other half, and each half bifurcated with two bigger dots.">
                         </div>
                         
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -403,46 +403,46 @@
 
                 <div class="w-100 flex-this wrap">
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkv" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-verified.png' %}" alt="TK Verified (TK V) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkv" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-verified.png' %}" alt="TK Verified Label icon. Black tag shape with a white checkmark in center."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Verified <br> (TK V) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tknv" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-non-verified.png' %}" alt="TK Non-Verified (TK NV) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tknv" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-non-verified.png' %}" alt="TK Non-Verified Label icon. Black tag shape with a white checkmark and diagonal line through it in center."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Non-Verified <br> (TK NV) </p></div>
                     </div>
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tks" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-seasonal.png' %}" alt="TK Seasonal (TK S) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tks" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-seasonal.png' %}" alt="TK Seasonal Label icon. Black background with simple illustrations of a tree with bare branches and another tree with a circle representing leaves.></div>
                         <div class="toggle-txt-color grey-text"><p>TK Seasonal <br> (TK S) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkwg" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-women-general.png' %}" alt="TK Weomen General (TK WG) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkwg" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-women-general.png' %}" alt="TK Women General Label icon. Black tag shape with a white figure made up of a triangle on bottom and circle on top."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Women General <br> (TK WG) </p></div>
                     </div>
         
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmg" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-men-general.png' %}" alt="TK Men General (TK MG) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmg" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-men-general.png' %}" alt="TK Men General Label icon. Black tag shape with a white figure made up of a square on bottom and circle on top."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Men General <br> (TK MG) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmr" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-men-restricted.png' %}" alt="TK Men Restricted (TK MR) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkmr" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-men-restricted.png' %}" alt="TK Men Restricted Label icon. Black tag shape with two white figures made up of two squares on bottom and two circles on top with a double-sided arrow connecting both figures."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Men Restricted <br> (TK MR) </p></div>
                     </div>
         
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkwr" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-women-restricted.png' %}" alt="TK Women Restricted (TK WR) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkwr" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-women-restricted.png' %}" alt="TK Women Restricted Label icon. Black tag shape with two white figures made up of two triangles on bottom and two circles on top with a double-sided arrow connecting both figures."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Women Restricted <br> (TK WR) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcs" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-culturally-sensitive.png' %}" alt="TK Culturally Sensitive (TK CS) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcs" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-culturally-sensitive.png' %}" alt="TK Culturally Sensitive Label icon. Black tag shape with four hands in a circle surrounding a white cube."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Culturally <br> Sensitive <br> (TK CS) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkss" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-secret-sacred.png' %}" alt="TK Secret Sacred (TK SS) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkss" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-secret-sacred.png' %}" alt="TK Secret / Sacred Label icon. Black tag shape with a large white cube in center."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Secret Sacred <br> (TK SS) </p></div>
                     </div>
                 </div>
@@ -454,31 +454,31 @@
                 <div class="flex-this">
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
                         <div id="tklabel-expanded-img-tknv" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tknv' %}" class="default-label-img pointer-event-none" alt="TK Non-Verified (TK NV) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tknv' %}" class="default-label-img pointer-event-none" alt="TK Non-Verified Label icon. Black tag shape with a white checkmark and diagonal line through it in center.">
                         </div>
                         <div id="tklabel-expanded-img-tkv" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkv' %}" class="default-label-img pointer-event-none" alt="TK Verified (TK V) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkv' %}" class="default-label-img pointer-event-none" alt="TK Verified Label icon. Black tag shape with a white checkmark in center.">
                         </div>
                         <div id="tklabel-expanded-img-tks" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tks' %}" class="default-label-img pointer-event-none" alt="TK Seasonal (TK S) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tks' %}" class="default-label-img pointer-event-none" alt="TK Seasonal Label icon. Black background with simple illustrations of a tree with bare branches and another tree with a circle representing leaves.">
                         </div>
                         <div id="tklabel-expanded-img-tkwg" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkwg' %}" class="default-label-img pointer-event-none" alt="TK Weomen General (TK WG) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkwg' %}" class="default-label-img pointer-event-none" alt="TK Women General Label icon. Black tag shape with a white figure made up of a triangle on bottom and circle on top.">
                         </div>
                         <div id="tklabel-expanded-img-tkmg" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmg' %}" class="default-label-img pointer-event-none" alt="TK Men General (TK MG) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmg' %}" class="default-label-img pointer-event-none" alt="TK Men General Label icon. Black tag shape with a white figure made up of a square on bottom and circle on top.">
                         </div>
                         <div id="tklabel-expanded-img-tkmr" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmr' %}" class="default-label-img pointer-event-none" alt="TK Men Restricted (TK MR) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkmr' %}" class="default-label-img pointer-event-none" alt="TK Men Restricted Label icon. Black tag shape with two white figures made up of two squares on bottom and two circles on top with a double-sided arrow connecting both figures.">
                         </div>
                         <div id="tklabel-expanded-img-tkwr" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkwr' %}" class="default-label-img pointer-event-none" alt="TK Women Restricted (TK WR) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkwr' %}" class="default-label-img pointer-event-none" alt="TK Women Restricted Label icon. Black tag shape with two white figures made up of two triangles on bottom and two circles on top with a double-sided arrow connecting both figures.">
                         </div>
                         <div id="tklabel-expanded-img-tkcs" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcs' %}" class="default-label-img pointer-event-none" alt="TK Culturally Sensitive (TK CS) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcs' %}" class="default-label-img pointer-event-none" alt="TK Culturally Sensitive Label icon. Black tag shape with four hands in a circle surrounding a white cube.">
                         </div>
                         <div id="tklabel-expanded-img-tkss" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkss' %}" class="default-label-img pointer-event-none" alt="TK Secret Sacred (TK SS) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkss' %}" class="default-label-img pointer-event-none" alt="TK Secret / Sacred Label icon. Black tag shape with a large white cube in center.">
                         </div>
 
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -529,27 +529,27 @@
                 <div class="flex-this wrap">
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkoc" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-commercial.png' %}" alt="TK Open to Commercialization (TK OC) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkoc" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-commercial.png' %}" alt="TK Open to Commercialization Label icon. Black tag shape with a white dollar sign in center."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Open to Commercialization <br> (TK OC) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tknc" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-non-commercial.png' %}" alt="TK Non-Commercial (TK NC) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tknc" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-non-commercial.png' %}" alt="TK Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Non-Commercial <br> (TK NC) </p></div>
                     </div>
         
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkco" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-community-use-only.png' %}" alt="TK Community Use Only (TK CO) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkco" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-community-use-only.png' %}" alt="TK Community Use Only Label icon. Black tag shape with four criss-crossed white lines in center."></div>
                         <div class="toggle-txt-color grey-text"><p>TK Community Use <br> Only <br> (TK CO) </p></div>
                     </div>
     
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tko" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-outreach.png' %}" alt="TK Outreach (TK O) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tko" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-outreach.png' %}" alt="TK Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger."></div>
                         <div class="toggle-txt-color grey-text"><p> TK Outreach <br> (TK O)</p></div>
                     </div>
 
                     <div class="center-text w-15 margin-left-1 margin-right-1">
-                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcb" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-open-to-collaboration.png' %}" alt="TK Open to Collaboration (TK CB) Label"></div>
+                        <div class="image-container pointer" onclick="expandTKLabel(event.target.querySelector('img'))"><img loading="lazy" id="tkcb" class="default-label-img pointer-event-none" src="{% static 'images/tk-labels/tk-open-to-collaboration.png' %}" alt="TK Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top."></div>
                         <div class="toggle-txt-color grey-text"><p> TK Open to Collaboration <br> (TK CB)</p></div>
                     </div>
 
@@ -562,19 +562,19 @@
                 <div class="flex-this">
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
                         <div id="tklabel-expanded-img-tko" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tko' %}" class="default-label-img pointer-event-none" alt="TK Outreach (TK O) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tko' %}" class="default-label-img pointer-event-none" alt="TK Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger.">
                         </div>
                         <div id="tklabel-expanded-img-tknc" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tknc' %}" class="default-label-img pointer-event-none" alt="TK Non-Commercial (TK NC) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tknc' %}" class="default-label-img pointer-event-none" alt="TK Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center.">
                         </div>
                         <div id="tklabel-expanded-img-tkoc" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkoc' %}" class="default-label-img  pointer-event-none" alt="TK Open to Commercialization (TK OC) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkoc' %}" class="default-label-img  pointer-event-none" alt="TK Open to Commercialization Label icon. Black tag shape with a white dollar sign in center.">
                         </div> 
                         <div id="tklabel-expanded-img-tkco" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkco' %}" class="default-label-img  pointer-event-none" alt="TK Community Use Only (TK CO) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkco' %}" class="default-label-img  pointer-event-none" alt="TK Community Use Only Label icon. Black tag shape with four criss-crossed white lines in center.">
                         </div>
                         <div id="tklabel-expanded-img-tkcb" class="tk-img-div hide">
-                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcb' %}" class="default-label-img pointer-event-none" alt="TK Open to Collaboration (TK CB) Label">
+                            <img loading="lazy" src="{% get_tklabel_img_url 'tkcb' %}" class="default-label-img pointer-event-none" alt="TK Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top.">
                         </div>
 
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -656,17 +656,17 @@
             <div class="flex-this wrap w-100">
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcp" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-provenance.png' %}" alt="BC Provenance (BC P) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcp" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-provenance.png' %}" alt="BC Provenance Label icon. Black tag shape with six perpendicular white lines of increasing width. On left side are three white dots."></div>
                     <div class="toggle-txt-color grey-text"><p> Provenance <br> (BC P)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcmc" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-multiple-community.png' %}" alt="BC Multiple Communities (BC MC) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcmc" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-multiple-community.png' %}" alt="BC Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square. On left side are three white dots."></div>
                     <div class="toggle-txt-color grey-text"><p>Multiple Communities <br> (BC MC)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccl" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-clan.png' %}" alt="BC Clan (BC CL) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccl" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-clan.png' %}" alt="BC Clan Label icon. Black tag shape with a circle made of small white dots in center. On left side are three larger white dots."></div>
                     <div class="toggle-txt-color grey-text"><p>Clan <br> (BC CL)</p></div>
                 </div>
 
@@ -677,15 +677,15 @@
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
         
                         <div id="bclabel-expanded-img-bcp" class="bc-img-div hide">
-                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcp' %}" alt="BC Provenance (BC P) Label">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcp' %}" alt="BC Provenance Label icon. Black tag shape with six perpendicular white lines of increasing width. On left side are three white dots.">
                         </div>
         
                         <div id="bclabel-expanded-img-bcmc" class="bc-img-div hide">
-                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcmc' %}"  alt="BC Multiple Communities (BC MC) Label">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcmc' %}"  alt="BC Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square. On left side are three white dots.">
                         </div>
         
                         <div id="bclabel-expanded-img-bccl" class="bc-img-div hide">
-                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccl' %}"  alt="BC Clan (BC CL) Label">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccl' %}"  alt="BC Clan Label icon. Black tag shape with a circle made of small white dots in center. On left side are three larger white dots.">
                         </div>
         
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -736,12 +736,12 @@
             <div class="flex-this wrap w-100">
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccv" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-consent-verified.png' %}" alt="BC Consent Verified (BC CV) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccv" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-consent-verified.png' %}" alt="BC Consent Verified Label icon. Black tag shape with a white checkmark in center. On left side are three white dots."></div>
                     <div class="toggle-txt-color grey-text"><p>Consent Verified <br> (BC CV) </p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccnv" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-consent-non-verified.png' %}" alt="BC Consent Non-Verified (BC CNV) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccnv" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-consent-non-verified.png' %}" alt="BC Consent Non-Verified Label icon. Black tag shape with a white checkmark and a diagonal line through it in the center. On left side are three white dots."></div>
                     <div class="toggle-txt-color grey-text"><p>Consent Non-Verified <br> (BC CNV) </p></div>
                 </div>
             </div>
@@ -751,11 +751,11 @@
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
         
                         <div id="bclabel-expanded-img-bccv" class="bc-img-div hide">
-                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccv' %}" alt="BC Consent Verified (BC CV) Label">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccv' %}" alt="BC Consent Verified Label icon. Black tag shape with a white checkmark in center. On left side are three white dots.">
                         </div>
         
                         <div id="bclabel-expanded-img-bccnv" class="bc-img-div hide">
-                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccnv' %}" alt="BC Consent Non-Verified (BC CNV) Label">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccnv' %}" alt="BC Consent Non-Verified Label icon. Black tag shape with a white checkmark and a diagonal line through it in the center. On left side are three white dots.">
                         </div>
         
                         <!-- <div><button class="primary-btn green-btn primary-btn green-btn-default-size">Listen <i class="fa fa-volume-up"></i></button></div> -->
@@ -806,27 +806,27 @@
             <div class="flex-this wrap w-100">
     
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcr" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-research-use.png' %}" alt="BC Research Use (BC R) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcr" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-research-use.png' %}" alt="BC Research Use Label icon. Black tag shape with four rectangles inside two concentric circles. On left side are three white dots."></div>
                     <div class="toggle-txt-color grey-text"><p>Research Use <br> (BC R) </p></div>
                 </div>
     
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccb" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-collaboration.png' %}" alt="BC Open to Collaboration (BC CB) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bccb" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-collaboration.png' %}" alt="BC Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top. On left side are three white dots."></div>
                     <div class="toggle-txt-color grey-text"><p>Open to <br>Collaboration <br> (BC CB) </p></div>
                 </div>
     
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcoc" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" alt="BC Open to Commercialization (BC OC) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcoc" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-open-to-commercialization.png' %}" alt="BC Open to Commercialization Label icon. Black tag shape with a white dollar sign in center. On left side are three white dots."></div>
                     <div class="toggle-txt-color grey-text"><p>Open to <br>Commercialization <br> (BC OC)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bco" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-outreach.png' %}" alt="BC Outreach (BC O) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bco" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-outreach.png' %}" alt="BC Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger. On left side are three white dots."></div>
                     <div class="toggle-txt-color grey-text"><p>Outreach <br> (BC O)</p></div>
                 </div>
 
                 <div class="center-text w-15 margin-left-1 margin-right-1">
-                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcnc" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-non-commercial.png' %}" alt="BC Non-Commercial (BC NC) Label"></div>
+                    <div class="image-container pointer" onclick="expandBCLabel(event.target.querySelector('img'))"><img loading="lazy" id="bcnc" class="default-label-img pointer-event-none" src="{% static 'images/bc-labels/bc-non-commercial.png' %}" alt="BC Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center. On left side are three white dots."></div>
                     <div class="toggle-txt-color grey-text"><p>Non-Commercial <br> (BC NC)</p></div>
                 </div>
 
@@ -840,23 +840,23 @@
                     <div class="w-20 margin-right-1 margin-top-1" style="text-align: right;">
 
                         <div id="bclabel-expanded-img-bcr" class="bc-img-div hide">
-                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcr' %}" alt="BC Research Use (BC R) Label">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcr' %}" alt="BC Research Use Label icon. Black tag shape with four rectangles inside two concentric circles. On left side are three white dots.">
                         </div>
 
                         <div id="bclabel-expanded-img-bccb" class="bc-img-div hide">
-                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccb' %}" alt="BC Open to Collaboration (BC CB) Label">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bccb' %}" alt="BC Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top. On left side are three white dots.">
                         </div>
 
                         <div id="bclabel-expanded-img-bcoc" class="bc-img-div hide">
-                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcoc' %}" alt="BC Open to Commercialization (BC OC) Label">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcoc' %}" alt="BC Open to Commercialization Label icon. Black tag shape with a white dollar sign in center. On left side are three white dots.">
                         </div>
 
                         <div id="bclabel-expanded-img-bco" class="bc-img-div hide">
-                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bco' %}" alt="BC Outreach (BC O) Label">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bco' %}" alt="BC Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger. On left side are three white dots.">
                         </div>
 
                         <div id="bclabel-expanded-img-bcnc" class="bc-img-div hide">
-                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcnc' %}" alt="BC Non-Commercial (BC NC) Label">
+                            <img class="default-label-img pointer-event-none" loading="lazy" src="{% get_bclabel_img_url 'bcnc' %}" alt="BC Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center. On left side are three white dots.">
                         </div>
                     </div>
 

--- a/templates/partials/_notices.html
+++ b/templates/partials/_notices.html
@@ -43,7 +43,7 @@
         </div>
     </div>
     <div class="flex-this">
-        <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="119px" alt="black square with a rectangle and on hand on top and bottom in the middle in white"></div>
+        <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="119px" alt="Open to Collaborate Notice icon. Black square with the top right corner folded and two white hands reaching toward each other from top to bottom over a white horizontal rectangle."></div>
         <div class="flex-this column margin-left-16">
             <div class="w-90">
                 <h3 class="no-top-margin">Open to Collaborate</h3>
@@ -135,16 +135,16 @@
 
     <div class="flex-this justify-center">
         <div id="disclosureTK" class="cc-notice__container" onclick="expandDisclosureNotice(this)">
-            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="119px" alt="black square with the letters TK in the middle in white"></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="119px" alt="TK Notice icon. Black background with the top right corner folded and the letters “TK” in white in center."></div>
             <div><p>Traditional Knowledge</p></div>
         </div>
         <div id="disclosureBC" class="cc-notice__container" onclick="expandDisclosureNotice(this)">
-            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="119px" alt="black square with the letters BC in the middle in white"></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="119px" alt="BC Notice icon. Black background with the top right corner folded and the letters “BC” in white in center."></div>
             <div><p>Biocultural</p></div>
         </div>
         
         <div id="disclosureAI" class="cc-notice__container" onclick="expandDisclosureNotice(this)">
-            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="black square with an unfinished square in the middle in white"></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="Attribution Incomplete Notice icon. Black square with the top right corner folded and a white square in center with left side in solid line and right side in dotted line."></div>
             <div><p>Attribution Incomplete</p></div>
         </div>
     </div>
@@ -153,7 +153,7 @@
 
         <div id="openDiv-disclosureTK" class="disclosure-notice__expanded-container hide">
             <div class="flex-this">
-                <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="black square with the letters TK in the middle in white"></div>
+                <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="TK Notice icon. Black background with the top right corner folded and the letters “TK” in white in center."></div>
                 <div class="flex-this column margin-left-16">
                     <div class="w-90">
                         <h2 class="no-top-margin">Traditional Knowledge Notice</h2>
@@ -175,7 +175,7 @@
 
         <div id="openDiv-disclosureBC" class="disclosure-notice__expanded-container hide">
             <div class="flex-this">
-                <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" alt="black square with the letters BC in the middle in white"></div>
+                <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" alt="BC Notice icon. Black background with the top right corner folded and the letters “BC” in white in center."></div>
                 <div class="flex-this column margin-left-16">
                     <div class="w-90">
                         <h2 class="no-top-margin">Biocultural Notice</h2>
@@ -197,7 +197,7 @@
 
         <div id="openDiv-disclosureAI" class="disclosure-notice__expanded-container hide">
             <div class="flex-this">
-                <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="black square with an unfinished square in the middle in white"></div>
+                <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="Attribution Incomplete Notice icon. Black square with the top right corner folded and a white square in center with left side in solid line and right side in dotted line."></div>
                 <div class="flex-this column margin-left-16">
                     <div class="w-90">
                         <h2 class="no-top-margin">Attribution Incomplete Notice</h2>
@@ -254,7 +254,7 @@
             </div>
         </div>
         <div class="flex-this">
-            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-overall-notice.png' %}" width="119px" alt="Icon for Collection Care Notice. Abstract design with the letter L and C in the dotted black circle."></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-overall-notice.png' %}" width="119px" alt="Overall Collections Care Notice icon. White square with top right corner folded. Inside is a circle outline made of different sized dots around “LC”."></div>
             <div class="flex-this column margin-left-16">
                 <div class="w-80">
                     <p>
@@ -280,45 +280,45 @@
 
                     <div class="flex-this space-between">
                         <div id="authorization" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-authorization.png' %}" width="119px" alt="Icon for Authorization Notice. Abstract design within a white square. Black circle above a set of three curved black lines with one curved black line below."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-authorization.png' %}" width="119px" alt="Authorization Collections Care Notice icon. White square with top right corner folded. Inside are three black lines from the left edge curving up to cradle a black circle and one black line from bottom right edge curving up."></div>
                             <div><p>Authorization</p></div>
                         </div>
                         <div id="belonging" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-belonging.png' %}" width="119px" alt="Icon for Belonging Notice. Abstract design within a white square. Three layered sets of black circles with two curved black lines representing three people."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-belonging.png' %}" width="119px" alt="Belonging Collections Care Notice icon. White square with top right corner folded. Inside are three black circles in descending size from top to bottom, each with two lines like arms extending down to touch the figure below."></div>
                             <div><p>Belonging</p></div>
                         </div>
                         
                         <div id="caring" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-caring.png' %}" width="119px" alt="Icon for Caring Notice. Abstract design within a white square. Two curved black lines surround a black circle."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-caring.png' %}" width="119px" alt="Caring Collections Care Notice icon. White square with top right corner folded. Inside are two wave-like curved lines extending from the edge toward the center which curve around a black circle."></div>
                             <div><p>Caring</p></div>
                         </div>
                     
                         <div id="gender-aware" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-gender-aware.png' %}" width="119px" alt="Icon for Gender Aware Notice. Abstract design within a white square. Three circles in a diagonal line: A black outlined circle, a black filled circle, and a striped black and white circle."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-gender-aware.png' %}" width="119px" alt="Gender Aware Collections Care Notice icon. White square with top right corner folded. Inside are three circles in a diagonal. One has white shading, one has black shading, one has striped shading."></div>
                             <div><p>Gender Aware</p></div>
                         </div>
                     </div>
                     <div class="flex-this space-between">
                         <div id="leave-undisturbed" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-leave-undisturbed.png' %}" width="119px" alt="Icon for Leave Undisturbed Notice. Abstract design within a white square. A black circle in the center of two curved black lines which form a struck-through circle."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-leave-undisturbed.png' %}" width="119px" alt="Leave Undisturbed Collections Care Notice icon. White square with top right corner folded. Circle outline made of two black lines that radiate from a central black circle at center and curve to form the outline."></div>
                             <div><p>Leave Undisturbed</p></div>
                         </div>
                         <div id="safety" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-safety.png' %}" width="119px" alt="Icon for Safety Notice. Abstract design within a white square. A black circle in the center of three curved black lines which form a circle."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-safety.png' %}" width="119px" alt="Safety Collections Care Notice icon. White square with top right corner folded. Inside is a circle made of three black curved lines surrounding a black circle."></div>
                             <div><p>Safety</p></div>
                         </div>
                         <div id="viewing" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-viewing.png' %}" width="119px" alt="Icon for Viewing Notice. Abstract design within a white square. A black circle in the center of two curved lines, forming an abstract eye."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-viewing.png' %}" width="119px" alt="Viewing Collections Care Notice icon. White square with top right corner folded. Insides are two horizontal curved black lines surrounding a small black circle."></div>
                             <div><p>Viewing</p></div>
                         </div>
                         <div id="withholding" class="cc-notice__container" onclick="expandCCNotice(this)">
-                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-withholding.png' %}" width="119px" alt="Icon for Withholding Notice. Abstract design within a white square. A black circle in the center of two curved lines."></div>
+                            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-withholding.png' %}" width="119px" alt="Withholding Collections Care Notice icon. White square with top right corner folded. Inside are two curved black lines from the bottom edge surrounding a small black circle."></div>
                             <div><p>Withholding</p></div>
                         </div>
                     </div>
 
                     <div id="openDiv-authorization" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-authorization.png' %}" width="119px" alt="Icon for Authorization Notice. Abstract design within a white square. Black circle above a set of three curved black lines with one curved black line below."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-authorization.png' %}" width="119px" alt="Authorization Collections Care Notice icon. White square with top right corner folded. Inside are three black lines from the left edge curving up to cradle a black circle and one black line from bottom right edge curving up."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Authorization</h2></div>
 
@@ -334,7 +334,7 @@
                     </div>
 
                     <div id="openDiv-belonging" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-belonging.png' %}" width="119px" alt="Icon for Belonging Notice. Abstract design within a white square. Three layered sets of black circles with two curved black lines representing three people."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-belonging.png' %}" width="119px" alt="Belonging Collections Care Notice icon. White square with top right corner folded. Inside are three black circles in descending size from top to bottom, each with two lines like arms extending down to touch the figure below."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Belonging</h2></div>
 
@@ -349,7 +349,7 @@
                     </div>
 
                     <div id="openDiv-caring" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-caring.png' %}" width="119px" alt="Icon for Caring Notice. Abstract design within a white square. Two curved black lines surround a black circle."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-caring.png' %}" width="119px" alt="Caring Collections Care Notice icon. White square with top right corner folded. Inside are two wave-like curved lines extending from the edge toward the center which curve around a black circle."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Caring</h2></div>
 
@@ -364,7 +364,7 @@
                     </div>
 
                     <div id="openDiv-gender-aware" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-gender-aware.png' %}" width="119px" alt="Icon for Gender Aware Notice. Abstract design within a white square. Three circles in a diagonal line: A black outlined circle, a black filled circle, and a striped black and white circle."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-gender-aware.png' %}" width="119px" alt="Gender Aware Collections Care Notice icon. White square with top right corner folded. Inside are three circles in a diagonal. One has white shading, one has black shading, one has striped shading."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Gender Aware</h2></div>
 
@@ -379,7 +379,7 @@
                     </div>
 
                     <div id="openDiv-leave-undisturbed" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-leave-undisturbed.png' %}" width="119px" alt="Icon for Leave Undisturbed Notice. Abstract design within a white square. A black circle in the center of two curved black lines which form a struck-through circle."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-leave-undisturbed.png' %}" width="119px" alt="Leave Undisturbed Collections Care Notice icon. White square with top right corner folded. Circle outline made of two black lines that radiate from a central black circle at center and curve to form the outline."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Leave Undisturbed</h2></div>
 
@@ -394,7 +394,7 @@
                     </div>
 
                     <div id="openDiv-safety" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-safety.png' %}" width="119px" alt="Icon for Safety Notice. Abstract design within a white square. A black circle in the center of three curved black lines which form a circle."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-safety.png' %}" width="119px" alt="Safety Collections Care Notice icon. White square with top right corner folded. Inside is a circle made of three black curved lines surrounding a black circle."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Safety</h2></div>
 
@@ -409,7 +409,7 @@
                     </div>
 
                     <div id="openDiv-viewing" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-viewing.png' %}" width="119px" alt="Icon for Viewing Notice. Abstract design within a white square. A black circle in the center of two curved lines, forming an abstract eye."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-viewing.png' %}" width="119px" alt="Viewing Collections Care Notice icon. White square with top right corner folded. Insides are two horizontal curved black lines surrounding a small black circle."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Viewing</h2></div>
 
@@ -425,7 +425,7 @@
                     </div>
 
                     <div id="openDiv-withholding" class="flex-this cc-notice__expanded-container hide">
-                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-withholding.png' %}" width="119px" alt="Icon for Withholding Notice. Abstract design within a white square. A black circle in the center of two curved lines."></div>
+                        <div class="cc-notice__expanded-img"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/collections-care/cc-withholding.png' %}" width="119px" alt="Withholding Collections Care Notice icon. White square with top right corner folded. Inside are two curved black lines from the bottom edge surrounding a small black circle."></div>
                         <div class="cc-notice__expanded-text">
                             <div><h2 class="no-top-margin">Withholding</h2></div>
 

--- a/templates/partials/_project-actions.html
+++ b/templates/partials/_project-actions.html
@@ -265,11 +265,11 @@
                             <div>
                                 <div class="margin-top-16">
                                     {% if notice.notice_type == 'biocultural' %}
-                                    <img class="pointer-event-none" loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="black square with white letters BC in the middle">
+                                    <img class="pointer-event-none" loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="BC Notice icon. Black background with the top right corner folded and the letters “BC” in white in center.">
                                     {% elif notice.notice_type == 'traditional_knowledge' %}
-                                    <img class="pointer-event-none" loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="black square with white letters TK in the middle">
+                                    <img class="pointer-event-none" loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="TK Notice icon. Black background with the top right corner folded and the letters “TK” in white in center.">
                                     {% else  %}
-                                    <img class="pointer-event-none" loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="black square with an unfinished square in the middle in white">
+                                    <img class="pointer-event-none" loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="Attribution Incomplete Notice icon. Black square with the top right corner folded and a white square in center with left side in solid line and right side in dotted line.">
                                     {% endif %}
                                 </div>
                                 <p>

--- a/templates/partials/_project-contributor-view.html
+++ b/templates/partials/_project-contributor-view.html
@@ -24,7 +24,7 @@
 
                     {% if notice.notice_type == 'biocultural' %}
                         <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                            <div class="w-15 pad-top-1"><img loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="black square with white letters BC in the middle"></div>
+                            <div class="w-15 pad-top-1"><img loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="BC Notice icon. Black background with the top right corner folded and the letters “BC” in white in center."></div>
                             <div class="w-80 pad-top-1">
                                 <h3 class="no-top-margin">Biocultural Notice</h3>
                                 <p>{{ notice.default_text}}</p>
@@ -34,7 +34,7 @@
 
                     {% if notice.notice_type == 'traditional_knowledge' %}
                         <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                            <div class="w-15 pad-top-1"><img loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="black square with white letters TK in the middle"></div>
+                            <div class="w-15 pad-top-1"><img loading="lazy" src="{{ notice.img_url }}" width="78" height="78" alt="TK Notice icon. Black background with the top right corner folded and the letters “TK” in white in center."></div>
                             <div class="w-80 pad-top-1">
                                 <h3 class="no-top-margin">Traditional Knowledge Notice</h3>
                                 <p>{{ notice.default_text}}</p>
@@ -44,7 +44,7 @@
 
                     {% if notice.notice_type == 'attribution_incomplete' %}
                         <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                            <div class="w-15 pad-top-1"><img loading="lazy" src="{{ notice.img_url }}" alt="black square with an unfinished square in the middle in white" width="78" height="78"></div>
+                            <div class="w-15 pad-top-1"><img loading="lazy" src="{{ notice.img_url }}" alt="Attribution Incomplete Notice icon. Black square with the top right corner folded and a white square in center with left side in solid line and right side in dotted line." width="78" height="78"></div>
                             <div class="w-80 pad-top-1">
                                 <h3 class="no-top-margin">Attribution Incomplete Notice</h3>
                                 <p>{{ notice.default_text}}</p>

--- a/templates/partials/infocards/_institution-card.html
+++ b/templates/partials/infocards/_institution-card.html
@@ -35,7 +35,7 @@
                         </div>
                         {% if institution.otc_institution_url.all %}
                             <div class="flex-this flex-end">
-                                <img class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="60px" alt="black square with white rectangle being held by two hands in the middle">
+                                <img class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="60px" alt="Open to Collaborate Notice icon. Black square with the top right corner folded and two white hands reaching toward each other from top to bottom over a white horizontal rectangle. ">
                             </div>
                         {% endif %}
                     </div>

--- a/templates/partials/infocards/_researcher-card.html
+++ b/templates/partials/infocards/_researcher-card.html
@@ -44,7 +44,7 @@
             class="pointer-event-none"
             src="{% static 'images/notices/ci-open-to-collaborate.png' %}"
             width="60px"
-            alt="black square with white rectangle being held by two hands in the middle"
+            alt="Open to Collaborate Notice icon. Black square with the top right corner folded and two white hands reaching toward each other from top to bottom over a white horizontal rectangle. "
           />
         </div>
         {% endif %} {% endif %}

--- a/templates/public.html
+++ b/templates/public.html
@@ -239,15 +239,15 @@
                 <h3>Notices Used</h3>
                 <div class="flex-this">
                     {% if bcnotice %} 
-                        <div class="margin-right-16"><img class="pointer-event-none" loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" width="90px" alt="black square with white letters BC in the middle"></div>
+                        <div class="margin-right-16"><img class="pointer-event-none" loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" width="90px" alt="BC Notice icon. Black background with the top right corner folded and the letters “BC” in white in center."></div>
                     {% endif %}
 
                     {% if tknotice %} 
-                        <div class="margin-right-16"><img class="pointer-event-none" loading="lazy" src="{% static 'images/notices/tk-notice.png' %}" width="90px" alt="black square with white letters TK in the middle"></div>
+                        <div class="margin-right-16"><img class="pointer-event-none" loading="lazy" src="{% static 'images/notices/tk-notice.png' %}" width="90px" alt="TK Notice icon. Black background with the top right corner folded and the letters “TK” in white in center."></div>
                     {% endif %}
 
                     {% if attrnotice %} 
-                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" alt="black square with an unfinished square in the middle in white" width="90px"></div>
+                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" alt="Attribution Incomplete Notice icon. Black square with the top right corner folded and a white square in center with left side in solid line and right side in dotted line." width="90px"></div>
                     {% endif %}
                     {% if not bcnotice and not tknotice and not attrnotice %} No Notices to display yet {% endif %}
                 </div>
@@ -257,7 +257,7 @@
                 <div class="flex-this column">
                     <h3>Open To Collaboration</h3>
                     <div class="flex-this">
-                        <div class="margin-right-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="90px" alt="black square with white rectangle being held by two hands in the middle"></div>
+                        <div class="margin-right-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="90px" alt="Open to Collaborate Notice icon. Black square with the top right corner folded and two white hands reaching toward each other from top to bottom over a white horizontal rectangle."></div>
                         <ul>
                             {% for notice in otc_notices %}
                                 <li>
@@ -360,15 +360,15 @@
                 <h3>Notices Used</h3>
                 <div class="flex-this">
                     {% if bcnotice %} 
-                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="90px" alt="black square with white letters BC in the middle"></div>
+                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="90px" alt="BC Notice icon. Black background with the top right corner folded and the letters “BC” in white in center."></div>
                     {% endif %}
 
                     {% if tknotice %} 
-                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="90px" alt="black square with white letters TK in the middle"></div>
+                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="90px" alt="TK Notice icon. Black background with the top right corner folded and the letters “TK” in white in center."></div>
                     {% endif %}
 
                     {% if attrnotice %} 
-                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" alt="black square with an unfinished square in the middle in white" width="90px"></div>
+                        <div class="margin-right-16"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" alt="Attribution Incomplete Notice icon. Black square with the top right corner folded and a white square in center with left side in solid line and right side in dotted line." width="90px"></div>
                     {% endif %}
                     {% if not bcnotice and not tknotice and not attrnotice %} No Notices to display yet {% endif %}
                 </div>
@@ -378,7 +378,7 @@
                 <div class="flex-this column">
                     <h3>Open To Collaboration</h3>
                     <div class="flex-this">
-                        <div class="margin-right-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="90px" alt="black square with white rectangle being held by two hands in the middle"></div>
+                        <div class="margin-right-8"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-open-to-collaborate.png' %}" width="90px" alt="Open to Collaborate Notice icon. Black square with the top right corner folded and two white hands reaching toward each other from top to bottom over a white horizontal rectangle. "></div>
                         <ul>
                             {% for notice in otc_notices %}
                                 <li>

--- a/templates/snippets/pdfs/community-labels.html
+++ b/templates/snippets/pdfs/community-labels.html
@@ -60,7 +60,7 @@
             {% for bclabel in bclabels %}
                 <tr>
                     <td class="image-td">
-                        <img loading="lazy" src="{{ bclabel.img_url }}" width="200px" alt="{{ bclabel.name }} Label">
+                        <img loading="lazy" src="{{ bclabel.img_url }}" width="200px" alt="{{ bclabel.alt_text }}">
                     </td>
                     <td class="text-td">
                         <h1 class="no-bottom-margin">{{ bclabel.name }}</h1>
@@ -78,7 +78,7 @@
             {% for tklabel in tklabels %}
                 <tr>
                     <td class="image-td">
-                        <img loading="lazy" src="{{ tklabel.img_url }}" width="200px" alt="{{ tklabel.name }} Label">
+                        <img loading="lazy" src="{{ tklabel.img_url }}" width="200px" alt="{{ tklabel.alt_text }}">
                     </td>
                     <td class="text-td">
                         <h1 class="no-bottom-margin">{{ tklabel.name }}</h1>

--- a/templates/snippets/pdfs/project-pdf.html
+++ b/templates/snippets/pdfs/project-pdf.html
@@ -126,7 +126,7 @@
                         {% if notice.notice_type == 'biocultural' %}
                             <tr>
                                 <td class="image-td">
-                                    <img loading="lazy" src="{{ notice.img_url }}" width="200px" alt="black square with white letters BC in the middle">
+                                    <img loading="lazy" src="{{ notice.img_url }}" width="200px" alt="BC Notice icon. Black background with the top right corner folded and the letters “BC” in white in center.">
                                 </td>
                                 <td class="text-td">
                                     <h1 class="no-bottom-margin">Biocultural Notice</h1>
@@ -137,7 +137,7 @@
                         {% if notice.notice_type == 'traditional_knowledge' %}
                             <tr>
                                 <td class="image-td">
-                                    <img loading="lazy" src="{{ notice.img_url }}" width="200px" alt="black square with white letters TK in the middle">
+                                    <img loading="lazy" src="{{ notice.img_url }}" width="200px" alt="TK Notice icon. Black background with the top right corner folded and the letters “TK” in white in center.">
                                 </td>
                                 <td class="text-td">
                                     <h1 class="no-bottom-margin">Traditional Knowledge Notice</h1>
@@ -148,7 +148,7 @@
                         {% if notice.notice_type == 'attribution_incomplete' %}
                             <tr>
                                 <td class="image-td">
-                                    <img loading="lazy" src="{{ notice.img_url }}" width="200px" alt="black square with an unfinished square in the middle in white">
+                                    <img loading="lazy" src="{{ notice.img_url }}" width="200px" alt="Attribution Incomplete Notice icon. Black square with the top right corner folded and a white square in center with left side in solid line and right side in dotted line.">
                                 </td>
                                 <td class="text-td">
                                     <h1 class="no-bottom-margin">Attribution Incomplete Notice</h1>
@@ -160,11 +160,11 @@
                 {% endfor %}
             {% endif %}
 
-            {% if project.bc_labels.all %}
-                {% for bclabel in project.bc_labels.all %}
+            {% if project_bclabels %}
+                {% for bclabel in project_bclabels %}
                     <tr>
                         <td class="image-td">
-                            <img loading="lazy" src="{{ bclabel.img_url }}" alt="{{ bclabel.name }} Label" width="200px">
+                            <img loading="lazy" src="{{ bclabel.img_url }}" alt="{{ bclabel.alt_text }}" width="200px">
                         </td>
                         <td class="text-td">
                             <h1 class="no-bottom-margin">{{ bclabel.name }} ({{ bclabel.community.community_name }})</h1>
@@ -181,11 +181,11 @@
                 {% endfor %}
             {% endif %}
 
-            {% if project.tk_labels.all %}
-                {% for tklabel in project.tk_labels.all %}
+            {% if project_tklabels %}
+                {% for tklabel in project_tklabels %}
                     <tr>
                         <td class="image-td">
-                            <img loading="lazy" src="{{ tklabel.img_url }}" alt="{{ tklabel.name }} Label" width="200px">
+                            <img loading="lazy" src="{{ tklabel.img_url }}" alt="{{ tklabel.alt_text}}" width="200px">
                         </td>
                         <td class="text-td">
                             <h1 class="no-bottom-margin">{{ tklabel.name }} ({{ tklabel.community.community_name }})</h1>

--- a/templates/snippets/project_notices.html
+++ b/templates/snippets/project_notices.html
@@ -19,7 +19,7 @@
     <!-- NOTICE CHECKBOXES -->
     <div class="flex-this w-40 space-between margin-left-16 margin-bottom-16">     
         <div class="flex-this column center-text">
-            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="73px" alt="black square with white letters TK in the middle"></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" width="73px" alt="TK Notice icon. Black background with the top right corner folded and the letters “TK” in white in center."></div>
             <div><p id="title-tk-notice" class="grey-text">Traditional<br> Knowledge Notice</p></div>
             <div class="notice-checkbox-container">
 
@@ -40,7 +40,7 @@
         </div>
 
         <div class="flex-this column center-text margin-left-16">
-            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="73px" alt="black square with white letters BC in the middle"></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" width="73px" alt="BC Notice icon. Black background with the top right corner folded and the letters “BC” in white in center."></div>
             <div><p id="title-bc-notice" class="grey-text">Biocultural<br> Notice</p></div>
             <div class="notice-checkbox-container">
 
@@ -62,7 +62,7 @@
         </div>
 
         <div class="flex-this column center-text margin-left-16 align-center">
-            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" alt="black square with an unfinished square in the middle in white" width="73px"></div>
+            <div><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" alt="Attribution Incomplete Notice icon. Black square with the top right corner folded and a white square in center with left side in solid line and right side in dotted line." width="73px"></div>
             <div><p id="title-attr-notice" class="grey-text">Attribution Incomplete <br> Notice</p></div>
             <div class="notice-checkbox-container">
 
@@ -95,7 +95,7 @@
                     class="show"
                 >
                     <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                        <div class="w-15 pad-top-1"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="black square with white letters TK in the middle"></div>
+                        <div class="w-15 pad-top-1"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="TK Notice icon. Black background with the top right corner folded and the letters “TK” in white in center."></div>
                         <div class="w-80 pad-top-1">
                             <h3 class="no-top-margin">{{ notice.name }}</h3>
                             <p>
@@ -185,7 +185,7 @@
                     class="show"
                 >
                     <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                        <div class="w-15 pad-top-1"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" alt="black square with white letters BC in the middle"></div>
+                        <div class="w-15 pad-top-1"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/bc-notice.png' %}" alt="BC Notice icon. Black background with the top right corner folded and the letters “BC” in white in center."></div>
                         <div class="w-80 pad-top-1">
                             <h3 class="no-top-margin">{{ notice.name }}</h3>
                             <p>
@@ -275,7 +275,7 @@
                     class="show"
                 >
                     <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                        <div class="w-15 pad-top-1"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="black square with white letters BC in the middle"></div>
+                        <div class="w-15 pad-top-1"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="Attribution Incomplete Notice icon. Black square with the top right corner folded and a white square in center with left side in solid line and right side in dotted line."></div>
                         <div class="w-80 pad-top-1">
                             <h3 class="no-top-margin">{{ notice.name }}</h3>
                             <p>
@@ -372,7 +372,7 @@
                 class="hide"
             >
                 <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                    <div class="w-15 pad-top-1"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="black square with white letters TK in the middle"></div>
+                    <div class="w-15 pad-top-1"><img loading="lazy" class="pointer-event-none" src="{% static 'images/notices/tk-notice.png' %}" alt="TK Notice icon. Black background with the top right corner folded and the letters “TK” in white in center."></div>
                     <div class="w-80 pad-top-1">
                         <div>
                             <h3 class="no-top-margin">{{ notice.noticeName }}</h3>
@@ -449,7 +449,7 @@
                 class="hide"
             >
                 <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                    <div class="w-15 pad-top-1"><img class="pointer-event-none" loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" alt="black square with white letters BC in the middle"></div>
+                    <div class="w-15 pad-top-1"><img class="pointer-event-none" loading="lazy" src="{% static 'images/notices/bc-notice.png' %}" alt="BC Notice icon. Black background with the top right corner folded and the letters “BC” in white in center."></div>
                     <div class="w-80 pad-top-1">
                         <div>
                             <h3 class="no-top-margin">Biocultural Notice</h3>
@@ -524,7 +524,7 @@
                 class="hide"
             >
                 <div class="flex-this border-top-solid-teal border-bottom-solid-teal">
-                    <div class="w-15 pad-top-1"><img class="pointer-event-none" loading="lazy" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="black square with white letters BC in the middle"></div>
+                    <div class="w-15 pad-top-1"><img class="pointer-event-none" loading="lazy" src="{% static 'images/notices/ci-attribution-incomplete.png' %}" width="119px" alt="Attribution Incomplete Notice icon. Black square with the top right corner folded and a white square in center with left side in solid line and right side in dotted line."></div>
                     <div class="w-80 pad-top-1">
                         <div>
                             <h3 class="no-top-margin">{{ notice.noticeName }}</h3>

--- a/templates/tklabels/mini-labels.html
+++ b/templates/tklabels/mini-labels.html
@@ -7,83 +7,83 @@
 
         {% if tklabel.label_type == 'attribution' %} 
             src="{% static 'images/tk-labels/tk-attribution.png' %}" 
-            alt="TK Attribution (TK A) Label"
+            alt="TK Attribution Label icon. Black tag shape with two stacked white arrows, one pointing left and one pointing right."
         {% endif %}
         {% if tklabel.label_type == 'clan' %} 
             src="{% static 'images/tk-labels/tk-clan.png' %}" 
-            alt="TK Clan (TK CL) Label"
+            alt="TK Clan Label icon. Black tag shape with a circle made of small white dots in the center."
         {% endif %}
         {% if tklabel.label_type == 'family' %} 
             src="{% static 'images/tk-labels/tk-family.png' %}" 
-            alt="TK Family (TK F) Label"
+            alt="TK Family Label icon. Black tag shape with a circle made of alternating small and big white dots in the center."
         {% endif %}
         {% if tklabel.label_type == 'outreach' %} 
             src="{% static 'images/tk-labels/tk-outreach.png' %}" 
-            alt="TK Outreach (TK O) Label"
+            alt="TK Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger."
         {% endif %}
         {% if tklabel.label_type == 'tk_multiple_community' %} 
             src="{% static 'images/tk-labels/tk-multiple-community.png' %}" 
-            alt="TK Multiple Community (TK MC) Label"
+            alt="TK Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square."
         {% endif %}
         {% if tklabel.label_type == 'non_verified' %} 
             src="{% static 'images/tk-labels/tk-non-verified.png' %}" 
-            alt="TK Non-Verifed (TK NV) Label"
+            alt="TK Non-Verified Label icon. Black tag shape with a white checkmark and diagonal line through it in center."
         {% endif %}
         {% if tklabel.label_type == 'verified' %} 
             src="{% static 'images/tk-labels/tk-verified.png' %}" 
-            alt="TK Verified (TK V) Label"
+            alt="TK Verified Label icon. Black tag shape with a white checkmark in center."
         {% endif %}
         {% if tklabel.label_type == 'non_commercial' %} 
             src="{% static 'images/tk-labels/tk-non-commercial.png' %}" 
-            alt="TK Non-Commercial (TK NC) Label"
+            alt="TK Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center."
         {% endif %}
         {% if tklabel.label_type == 'commercial' %} 
             src="{% static 'images/tk-labels/tk-commercial.png' %}" 
-            alt="TK Open to Commercialization (TK OC) Label"
+            alt="TK Open to Commercialization Label icon. Black tag shape with a white dollar sign in center."
         {% endif %}
         {% if tklabel.label_type == 'culturally_sensitive' %} 
             src="{% static 'images/tk-labels/tk-culturally-sensitive.png' %}" 
-            alt="TK Culturally Sensitive (TK CS) Label"
+            alt="TK Culturally Sensitive Label icon. Black tag shape with four hands in a circle surrounding a white cube."
         {% endif %}
         {% if tklabel.label_type == 'community_voice' %} 
             src="{% static 'images/tk-labels/tk-community-voice.png' %}" 
-            alt="TK Community Voice (TK CV) Label"
+            alt="TK Community Voice Label icon. Black tag shape with three different sized human figures in white and dialogue bubbles that overlap."
         {% endif %}
         {% if tklabel.label_type == 'community_use_only' %} 
             src="{% static 'images/tk-labels/tk-community-use-only.png' %}" 
-            alt="TK Community Use Only (TK CO) Label"
+            alt="TK Community Use Only Label icon. Black tag shape with four criss-crossed white lines in center."
         {% endif %}
         {% if tklabel.label_type == 'seasonal' %} 
             src="{% static 'images/tk-labels/tk-seasonal.png' %}" 
-            alt="TK Seasonal (TK S) Label"
+            alt="TK Seasonal Label icon. Black background with simple illustrations of a tree with bare branches and another tree with a circle representing leaves."
         {% endif %}
         {% if tklabel.label_type == 'women_general' %} 
             src="{% static 'images/tk-labels/tk-women-general.png' %}" 
-            alt="TK Women General (TK WG) Label"
+            alt="TK Women General Label icon. Black tag shape with a white figure made up of a triangle on bottom and circle on top."
         {% endif %}
         {% if tklabel.label_type == 'men_general' %} 
             src="{% static 'images/tk-labels/tk-men-general.png' %}" 
-            alt="TK Men General (TK MG) Label"
+            alt="TK Men General Label icon. Black tag shape with a white figure made up of a square on bottom and circle on top."
         {% endif %}
         {% if tklabel.label_type == 'men_restricted' %} 
             src="{% static 'images/tk-labels/tk-men-restricted.png' %}" 
-            alt="TK Men Restricted (TK MR) Label"
+            alt="TK Men Restricted Label icon. Black tag shape with two white figures made up of two squares on bottom and two circles on top with a double-sided arrow connecting both figures."
         {% endif %}
         {% if tklabel.label_type == 'women_restricted' %} 
             src="{% static 'images/tk-labels/tk-women-restricted.png' %}" 
-            alt="TK Women Restricted (TK WR) Label"
+            alt="TK Women Restricted Label icon. Black tag shape with two white figures made up of two triangles on bottom and two circles on top with a double-sided arrow connecting both figures."
         {% endif %}
         {% if tklabel.label_type == 'secret_sacred' %} 
             src="{% static 'images/tk-labels/tk-secret-sacred.png' %}" 
-            alt="TK Secret Sacred (TK SS) Label"
+            alt="TK Secret / Sacred Label icon. Black tag shape with a large white cube in center."
         {% endif %}
         {% if tklabel.label_type == 'open_to_collaboration' %} 
             src="{% static 'images/tk-labels/tk-open-to-collaboration.png' %}" 
-            alt="TK Open to Collaboration (TK CB) Label"
+            alt="TK Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top."
         {% endif %}
         {% if tklabel.label_type == 'creative' %} 
             src="{% static 'images/tk-labels/tk-creative.png' %}" 
-            alt="TK Creative (TK CR) Label"
+            alt="TK Creative Label icon. Black tag shape with a white circle made up of eight small dots on one half, a solid line on the other half, and each half bifurcated with two bigger dots."
         {% endif %}
     >
 </div>

--- a/templates/tklabels/tiny-labels.html
+++ b/templates/tklabels/tiny-labels.html
@@ -7,83 +7,83 @@
 
         {% if tklabel.label_type == 'attribution' %} 
             src="{% static 'images/tk-labels/tk-attribution.png' %}" 
-            alt="TK Attribution (TK A) Label"
+            alt="TK Attribution Label icon. Black tag shape with two stacked white arrows, one pointing left and one pointing right."
         {% endif %}
         {% if tklabel.label_type == 'clan' %} 
             src="{% static 'images/tk-labels/tk-clan.png' %}" 
-            alt="TK Clan (TK CL) Label"
+            alt="TK Clan Label icon. Black tag shape with a circle made of small white dots in the center."
         {% endif %}
         {% if tklabel.label_type == 'family' %} 
             src="{% static 'images/tk-labels/tk-family.png' %}" 
-            alt="TK Family (TK F) Label"
+            alt="TK Family Label icon. Black tag shape with a circle made of alternating small and big white dots in the center."
         {% endif %}
         {% if tklabel.label_type == 'outreach' %} 
             src="{% static 'images/tk-labels/tk-outreach.png' %}" 
-            alt="TK Outreach (TK O) Label"
+            alt="TK Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger."
         {% endif %}
         {% if tklabel.label_type == 'tk_multiple_community' %} 
             src="{% static 'images/tk-labels/tk-multiple-community.png' %}" 
-            alt="TK Multiple Community (TK MC) Label"
+            alt="TK Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square."
         {% endif %}
         {% if tklabel.label_type == 'non_verified' %} 
             src="{% static 'images/tk-labels/tk-non-verified.png' %}" 
-            alt="TK Non-Verifed (TK NV) Label"
+            alt="TK Non-Verified Label icon. Black tag shape with a white checkmark and diagonal line through it in center."
         {% endif %}
         {% if tklabel.label_type == 'verified' %} 
             src="{% static 'images/tk-labels/tk-verified.png' %}" 
-            alt="TK Verified (TK V) Label"
+            alt="TK Verified Label icon. Black tag shape with a white checkmark in center."
         {% endif %}
         {% if tklabel.label_type == 'non_commercial' %} 
             src="{% static 'images/tk-labels/tk-non-commercial.png' %}" 
-            alt="TK Non-Commercial (TK NC) Label"
+            alt="TK Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center."
         {% endif %}
         {% if tklabel.label_type == 'commercial' %} 
             src="{% static 'images/tk-labels/tk-commercial.png' %}" 
-            alt="TK Open to Commercialization (TK OC) Label"
+            alt="TK Open to Commercialization Label icon. Black tag shape with a white dollar sign in center."
         {% endif %}
         {% if tklabel.label_type == 'culturally_sensitive' %} 
             src="{% static 'images/tk-labels/tk-culturally-sensitive.png' %}" 
-            alt="TK Culturally Sensitive (TK CS) Label"
+            alt="TK Culturally Sensitive Label icon. Black tag shape with four hands in a circle surrounding a white cube."
         {% endif %}
         {% if tklabel.label_type == 'community_voice' %} 
             src="{% static 'images/tk-labels/tk-community-voice.png' %}" 
-            alt="TK Community Voice (TK CV) Label"
+            alt="TK Community Voice Label icon. Black tag shape with three different sized human figures in white and dialogue bubbles that overlap."
         {% endif %}
         {% if tklabel.label_type == 'community_use_only' %} 
             src="{% static 'images/tk-labels/tk-community-use-only.png' %}" 
-            alt="TK Community Use Only (TK CO) Label"
+            alt="TK Community Use Only Label icon. Black tag shape with four criss-crossed white lines in center."
         {% endif %}
         {% if tklabel.label_type == 'seasonal' %} 
             src="{% static 'images/tk-labels/tk-seasonal.png' %}" 
-            alt="TK Seasonal (TK S) Label"
+            alt="TK Seasonal Label icon. Black background with simple illustrations of a tree with bare branches and another tree with a circle representing leaves."
         {% endif %}
         {% if tklabel.label_type == 'women_general' %} 
             src="{% static 'images/tk-labels/tk-women-general.png' %}" 
-            alt="TK Women General (TK WG) Label"
+            alt="TK Women General Label icon. Black tag shape with a white figure made up of a triangle on bottom and circle on top."
         {% endif %}
         {% if tklabel.label_type == 'men_general' %} 
             src="{% static 'images/tk-labels/tk-men-general.png' %}" 
-            alt="TK Men General (TK MG) Label"
+            alt="TK Men General Label icon. Black tag shape with a white figure made up of a square on bottom and circle on top."
         {% endif %}
         {% if tklabel.label_type == 'men_restricted' %} 
             src="{% static 'images/tk-labels/tk-men-restricted.png' %}" 
-            alt="TK Men Restricted (TK MR) Label"
+            alt="TK Men Restricted Label icon. Black tag shape with two white figures made up of two squares on bottom and two circles on top with a double-sided arrow connecting both figures."
         {% endif %}
         {% if tklabel.label_type == 'women_restricted' %} 
             src="{% static 'images/tk-labels/tk-women-restricted.png' %}" 
-            alt="TK Women Restricted (TK WR) Label"
+            alt="TK Women Restricted Label icon. Black tag shape with two white figures made up of two triangles on bottom and two circles on top with a double-sided arrow connecting both figures."
         {% endif %}
         {% if tklabel.label_type == 'secret_sacred' %} 
             src="{% static 'images/tk-labels/tk-secret-sacred.png' %}" 
-            alt="TK Secret Sacred (TK SS) Label"
+            alt="TK Secret / Sacred Label icon. Black tag shape with a large white cube in center."
         {% endif %}
         {% if tklabel.label_type == 'open_to_collaboration' %} 
             src="{% static 'images/tk-labels/tk-open-to-collaboration.png' %}" 
-            alt="TK Open to Collaboration (TK CB) Label"
+            alt="TK Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top."
         {% endif %}
         {% if tklabel.label_type == 'creative' %} 
             src="{% static 'images/tk-labels/tk-creative.png' %}" 
-            alt="TK Creative (TK CR) Label"
+            alt="TK Creative Label icon. Black tag shape with a white circle made up of eight small dots on one half, a solid line on the other half, and each half bifurcated with two bigger dots."
         {% endif %}
     >
 </div>

--- a/templates/tklabels/which-label.html
+++ b/templates/tklabels/which-label.html
@@ -8,83 +8,83 @@
 
         {% if tklabel.label_type == 'attribution' %} 
             src="{% static 'images/tk-labels/tk-attribution.png' %}" 
-            alt="TK Attribution (TK A) Label"
+            alt="TK Attribution Label icon. Black tag shape with two stacked white arrows, one pointing left and one pointing right."
         {% endif %}
         {% if tklabel.label_type == 'clan' %} 
             src="{% static 'images/tk-labels/tk-clan.png' %}" 
-            alt="TK Clan (TK CL) Label"
+            alt="TK Clan Label icon. Black tag shape with a circle made of small white dots in the center."
         {% endif %}
         {% if tklabel.label_type == 'family' %} 
             src="{% static 'images/tk-labels/tk-family.png' %}" 
-            alt="TK Family (TK F) Label"
+            alt="TK Family Label icon. Black tag shape with a circle made of alternating small and big white dots in the center."
         {% endif %}
         {% if tklabel.label_type == 'outreach' %} 
             src="{% static 'images/tk-labels/tk-outreach.png' %}" 
-            alt="TK Outreach (TK O) Label"
+            alt="TK Outreach Label icon. Black tag shape with a white hand that has two dots stretching outward from each finger."
         {% endif %}
         {% if tklabel.label_type == 'tk_multiple_community' %} 
             src="{% static 'images/tk-labels/tk-multiple-community.png' %}" 
-            alt="TK Multiple Community (TK MC) Label"
+            alt="TK Multiple Communities Label icon. Black tag shape with four white over-under woven patchworks arranged in a 2x2 square."
         {% endif %}
         {% if tklabel.label_type == 'non_verified' %} 
             src="{% static 'images/tk-labels/tk-non-verified.png' %}" 
-            alt="TK Non-Verifed (TK NV) Label"
+            alt="TK Non-Verified Label icon. Black tag shape with a white checkmark and diagonal line through it in center."
         {% endif %}
         {% if tklabel.label_type == 'verified' %} 
             src="{% static 'images/tk-labels/tk-verified.png' %}" 
-            alt="TK Verified (TK V) Label"
+            alt="TK Verified Label icon. Black tag shape with a white checkmark in center."
         {% endif %}
         {% if tklabel.label_type == 'non_commercial' %} 
             src="{% static 'images/tk-labels/tk-non-commercial.png' %}" 
-            alt="TK Non-Commercial (TK NC) Label"
+            alt="TK Non-Commercial Label icon. Black tag shape with a white dollar sign and a diagonal line through it in center."
         {% endif %}
         {% if tklabel.label_type == 'commercial' %} 
             src="{% static 'images/tk-labels/tk-commercial.png' %}" 
-            alt="TK Open to Commercialization (TK OC) Label"
+            alt="TK Open to Commercialization Label icon. Black tag shape with a white dollar sign in center."
         {% endif %}
         {% if tklabel.label_type == 'culturally_sensitive' %} 
             src="{% static 'images/tk-labels/tk-culturally-sensitive.png' %}" 
-            alt="TK Culturally Sensitive (TK CS) Label"
+            alt="TK Culturally Sensitive Label icon. Black tag shape with four hands in a circle surrounding a white cube."
         {% endif %}
         {% if tklabel.label_type == 'community_voice' %} 
             src="{% static 'images/tk-labels/tk-community-voice.png' %}" 
-            alt="TK Community Voice (TK CV) Label"
+            alt="TK Community Voice Label icon. Black tag shape with three different sized human figures in white and dialogue bubbles that overlap."
         {% endif %}
         {% if tklabel.label_type == 'community_use_only' %} 
             src="{% static 'images/tk-labels/tk-community-use-only.png' %}" 
-            alt="TK Community Use Only (TK CO) Label"
+            alt="TK Community Use Only Label icon. Black tag shape with four criss-crossed white lines in center."
         {% endif %}
         {% if tklabel.label_type == 'seasonal' %} 
             src="{% static 'images/tk-labels/tk-seasonal.png' %}" 
-            alt="TK Seasonal (TK S) Label"
+            alt="TK Seasonal Label icon. Black background with simple illustrations of a tree with bare branches and another tree with a circle representing leaves."
         {% endif %}
         {% if tklabel.label_type == 'women_general' %} 
             src="{% static 'images/tk-labels/tk-women-general.png' %}" 
-            alt="TK Women General (TK WG) Label"
+            alt="TK Women General Label icon. Black tag shape with a white figure made up of a triangle on bottom and circle on top."
         {% endif %}
         {% if tklabel.label_type == 'men_general' %} 
             src="{% static 'images/tk-labels/tk-men-general.png' %}" 
-            alt="TK Men General (TK MG) Label"
+            alt="TK Men General Label icon. Black tag shape with a white figure made up of a square on bottom and circle on top."
         {% endif %}
         {% if tklabel.label_type == 'men_restricted' %} 
             src="{% static 'images/tk-labels/tk-men-restricted.png' %}" 
-            alt="TK Men Restricted (TK MR) Label"
+            alt="TK Men Restricted Label icon. Black tag shape with two white figures made up of two squares on bottom and two circles on top with a double-sided arrow connecting both figures."
         {% endif %}
         {% if tklabel.label_type == 'women_restricted' %} 
             src="{% static 'images/tk-labels/tk-women-restricted.png' %}" 
-            alt="TK Women Restricted (TK WR) Label"
+            alt="TK Women Restricted Label icon. Black tag shape with two white figures made up of two triangles on bottom and two circles on top with a double-sided arrow connecting both figures."
         {% endif %}
         {% if tklabel.label_type == 'secret_sacred' %} 
             src="{% static 'images/tk-labels/tk-secret-sacred.png' %}" 
-            alt="TK Secret Sacred (TK SS) Label"
+            alt="TK Secret / Sacred Label icon. Black tag shape with a large white cube in center."
         {% endif %}
         {% if tklabel.label_type == 'open_to_collaboration' %} 
             src="{% static 'images/tk-labels/tk-open-to-collaboration.png' %}" 
-            alt="TK Open to Collaboration (TK CB) Label"
+            alt="TK Open to Collaboration Label icon. Black tag shape with three white overlapping figures in center made up of hexagons on bottom and circles on top."
         {% endif %}
         {% if tklabel.label_type == 'creative' %} 
             src="{% static 'images/tk-labels/tk-creative.png' %}" 
-            alt="TK Creative (TK CR) Label"
+            alt="TK Creative Label icon. Black tag shape with a white circle made up of eight small dots on one half, a solid line on the other half, and each half bifurcated with two bigger dots."
         {% endif %}
     >
 </div>


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8685tnmg0)**
  
- Description: Corrie provided content update for the Labels and Notices img alt text.

**Solution:**
- Updated Alt text for all image tag with src of notice's or label's and handled the alt text in the templates.
- For dynamic assigning of alt text, I inserted the labelAlternateText in the labels.json fetched the alt text from that Json file, and appended it temporarily.

**Before:**

![alttext(1)](https://github.com/localcontexts/localcontextshub/assets/145371882/27e44ec1-6fd2-4213-b247-d7951619bd8d)

![alttext(2)](https://github.com/localcontexts/localcontextshub/assets/145371882/a414c2c1-a449-4798-9f1d-b7ac5a141fb7)

**After:**

![alttext(1)](https://github.com/localcontexts/localcontextshub/assets/145371882/6770e044-fb3c-4de4-b183-9b2ddaedf2e5)

![alt(2)](https://github.com/localcontexts/localcontextshub/assets/145371882/0a8a79bc-e4ba-4b1f-8679-a96fc1f98d26)
