### PR TITLE
#8686qkezr autodelete inactive accounts

### DIFF
--- a/helpers/apps.py
+++ b/helpers/apps.py
@@ -1,9 +1,10 @@
 from django.apps import AppConfig
-
+import sys
 
 class HelpersConfig(AppConfig):
     name = 'helpers'
 
     def ready(self):
-        from helpers.scheduler import start_scheduler
-        start_scheduler()
+        if 'migrate' not in sys.argv:
+            from helpers.scheduler import start_scheduler
+            start_scheduler()

--- a/helpers/apps.py
+++ b/helpers/apps.py
@@ -3,3 +3,7 @@ from django.apps import AppConfig
 
 class HelpersConfig(AppConfig):
     name = 'helpers'
+
+    def ready(self):
+        from helpers.scheduler import start_scheduler
+        start_scheduler()

--- a/helpers/scheduler.py
+++ b/helpers/scheduler.py
@@ -1,0 +1,29 @@
+from django.conf import settings
+from django.utils import timezone
+from django.contrib.auth.models import User
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from django_apscheduler.jobstores import DjangoJobStore
+
+def cleanup_inactive_users():
+    thirty_days_ago = timezone.now() - timezone.timedelta(days=30)
+    inactive_users = User.objects.filter(last_login__isnull=True, date_joined__lt=thirty_days_ago, is_active=False)
+    inactive_users.delete()
+
+def start_scheduler():
+    scheduler = BackgroundScheduler(timezone=settings.TIME_ZONE)
+    scheduler.add_jobstore(DjangoJobStore(), "default")
+
+    scheduler.add_job(
+        cleanup_inactive_users,
+        trigger=CronTrigger(hour=0, minute=0),
+        id="cleanup_inactive_users",
+        max_instances=1,
+        replace_existing=True,
+    )
+
+    try:
+        scheduler.start()
+    except KeyboardInterrupt:
+        scheduler.shutdown()

--- a/localcontexts/admin.py
+++ b/localcontexts/admin.py
@@ -14,6 +14,7 @@ from django.http import Http404, HttpResponse
 from django.shortcuts import redirect, render
 
 from accounts.models import Profile, UserAffiliation, SignUpInvitation
+from django_apscheduler.models import DjangoJob, DjangoJobExecution
 from accounts.utils import get_users_name
 from rest_framework_api_key.admin import APIKey, APIKeyModelAdmin
 from django.contrib.auth.admin import UserAdmin, GroupAdmin
@@ -1206,3 +1207,16 @@ class TKLabelAdmin(admin.ModelAdmin):
     search_fields = ('name', 'community__community_name', 'created_by__username', 'label_type')
 
 admin_site.register(TKLabel, TKLabelAdmin)
+
+# DJANGOJOB ADMIN
+class DjangoJobAdmin(admin.ModelAdmin):
+    list_display = ('id', 'next_run_time')
+    readonly_fields = ('id', 'next_run_time')
+    search_fields = ('id', 'next_run_time')
+
+admin_site.register(DjangoJob, DjangoJobAdmin)
+
+class DjangoJobExecutionAdmin(admin.ModelAdmin):
+    list_display = ('job', 'status', 'run_time')
+
+admin_site.register(DjangoJobExecution, DjangoJobExecutionAdmin)

--- a/localcontexts/settings.py
+++ b/localcontexts/settings.py
@@ -73,6 +73,7 @@ INSTALLED_APPS = [
 
     'django_countries',
     'django_cleanup',
+    'django_apscheduler',
     'storages',
 
     'rest_framework',

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ django-cookie-consent==0.2.6
 django-cors-headers==3.11.0
 django-countries==7.5.1
 django-dbbackup==4.0.2
+django-apscheduler==0.6.2
 django-debug-toolbar==3.2.4
 django-guardian==2.3.0
 django-maintenance-mode==0.16.0


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8686qkezr)**
  
- Description: Set up an auto-delete of new accounts that have never logged in and never verified their emails. There could be instances where someone had deactivated their account after activation but those users should be handled separately. This task is only for those accounts that signed up, never activated and don't have a date for last_login.

**Solution:**
- Added a helper file `scheduler.py` to setup a job that runs at the start of every month and deletes all the inactive users.
- Added django-apsscheduler to schedule jobs.
 


