### PR TITLE
#8687c89p5 Correct-member-role

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -61,7 +61,7 @@ def add_user_to_role(account, role, user):
     role_map = {
         'admin': account.admins,
         'editor': account.editors,
-        'viewers': account.viewers,
+        'viewer': account.viewers,
     }
     role_map[role].add(user)
     account.save()


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8687c89p5)**
  
- Description: I found a bug while testing our app. When a user accepts a request from community as viewer. Then a key error occurs.

**Solution:**
- Updated the member role in add_user_to_role function.

**Before:**

https://github.com/localcontexts/localcontextshub/assets/145371882/aafa12e9-3f9e-4a1b-9ca8-a80fd0f9ccd5

![correctmemberrolebefore](https://github.com/localcontexts/localcontextshub/assets/145371882/d24b5c45-1495-41ed-8e38-a43f966e239d)

**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/efda089b-4462-4fe8-a577-b8cd5254b286



