### PR TITLE
#86878qevr fix HubActivity error in Admin panel

### DIFF
--- a/localcontexts/admin.py
+++ b/localcontexts/admin.py
@@ -959,6 +959,9 @@ class HubActivityAdmin(admin.ModelAdmin):
     
     def action(self, obj):
         user_name = get_users_name(User.objects.get(id=obj.action_user_id))
+        account_link = ''
+        account_name = ''
+        account_id = ''
 
         if obj.action_account_type == 'institution':
             account_id = obj.institution_id


### PR DESCRIPTION
Problem:
When user tried to look at the admin panel for HubActivity, was throwing an unbound variable error for some researcher related activity. Was happening because the hub activity for researcher was nested when it tried to assign `account_link`, `account_id` and `account_name`. 

Solved by initializing `account_link`, `account_id` and `account_name` variables in HubActivity admin before they were assigned and passed through to `action_message`.