### PR TITLE
#8685dweqe Notification-for-Notified-Communities

### DIFF
--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -3,6 +3,7 @@ from institutions.models import Institution
 from researchers.models import Researcher
 from django.contrib.auth.models import User
 from helpers.models import LabelNote
+from notifications.models import ActionNotification
 
 from localcontexts.utils import dev_prod_or_local
 from accounts.utils import get_users_name
@@ -360,6 +361,13 @@ def send_email_notice_placed(request, project, community, account):
         }
         send_mailgun_template_email(community.community_creator.email, subject, 'notice_placed', data)
 
+#Project status has been changed
+def send_email_project_status(request, project, communities):
+    from communities.utils import get_community
+    for community in communities:
+        community = get_community(community)
+        title = f"A {project} was customized by {request.user}."
+        ActionNotification.objects.create(community=community, sender=request.user, notification_type="Projects", title=title, reference_id=project.unique_id)
 
 """
     EMAILS FOR COMMUNITY APP

--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -370,7 +370,7 @@ def send_action_notification_project_status(request, project, communities):
     from communities.utils import get_community
     for community in communities:
         community = get_community(community)
-        title = f"A {project} was customized by {request.user}."
+        title = f"{request.user} has edited a Project:'{project}'."
         ActionNotification.objects.create(community=community, sender=request.user, notification_type="Projects", title=title, reference_id=project.unique_id)
 
 """

--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -370,7 +370,7 @@ def send_action_notification_project_status(request, project, communities):
     from communities.utils import get_community
     for community in communities:
         community = get_community(community)
-        title = f"{request.user} has edited a Project:'{project}'."
+        title = f"{request.user} has edited a Project: '{project}'."
         ActionNotification.objects.create(community=community, sender=request.user, notification_type="Projects", title=title, reference_id=project.unique_id)
 
 """

--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -363,6 +363,10 @@ def send_email_notice_placed(request, project, community, account):
 
 #Project status has been changed
 def send_email_project_status(request, project, communities):
+    login_url = get_site_url(request, 'login')
+    editor = request.user
+    project_description = project.description
+    project_title = project.title
     from communities.utils import get_community
     for community in communities:
         community = get_community(community)

--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -362,7 +362,7 @@ def send_email_notice_placed(request, project, community, account):
         send_mailgun_template_email(community.community_creator.email, subject, 'notice_placed', data)
 
 #Project status has been changed
-def send_email_project_status(request, project, communities):
+def send_action_notification_project_status(request, project, communities):
     login_url = get_site_url(request, 'login')
     editor = request.user
     project_description = project.description

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -175,7 +175,7 @@ def get_notice_defaults():
     return data
 
 # Create/Update/Delete Notices and Notice Translations
-def crud_notices(request, selected_notices, selected_translations, organization, project, existing_notices):
+def crud_notices(request, selected_notices, selected_translations, organization, project, existing_notices, has_changes):
     # organization: instance of institution or researcher
     # selected_notices: list: ['attribution_incomplete', 'bcnotice', 'tknotice']
     # existing_notices: a queryset of notices that exist for this project already
@@ -217,24 +217,28 @@ def crud_notices(request, selected_notices, selected_translations, organization,
             # Create any notice translations
             update_notice_translation(new_notice, selected_translations)
 
-    def create_notices(existing_notice_types):          
+    def create_notices(existing_notice_types):
+        nonlocal has_changes
         for notice_type in selected_notices:
             if notice_type:
                 if existing_notice_types:
-                    if not notice_type in existing_notice_types:  
+                    if not notice_type in existing_notice_types:
+                        has_changes = True
                         create(notice_type)
                 else:
                     create(notice_type)
     
     def update_notice_translation(notice, selected_translations):
         selected_notice_types_langs = [value.split('-') for value in selected_translations]
+        nonlocal has_changes
 
         for translation in notice.notice_translations.all():
             ntype = translation.notice_type
             lang_tag = translation.language_tag
 
             # If this notice translation is not in the selected translations and its type matches the notice, delete it
-            if (ntype, lang_tag) not in selected_notice_types_langs and notice.notice_type == ntype:
+            if [ntype, lang_tag] not in selected_notice_types_langs and notice.notice_type == ntype:
+                has_changes = True
                 translation.delete()
 
         for ntype, lang_tag in selected_notice_types_langs:
@@ -242,6 +246,7 @@ def crud_notices(request, selected_notices, selected_translations, organization,
             if notice.notice_type == ntype:
                 # If translation of this type in this language does NOT exist, create it.
                 if not notice.notice_translations.filter(notice_type=ntype, language_tag=lang_tag).exists():
+                    has_changes = True
                     notice.save(language_tag=lang_tag)
                 
     if existing_notices:
@@ -249,13 +254,15 @@ def crud_notices(request, selected_notices, selected_translations, organization,
         for notice in existing_notices:
             existing_notice_types.append(notice.notice_type)
             if not notice.notice_type in selected_notices: # if existing notice not in selected notices, delete notice
+                has_changes = True
                 notice.delete()
                 ProjectActivity.objects.create(project=project, activity=f'{notice.name} was removed from the Project by {name}')
             update_notice_translation(notice, selected_translations)
         create_notices(existing_notice_types)
-
+        return has_changes
     else:
         create_notices(None)
+        return has_changes
 
 def add_remove_labels(request, project, community):
     from projects.models import ProjectActivity

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -437,6 +437,7 @@ def edit_project(request, researcher, project_uuid):
 
     if request.method == 'POST':
         if form.is_valid() and formset.is_valid():
+            has_changes = form.has_changed()
             data = form.save(commit=False)
             project_links = request.POST.getlist('project_urls')
             data.urls = project_links
@@ -444,7 +445,7 @@ def edit_project(request, researcher, project_uuid):
 
             editor_name = get_users_name(request.user)
             ProjectActivity.objects.create(project=data, activity=f'Edits to Project were made by {editor_name}')
-
+            communities = ProjectStatus.objects.filter(project=data).select_related('community').order_by('community').distinct('community').values_list('community', flat=True)
             # Adds activity to Hub Activity
             HubActivity.objects.create(
                 action_user_id=request.user.id,
@@ -464,8 +465,10 @@ def edit_project(request, researcher, project_uuid):
             # Which notices were selected to change
             notices_selected = request.POST.getlist('checkbox-notice')
             translations_selected = request.POST.getlist('checkbox-translation')
-            crud_notices(request, notices_selected, translations_selected, researcher, data, notices)
+            has_changes = crud_notices(request, notices_selected, translations_selected, researcher, data, notices, has_changes)
 
+            if has_changes:
+                    send_email_project_status(request, project, communities)
         return redirect('researcher-project-actions', researcher.id, project.unique_id)
 
     context = {

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -445,7 +445,7 @@ def edit_project(request, researcher, project_uuid):
 
             editor_name = get_users_name(request.user)
             ProjectActivity.objects.create(project=data, activity=f'Edits to Project were made by {editor_name}')
-            communities = ProjectStatus.objects.filter(project=data, seen=True, status='labels_applied').select_related('community').order_by('community').distinct('community').values_list('community', flat=True)
+            communities = ProjectStatus.objects.filter(project=data, seen=True, status='pending').select_related('community').order_by('community').distinct('community').values_list('community', flat=True)
             # Adds activity to Hub Activity
             HubActivity.objects.create(
                 action_user_id=request.user.id,

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -445,7 +445,7 @@ def edit_project(request, researcher, project_uuid):
 
             editor_name = get_users_name(request.user)
             ProjectActivity.objects.create(project=data, activity=f'Edits to Project were made by {editor_name}')
-            communities = ProjectStatus.objects.filter(project=data).select_related('community').order_by('community').distinct('community').values_list('community', flat=True)
+            communities = ProjectStatus.objects.filter(project=data, seen=True, status='labels_applied').select_related('community').order_by('community').distinct('community').values_list('community', flat=True)
             # Adds activity to Hub Activity
             HubActivity.objects.create(
                 action_user_id=request.user.id,


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8685dweqe)**
  
- Description: Currently, if a community has been notified of a Project and that Project gets edited, there is no notification that lets the notified community know that anything has changed on the Project. There should be an action notification in the GUI and possibly an email sent as well.

**Solution:**
- Detected the change in the Edit project form.
- Updated the change flag based on the change in notice or notice translations.
- Get communities based of the status is Labels Pending or Acknowledge Notice.
- Sent ActionNotification to notified communities based on whether the change is detected or not.

**Before:**
![notifiedcommunities(before)](https://github.com/localcontexts/localcontextshub/assets/145371882/4471952f-14b0-4d3c-b52f-092d280d200e)


**After:**
The [link](https://drive.google.com/file/d/1WrK_-uLoaaU3AbEECpGYjb2ily5D5yJq/view?usp=sharing) for video demo.
![actionnotification(after)](https://github.com/localcontexts/localcontextshub/assets/145371882/c720ceb6-9295-43ef-9d24-d5c04d945d19)
