### PR TITLE
#86875x0x9 Allow Embed and Project page in Maintenance

### DIFF
--- a/projects/views.py
+++ b/projects/views.py
@@ -12,6 +12,8 @@ from helpers.downloads import download_project_zip
 from localcontexts.utils import dev_prod_or_local
 from .utils import can_download_project, return_project_labels_by_community
 
+from maintenance_mode.decorators import force_maintenance_mode_off
+
 
 def view_project(request, unique_id):
     try:
@@ -83,6 +85,7 @@ def download_project(request, unique_id):
     except:
         raise Http404()
 
+@force_maintenance_mode_off
 def embed_project(request, unique_id):
     layout = request.GET.get('lt')
     lang = request.GET.get('lang')

--- a/projects/views.py
+++ b/projects/views.py
@@ -14,7 +14,7 @@ from .utils import can_download_project, return_project_labels_by_community
 
 from maintenance_mode.decorators import force_maintenance_mode_off
 
-
+@force_maintenance_mode_off
 def view_project(request, unique_id):
     try:
         project = Project.objects.select_related('project_creator').prefetch_related('bc_labels', 'tk_labels').get(unique_id=unique_id)


### PR DESCRIPTION
- Allow Embed page to show even if Hub is in maintenance mode. 
- Allow Project View page to show even if Hub is in maintenance mode.