### PR TITLE
#86874v7z3 Skip Confirmation Preparation Step in Sandbox

### DIFF
--- a/communities/views.py
+++ b/communities/views.py
@@ -93,8 +93,11 @@ def connect_community(request):
 
 @login_required(login_url='login')
 def preparation_step(request):
-    community = True
-    return render(request, 'accounts/preparation.html', { 'community' : community })
+    if dev_prod_or_local(request.get_host()) == "SANDBOX":
+        return redirect('create-community')
+    else:
+        community = True
+        return render(request, 'accounts/preparation.html', { 'community' : community })
 
 
 # Create Community

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -67,8 +67,11 @@ def connect_institution(request):
 
 @login_required(login_url='login')
 def preparation_step(request):
-    institution = True
-    return render(request, 'accounts/preparation.html', { 'institution': institution })
+    if dev_prod_or_local(request.get_host()) == "SANDBOX":
+        return redirect('create-institution')
+    else:
+        institution = True
+        return render(request, 'accounts/preparation.html', { 'institution': institution })
 
 @login_required(login_url='login')
 def create_institution(request):


### PR DESCRIPTION
**Problem:** 
Account creation in the sandbox takes user to the preparation step which talks about the account confirmation step. Since the sandbox does not have/need a confirmation step, the preparation step does not need to be there either.

**Solution:** 
Have the preparation step view detect environment, and if it's sandbox, skip directly to create account page.

**Before (institution account creation with preparation step):**


https://github.com/localcontexts/localcontextshub/assets/41635757/cb0691d9-5768-44e2-ba71-7360b66d662e


**After (institution account creation without preparation step):**


https://github.com/localcontexts/localcontextshub/assets/41635757/3bf323a8-fa1b-40c8-8ce6-374ace102c21

Functionality is the same for both community and institution account creation.