### PR TITLE
86877rf1r Reset Password link and email UI

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,8 +1,13 @@
 from django import forms
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.forms import UserCreationForm, PasswordResetForm
 from django.contrib.auth.models import User
+from django.contrib.auth.tokens import default_token_generator
 from .models import Profile, SignUpInvitation
+from helpers.emails import send_password_reset_email
+from django.contrib.sites.shortcuts import get_current_site
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
 
 class RegistrationForm(UserCreationForm):
     email = forms.EmailField(required=True, max_length=150, help_text='Required')
@@ -92,3 +97,35 @@ class ContactOrganizationForm(forms.Form):
     email = forms.EmailField(label=_('Email Address'), required=True, widget=forms.EmailInput(attrs={'class': 'w-100', 'placeholder': 'email@domain.com'}))
     message= forms.CharField(widget=forms.Textarea(attrs={"rows":4, "cols":65, 'class': 'w-100'}))
     
+class CustomPasswordResetForm(PasswordResetForm):
+    def save(self, domain_override=None,
+             subject_template_name='registration/password_reset_subject.txt',
+            email_template_name=None,
+             use_https=False, token_generator=default_token_generator,
+             from_email=None, request=None, html_email_template_name=None,
+             extra_email_context=None):
+        """
+        Generate a one-use only link for resetting password and send it to the
+        user.
+        """
+        email = self.cleaned_data["email"]
+        if not domain_override:
+            current_site = get_current_site(request)
+            site_name = current_site.name
+            domain = current_site.domain
+        else:
+            site_name = domain = domain_override
+        email_field_name = User.get_email_field_name()
+        for user in self.get_users(email):
+            user_email = getattr(user, email_field_name)
+            context = {
+                'email': user_email,
+                'domain': domain,
+                'site_name': site_name,
+                'uid': urlsafe_base64_encode(force_bytes(user.pk)),
+                'user': user,
+                'token': token_generator.make_token(user),
+                'protocol': 'https' if use_https else 'http',
+                **(extra_email_context or {}),
+            }
+            send_password_reset_email(request, context)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -42,7 +42,7 @@ urlpatterns = [
     path('newsletter/preferences/<emailb64>/', views.newsletter_unsubscription, name='newsletter-unsubscription'),
 
 
-    path('reset-password/', auth_views.PasswordResetView.as_view(template_name="accounts/password-reset.html", from_email=settings.EMAIL_HOST_USER), name="reset_password"),
+    path('reset-password/', views.CustomPasswordResetView.as_view(), name="reset_password"),
     path('reset-password-sent/', auth_views.PasswordResetDoneView.as_view(template_name="accounts/password-reset-sent.html"), name="password_reset_done"),
     path('reset/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(template_name="accounts/password-reset-confirm.html"), name="password_reset_confirm"),
     path('reset-password-complete/', auth_views.PasswordResetCompleteView.as_view(template_name="accounts/password-reset-done.html"), name="password_reset_complete"),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render, redirect
 from django.http import HttpResponseRedirect, Http404
 from django.contrib import messages, auth
 from django.views.generic import View
-from django.contrib.auth.views import PasswordChangeForm, SetPasswordForm
+from django.contrib.auth.views import PasswordChangeForm, SetPasswordForm, PasswordResetView
 from allauth.socialaccount.views import SignupView, ConnectionsView
 from django.contrib.auth import update_session_auth_hash
 from allauth.socialaccount.models import SocialAccount
@@ -18,6 +18,8 @@ from django.conf import settings
 from django.utils.http import urlsafe_base64_decode
 from django.utils.safestring import mark_safe
 from django.utils.encoding import force_text
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_protect
 
 from unidecode import unidecode
 from django.db.models import Q
@@ -204,6 +206,16 @@ class CustomSocialConnectionsView(ConnectionsView):
             messages.error(request, 'Please set password first to unlink an account')
             return redirect('link-account')
         return super().dispatch(request, *args, **kwargs)
+
+class CustomPasswordResetView(PasswordResetView):
+    email_template_name = 'password_reset'
+    from_email = settings.EMAIL_HOST_USER
+    template_name = "accounts/password-reset.html"
+    form_class = CustomPasswordResetForm
+
+    @method_decorator(csrf_protect)
+    def dispatch(self, *args, **kwargs):
+        return super().dispatch(*args, **kwargs)
 
 @login_required(login_url='login')
 def dashboard(request):

--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils.http import urlsafe_base64_encode
 from django.utils.encoding import force_bytes
+from django.urls import reverse
 from django.contrib.sites.shortcuts import get_current_site
 import requests
 import json
@@ -207,6 +208,20 @@ def resend_activation_email(request, active_users):
     subject = 'Activate Your Local Contexts Hub Profile'
     send_mailgun_template_email(to_email, subject, 'activate_profile', data)
 
+
+def send_password_reset_email(request, context):
+    to_email = context['email']
+    domain = domain = context['domain']
+    uid = context['uid']
+    token = context['token']
+    protocol = context['protocol']
+    reset_path = reverse('password_reset_confirm', kwargs={'uidb64': uid, 'token': token})
+    reset_url = f'{protocol}://{domain}{reset_path}'
+    user = User.objects.filter(email__iexact=to_email).first().username
+    subject = 'Reset Password Link For Your Local Contexts Hub Profile'
+
+    data = {'user': user, 'reset_url': reset_url}
+    send_mailgun_template_email(to_email, subject, 'password_reset', data)
 
 # User has activated account and has logged in: Welcome email
 def send_welcome_email(request, user):   

--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -217,7 +217,7 @@ def send_password_reset_email(request, context):
     protocol = context['protocol']
     reset_path = reverse('password_reset_confirm', kwargs={'uidb64': uid, 'token': token})
     reset_url = f'{protocol}://{domain}{reset_path}'
-    user = User.objects.filter(email__iexact=to_email).first().username
+    user = User.objects.get(email=to_email).username
     subject = 'Reset Password Link For Your Local Contexts Hub Profile'
 
     data = {'user': user, 'reset_url': reset_url}

--- a/templates/accounts/password-reset-sent.html
+++ b/templates/accounts/password-reset-sent.html
@@ -7,7 +7,7 @@
             If you don't receive an email, please make sure you entered the address you registered with 
             and check your spam folder.<br><br>
             <strong>Still having issues?</strong> <br>
-            Email us at <a href="mailto:support@localcontexts.org">support@localcontexts.org</a>
+            Email us at <a class="default-a" href="mailto:support@localcontexts.org">support@localcontexts.org</a>
         </p>                               
     </div>
 {% endblock %}


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/86877rf1r)**
  
- Description: If possible, update the support email link UI to match the rest of the links in the Hub. Also, have password reset email match other email templates (reset link put as a button, header, footer, etc.).

**Solution:**
- Added an email template named password_reset template in mailgun.
- Added a custom view for password-reset and used mailgun email function to send email.
- Updated the email support link to match the rest of the links in the Hub.

**Before:**
![passwordreset(1)before](https://github.com/localcontexts/localcontextshub/assets/145371882/c44c37b2-e783-4c01-af4e-42ab50ddbd57)

![passwordreset(2)before](https://github.com/localcontexts/localcontextshub/assets/145371882/35ef71f2-9f06-4c35-b66b-c1ec896e3bfe)


**After:**
![passwordreset(1)after](https://github.com/localcontexts/localcontextshub/assets/145371882/e5641427-36e2-4037-87ea-04cfbe62aa06)

![reset(2)](https://github.com/localcontexts/localcontextshub/assets/145371882/d153bcf2-d561-4709-9c60-d91a3d521ed0)
