### PR TITLE
Add disclaimer to Public View for logged in, unconfirmed accounts

### DIFF
--- a/localcontexts/static/javascript/main.js
+++ b/localcontexts/static/javascript/main.js
@@ -1513,6 +1513,10 @@ function cancelUnlink() {
     confirmationAlert.style.display = 'none';
 }
 
+function cancelDisclaimer() {
+    var disclaimerAlert = document.getElementById('disclaimerAlert');
+    disclaimerAlert.style.display = 'none';
+}
 if (window.location.href.includes('newsletter/preferences/') ) {
     const unsubscribeChkbox = document.getElementById('unsubscribe');
     const unsubscribeBtn = document.getElementById('unsubscribebtn');

--- a/projects/views.py
+++ b/projects/views.py
@@ -19,6 +19,7 @@ def view_project(request, unique_id):
     try:
         project = Project.objects.select_related('project_creator').prefetch_related('bc_labels', 'tk_labels').get(unique_id=unique_id)
         creator = ProjectCreator.objects.get(project=project)
+        status = creator.account_is_confirmed()
         creator.validate_user_access(request.user)
     except (Project.DoesNotExist, UnconfirmedAccountException):
         return render(request, '404.html', status=404)
@@ -62,6 +63,7 @@ def view_project(request, unique_id):
         'template_name': template_name,
         'can_download': can_download,
         'label_groups': label_groups,
+        'status': status,
     }
 
     if template_name:

--- a/templates/partials/_project-actions.html
+++ b/templates/partials/_project-actions.html
@@ -1085,4 +1085,19 @@
         </div>
 
     </div>
+
+{% endif %}
+{% if status is False %}
+<div id="disclaimerAlert" class="modal">
+    <div class="modal-defaults deactivate-modal flex-this column w-100">
+        <div class="w-100">
+            <div>
+                <h5 class="primary-black-text no-top-margin">Your account status is still unconfirmed. Confirm your account so others can view your project.</h5>  
+            </div>
+            <div class="flex-this w-100 text-align-center">   
+                <div class="margin-left-1 primary-btn action-btn" onclick="cancelDisclaimer()">OK</div>
+            </div>
+        </div>
+    </div>
+</div>
 {% endif %}


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8687c2zh2)**
  
- Description: If user is unconfirmed, add disclaimer on "Public View" for a project page (where user is logged in and trying to see what a project would look like as a public link). Disclaimer would inform them that others cannot see this public view unless they confirmed their account.

**Solution:**
- For Community and Institute added a flag of status in the template
- Added a disclaimer over the template to render for those communities and institutions having False status