### PR TITLE
#8687azkcp Add settings option for account cards for all admins

### DIFF
--- a/templates/partials/infocards/_community-card.html
+++ b/templates/partials/infocards/_community-card.html
@@ -52,7 +52,7 @@
                     <!-- Notification -->
                     {% include 'snippets/notifications.html' with scope=community %}
                     <!-- Settings -->
-                    {% if request.user == community.community_creator or member_role == 'admin' %}
+                    {% if request.user == community.community_creator or request.user in community.get_admins %}
                         <div>
                             <a href="{% url 'update-community' community.id %}" class=" border-raduis50 darkteal-text primary-btn white-btn"><i class=" no-margin fa fa-cog" aria-hidden="true"></i></a>
                         </div>

--- a/templates/partials/infocards/_institution-card.html
+++ b/templates/partials/infocards/_institution-card.html
@@ -67,7 +67,7 @@
                     <!-- Notification -->
                     {% include 'snippets/notifications.html' with scope=institution %}
                     <!-- Settings -->
-                    {% if request.user == institution.institution_creator or member_role == 'admin'%}
+                    {% if request.user == institution.institution_creator or request.user in institution.get_admins %}
                         <div>
                             <a href="{% url 'update-institution' institution.id%}" class="border-raduis50 darkteal-text primary-btn white-btn"><i class="no-margin fa fa-cog" aria-hidden="true"></i></a>
                         </div>


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8687azkcp)**
  
- Description: As an admin for the Southwest Community the settings icon wasn't showing, it only shows at the moment for account creators. Since admins can also access the settings, the icon should show for them too.

**Solution:**
- Updated the rendering condition for settings icon.

**Before:**
![before](https://github.com/localcontexts/localcontextshub/assets/145371882/318bad46-76f2-4591-9801-fe6257006019)


**After:**
![aftersettings(1)](https://github.com/localcontexts/localcontextshub/assets/145371882/09f66e25-9888-4c6d-b1dd-1618ddb51c5e)
![aftersettings(2)](https://github.com/localcontexts/localcontextshub/assets/145371882/5b60a614-7537-4976-891c-f1f15df48a3b)

 