### PR TITLE
#8687c2q86 Added functionality of confirming email change

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -49,10 +49,11 @@ class UserUpdateForm(forms.ModelForm):
     def clean(self):
         super(UserUpdateForm, self).clean()
         email = self.cleaned_data.get('email')
+        user_id = self.instance.id if self.instance else None
 
         if len(email) == 0:
             self._errors['email'] = self.error_class(['Email Is Required'])
-        elif User.objects.filter(email=email).exists():
+        elif User.objects.filter(email=email).exclude(id=user_id).exists():
             self._errors['email'] = self.error_class(["Email already exists."])
         return self.cleaned_data
 

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -8,6 +8,7 @@ from helpers.emails import send_password_reset_email
 from django.contrib.sites.shortcuts import get_current_site
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
+from django.db.models import Q
 
 class RegistrationForm(UserCreationForm):
     email = forms.EmailField(required=True, max_length=150, help_text='Required')
@@ -50,10 +51,9 @@ class UserUpdateForm(forms.ModelForm):
         super(UserUpdateForm, self).clean()
         email = self.cleaned_data.get('email')
         user_id = self.instance.id if self.instance else None
-
         if len(email) == 0:
             self._errors['email'] = self.error_class(['Email Is Required'])
-        elif User.objects.filter(email=email).exclude(id=user_id).exists():
+        elif User.objects.filter(email=email).exclude(Q(id=user_id) | Q(is_active=False)).exists():
             self._errors['email'] = self.error_class(["Email already exists."])
         return self.cleaned_data
 

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -8,7 +8,6 @@ from helpers.emails import send_password_reset_email
 from django.contrib.sites.shortcuts import get_current_site
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
-from django.db.models import Q
 
 class RegistrationForm(UserCreationForm):
     email = forms.EmailField(required=True, max_length=150, help_text='Required')
@@ -53,7 +52,7 @@ class UserUpdateForm(forms.ModelForm):
         user_id = self.instance.id if self.instance else None
         if len(email) == 0:
             self._errors['email'] = self.error_class(['Email Is Required'])
-        elif User.objects.filter(email=email).exclude(Q(id=user_id) | Q(is_active=False)).exists():
+        elif User.objects.filter(email=email).exclude(id=user_id).exists():
             self._errors['email'] = self.error_class(["Email already exists."])
         return self.cleaned_data
 

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -52,6 +52,8 @@ class UserUpdateForm(forms.ModelForm):
 
         if len(email) == 0:
             self._errors['email'] = self.error_class(['Email Is Required'])
+        elif User.objects.filter(email=email).exists():
+            self._errors['email'] = self.error_class(["Email already exists."])
         return self.cleaned_data
 
 

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path('create-profile/', views.create_profile, name='create-profile'),
 
     path('update-profile/', views.update_profile, name='update-profile'),
+    path('confirm-email/<uidb64>/<token>/', views.confirm_email, name='confirm_email'),
     path('manage/', views.manage_organizations, name='manage-orgs'),
     path('link-account/', views.link_account, name='link-account'),
     path('change-password/', views.change_password, name='change-password'),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -292,7 +292,7 @@ def update_profile(request):
             user_form.save()
             token_generator = PasswordResetTokenGenerator()
             token = token_generator.make_token(request.user)
-            encoded_token = urlsafe_base64_encode(force_bytes(f"{token}+{new_email}+{request.user.id}"))
+            encoded_token = urlsafe_base64_encode(force_bytes(f"{token} {new_email} {request.user.id}"))
             verification_url = f"http://{get_current_site(request).domain}/confirm-email/{request.user.pk}/{encoded_token}"
             send_email_verification(request, old_email, new_email, verification_url)
             messages.add_message(request, messages.INFO, f'A verification email has been sent to {new_email}.')
@@ -312,7 +312,7 @@ def update_profile(request):
 @login_required(login_url='login')
 def confirm_email(request, uidb64, token):
     decoded_token = urlsafe_base64_decode(token).decode('utf-8')
-    new_token, new_email, user_id_str = decoded_token.split('+')
+    new_token, new_email, user_id_str = decoded_token.split(' ')
     new_token = new_token.strip()
     new_email = new_email.strip()
     user_id = user_id_str.strip()

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -20,6 +20,7 @@ from django.utils.safestring import mark_safe
 from django.utils.encoding import force_text
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_protect
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
 
 from unidecode import unidecode
 from django.db.models import Q
@@ -280,9 +281,20 @@ def update_profile(request):
     profile = Profile.objects.select_related('user').get(user=request.user)
 
     if request.method == 'POST':
+        old_email = request.user.email
         user_form = UserUpdateForm(request.POST, instance=request.user)
         profile_form = ProfileUpdateForm(request.POST, request.FILES, instance=request.user.user_profile)
-        if user_form.is_valid() and profile_form.is_valid():
+        new_email = user_form.data['email']
+        
+        if new_email != old_email and new_email != '' and user_form.is_valid():
+            token_generator = PasswordResetTokenGenerator()
+            token = token_generator.make_token(request.user)
+            encoded_token = urlsafe_base64_encode(force_bytes(f"{token}+{new_email}+{request.user.id}"))
+            verification_url = f"http://{get_current_site(request).domain}/confirm-email/{request.user.pk}/{encoded_token}"
+            send_email_verification(request, old_email, new_email, verification_url)
+            messages.add_message(request, messages.INFO, f'A verification email has been sent to {new_email}.')
+            return redirect('update-profile')
+        elif user_form.is_valid() and profile_form.is_valid(): 
             user_form.save()
             profile_form.save()
             messages.add_message(request, messages.SUCCESS, 'Profile updated!')
@@ -293,6 +305,27 @@ def update_profile(request):
 
     context = { 'profile': profile, 'user_form': user_form, 'profile_form': profile_form }
     return render(request, 'accounts/update-profile.html', context)
+
+@login_required(login_url='login')
+def confirm_email(request, uidb64, token):
+    decoded_token = urlsafe_base64_decode(token).decode('utf-8')
+    new_token, new_email, user_id_str = decoded_token.split('+')
+    new_token = new_token.strip()
+    new_email = new_email.strip()
+    user_id = user_id_str.strip()
+    
+    user = User.objects.get(pk=user_id)
+    token_valid = PasswordResetTokenGenerator().check_token(user, new_token)
+    
+    if not User.objects.filter(pk=user_id).exists():
+        meesage.error("User not found")
+        return redirect('login')
+
+    user = User.objects.get(pk=user_id)
+    user.email = new_email
+    user.save()
+    messages.add_message(request, messages.SUCCESS, 'Email updated Successfully.')
+    return redirect('dashboard')
 
 @login_required(login_url='login')
 def change_password(request):

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -287,6 +287,9 @@ def update_profile(request):
         new_email = user_form.data['email']
         
         if new_email != old_email and new_email != '' and user_form.is_valid():
+            user_form.instance.email = old_email
+            profile_form.save()
+            user_form.save()
             token_generator = PasswordResetTokenGenerator()
             token = token_generator.make_token(request.user)
             encoded_token = urlsafe_base64_encode(force_bytes(f"{token}+{new_email}+{request.user.id}"))

--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -561,4 +561,4 @@ def send_email_verification(request, old_email, new_email, verification_url):
     
     old_subject = 'Alert Email On Change of Email For Your Local Contexts Hub Profile'
     old_email_data = {'user':request.user.username, 'old_email':old_email, 'new_email':new_email}
-    send_mailgun_template_email(old_email, old_subject,'email_on_old_email', old_email_data)
+    send_mailgun_template_email(old_email, old_subject,'notify_email_on_email_update', old_email_data)

--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -556,7 +556,7 @@ def send_project_person_email(request, to_email, proj_id, account):
 
 def send_email_verification(request, old_email, new_email, verification_url):
     subject = 'Email Verification Link For Your Local Contexts Hub Profile'
-    data = {'user':request.user.username, 'verification_url':verification_url}
+    data = {'user':request.user.username, 'new_email':new_email, 'old_email':old_email, 'verification_url':verification_url}
     send_mailgun_template_email(new_email, subject, 'verify_email_update', data)
     
     old_subject = 'Alert Email On Change of Email For Your Local Contexts Hub Profile'

--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -557,8 +557,8 @@ def send_project_person_email(request, to_email, proj_id, account):
 def send_email_verification(request, old_email, new_email, verification_url):
     subject = 'Email Verification Link For Your Local Contexts Hub Profile'
     data = {'user':request.user.username, 'verification_url':verification_url}
-    send_mailgun_template_email(new_email, subject, 'verify_email', data)
+    send_mailgun_template_email(new_email, subject, 'verify_email_update', data)
     
     old_subject = 'Alert Email On Change of Email For Your Local Contexts Hub Profile'
     old_email_data = {'user':request.user.username, 'old_email':old_email, 'new_email':new_email}
-    send_mailgun_template_email(old_email, old_subject,'old_email', old_email_data)
+    send_mailgun_template_email(old_email, old_subject,'email_on_old_email', old_email_data)

--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -553,3 +553,12 @@ def send_project_person_email(request, to_email, proj_id, account):
 # if list, loop over each email.
 # def send_update_email(email):
 #     send_mailgun_template_email(email, 'Local Contexts Hub Updates', 'hub_updates', None)
+
+def send_email_verification(request, old_email, new_email, verification_url):
+    subject = 'Email Verification Link For Your Local Contexts Hub Profile'
+    data = {'user':request.user.username, 'verification_url':verification_url}
+    send_mailgun_template_email(new_email, subject, 'verify_email', data)
+    
+    old_subject = 'Alert Email On Change of Email For Your Local Contexts Hub Profile'
+    old_email_data = {'user':request.user.username, 'old_email':old_email, 'new_email':new_email}
+    send_mailgun_template_email(old_email, old_subject,'old_email', old_email_data)

--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -559,6 +559,6 @@ def send_email_verification(request, old_email, new_email, verification_url):
     data = {'user':request.user.username, 'new_email':new_email, 'old_email':old_email, 'verification_url':verification_url}
     send_mailgun_template_email(new_email, subject, 'verify_email_update', data)
     
-    old_subject = 'Alert Email On Change of Email For Your Local Contexts Hub Profile'
+    old_subject = 'Change of Email For Your Local Contexts Hub Profile'
     old_email_data = {'user':request.user.username, 'old_email':old_email, 'new_email':new_email}
     send_mailgun_template_email(old_email, old_subject,'notify_email_on_email_update', old_email_data)


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8687c2q86)**
  
- Description: Don't think we have anything like this but we should have a confirmation email that is sent to users when their email is changed from their profile (like other platforms do).

This email can either be:
- A confirmation email that a user is sent to the original email letting them know that the email is being changed and an email sent to the new email asking to confirm the email by clicking a button. If not clicked, the email doesnt change in the profile.
- A notification email to the original email saying that their email has been changed and if this was done in error to contact us. No confirmation needed, email changed right away.
- A mix of 1 and 2.

**Solution:**
- Added the functionality of detecting email changes on the update-profile.
- If the new_email doesn't exist in DB, generate a token and send it to new_email.
- Created a view to verify the token from new_email.
- Alert email on old_email notifying the user about the change of email on HUB.
- Made two new templates on Mailgun for new_email and old_email.

**Before:**
https://github.com/localcontexts/localcontextshub/assets/145371882/708f823d-640a-4f9a-ac7c-b892b2f9ea06



**After:**
https://github.com/localcontexts/localcontextshub/assets/145371882/a3e5a69b-982c-4328-a6d3-e73b16850d8a

**Email on New Email:**
![email_on_new_email](https://github.com/localcontexts/localcontextshub/assets/145371882/249bd4d6-aa5d-441e-ae5c-a4a80c343cf9)


**Email on Old Email:**
![email_on_old_email](https://github.com/localcontexts/localcontextshub/assets/145371882/80389e79-7b59-46f5-85c8-1f59a399ebbd)
