### PR TITLE
#8686qked3 Added email verification using mail gun

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -73,7 +73,7 @@ def register(request):
                     messages.error(request, 'A user with this username already exists.')
                     return redirect('register')
                 elif not validate_email(email=user.email):
-                    messages.error(request, 'The email you entered is invlaid')
+                    messages.error(request, 'The email you entered is invalid')
                     return redirect('register')
                 else:
                     user.is_active = False

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -33,6 +33,7 @@ from projects.models import Project
 from localcontexts.utils import dev_prod_or_local
 from researchers.utils import is_user_researcher
 from helpers.utils import accept_member_invite
+from helpers.utils import validate_email
 
 from helpers.emails import *
 from .models import *
@@ -70,6 +71,9 @@ def register(request):
                     return redirect('register')
                 elif User.objects.filter(username__iexact=user.username.lower()).exists():
                     messages.error(request, 'A user with this username already exists.')
+                    return redirect('register')
+                elif not validate_email(email=user.email):
+                    messages.error(request, 'The email you entered is invlaid')
                     return redirect('register')
                 else:
                     user.is_active = False

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -1,5 +1,7 @@
 import json
 import zipfile
+import requests
+from django.conf import settings
 from django.template.loader import get_template
 from io import BytesIO
 from accounts.models import UserAffiliation
@@ -400,3 +402,19 @@ def get_alt_text(data, bclabels, tklabels):
             label.alt_text = "TK label icon" 
     
     return bclabels, tklabels  
+
+def validate_email(email):
+    url = f"{settings.MAILGUN_V4_BASE_URL}/address/validate"
+    auth = ("api", settings.MAILGUN_API_KEY)
+    params = {"address": email}
+    
+    response = requests.get(url, auth=auth, params=params)
+    if response.status_code == 200:
+        data = response.json()
+        if data.get("result") == "deliverable":
+            return True
+        else:
+            return False
+    else:
+        print("Request failed with status code:", response.status_code)
+        return False

--- a/localcontexts/settings.py
+++ b/localcontexts/settings.py
@@ -207,6 +207,7 @@ MESSAGE_TAGS = {
 # MailGun Configs
 MAILGUN_API_KEY = os.environ.get('MAILGUN_API_KEY')
 MAILGUN_BASE_URL = os.environ.get('MAILGUN_BASE_URL')
+MAILGUN_V4_BASE_URL = os.environ.get('MAILGUN_V4_BASE_URL')
 MAILGUN_TEMPLATE_URL = os.environ.get('MAILGUN_TEMPLATE_URL')
 
 # Config for sending out emails


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8686qked3)**
  
- Description: Every few months we accumulate random users with suspicious emails that may or may not be legitimate, so we should set up an email checker on the backend using something like https://rapidapi.com/mr_admin/api/email-verifier to make sure only users with legitimate emails sign up.

**Solution:**
- Added a validation layer on top of registration to validate all the new user's emails. 
- Integrated mail-gun email validation for this purpose.

**Example**

<img width="810" alt="image" src="https://github.com/localcontexts/localcontextshub/assets/145371882/6e64c4b0-5aaa-4c64-9767-89924fc7096c">

- Before the mail-gun validation process, any email without the email format error(regex) was able to sign up into the hub. But now mail-gun will verify the email and check whether the mailbox for that email actually exist.

 
 


