### PR TITLE
#86877fkp0 added spinner on Confirm location Button

### DIFF
--- a/localcontexts/static/css/main.css
+++ b/localcontexts/static/css/main.css
@@ -1620,3 +1620,14 @@ i[data-tooltip]:hover:after {
 .confirmation-alert button {
     margin-right: 10px;
 }
+
+.spinner-container {
+    z-index: 10 !important;
+    position: absolute;
+    display: block !important;
+}
+
+.spinner{
+    z-index:-1; 
+    display:none;
+}

--- a/templates/communities/add-community-boundary.html
+++ b/templates/communities/add-community-boundary.html
@@ -154,6 +154,7 @@
                     onclick="setboundary(); event.preventDefault()"
                 >
                     Confirm location <i class="fa fa-arrow-right"></i>
+                    <i class="fa fa-spinner fa-spin fa-2x spinner"></i>
                 </a>
             </div>
             <div class="margin-right-8" id="skip-this-step">
@@ -222,6 +223,8 @@
 
         async function setboundary() {
             try {
+                document.getElementById("community-boundary-continue-btn").classList.add("disabled-btn");
+                document.querySelector("#community-boundary-continue-btn .fa-spinner").classList.add("spinner-container");
                 // do post call to get boundary
                 const href = document.querySelector('#community-boundary-continue-btn').getAttribute('href')
                 const slug = document.querySelector('#selected-title').getAttribute('data-slug')
@@ -229,6 +232,8 @@
                 const url = `https://native-land.ca/wp-json/nativeland/v1/api/index.php?maps=territories&name=${slug}`
                 const boundaryResponse = await fetch(url)
                 const boundaryData = await boundaryResponse.json()
+                document.querySelector("#community-boundary-continue-btn .fa-spinner").classList.remove("spinner-container");
+                document.getElementById("community-boundary-continue-btn").classList.remove("disabled-btn");
 
                 if (boundaryData.length === 0) {
                     const errorMessage = 'Selected location does not have any Native Land boundary'


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/86877fkp0)**
  
- Description: Ashley reported that the "Confirm Location" button on the "Add Community Boundary" page doesn't disable after adding boundaries using NLD, which allows users to press it multiple times and send multiple API calls.

**Solution:**
- Added a spinner icon to the Confirm Location button and disabled it during API call. 
- The Confirm Location button is re-enabled after the API returns the results.

**Before:**
![addboundarybefore](https://github.com/localcontexts/localcontextshub/assets/145371882/0924dd27-2c01-442e-b599-c93278c75445)

**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/545e783f-64e4-4e2d-a2b4-0c7d28988749


