### PR TITLE
#8687a6c16 removed old code from when a single boundary attribute stored multiple boundaries

### DIFF
--- a/templates/communities/add-community-boundary.html
+++ b/templates/communities/add-community-boundary.html
@@ -244,7 +244,7 @@
                 const payload = {
                     source: url,
                     name: boundary.properties.Name,
-                    boundary: [boundaryCoordinates]
+                    boundary: boundaryCoordinates
                 }
 
                 // do post call to set boundary in request


### PR DESCRIPTION
Native Land always returns a single boundary. And when multiple boundaries were stored in a single community attribute, the Frontend needed to place that single boundary inside of an array before sending it to the backend.

Since only a single boundary is stored in the boundary attribute, the [ `<single-boundary>` ] is no longer needed