### PR TITLE
#8687xm41k Project Person error on Project edit fix

### DIFF
--- a/communities/views.py
+++ b/communities/views.py
@@ -975,11 +975,8 @@ def edit_project(request, pk, project_uuid):
 
             instances = formset.save(commit=False)
             for instance in instances:
-                if not instance.name or not instance.email:
-                    instance.delete()
-                else:
-                    instance.project = data
-                    instance.save()
+                instance.project = data
+                instance.save()
 
             # Add selected contributors to the ProjectContributors object
             add_to_contributors(request, community, data)

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -720,11 +720,8 @@ def edit_project(request, pk, project_uuid):
 
             instances = formset.save(commit=False)
             for instance in instances:
-                if not instance.name or not instance.email:
-                    instance.delete()
-                else:
-                    instance.project = data
-                    instance.save()
+                instance.project = data
+                instance.save()
 
             # Add selected contributors to the ProjectContributors object
             add_to_contributors(request, institution, data)

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -470,11 +470,8 @@ def edit_project(request, researcher_id, project_uuid):
 
                 instances = formset.save(commit=False)
                 for instance in instances:
-                    if not instance.name or not instance.email:
-                        instance.delete()
-                    else:
-                        instance.project = data
-                        instance.save()
+                    instance.project = data
+                    instance.save()
 
                 # Add selected contributors to the ProjectContributors object
                 add_to_contributors(request, researcher, data)

--- a/templates/partials/_project-actions.html
+++ b/templates/partials/_project-actions.html
@@ -173,7 +173,15 @@
                             {% endif %}
                             {% if project.additional_contributors %}
                                 {% for contributor in project.additional_contributors.all %}
-                                    <li>{{ contributor.name }} | Contributor </li>
+                                    <li>
+                                        {% if contributor.name and contributor.email %}
+                                            {{ contributor.name }}, {{ contributor.email }}
+                                        {% elif contributor.name %}
+                                            {{ contributor.name }}
+                                        {% elif contributor.email %}
+                                            {{ contributor.email }} 
+                                        {% endif %} | Contributor
+                                    </li>
                                 {% endfor %}
                             {% endif %}
                         </ul>


### PR DESCRIPTION
**Problem:** 
When someone would create a Project and add a Project Person's email only, on Project edit that user would get an error because of the way views for Project contributors were set up.

**Solution:** 
Simplified the views to exclude the code that was causing the issue and also added a condition in the Project Action template for handling cases where there either wasn't a name or an email for a Project Person on save.

**How to test this PR:**
- Create a Project and add one Project Person with just email no name, and one with just a name no email. Save Project
- Go to edit this Project and just save it again.
- If there is no error and you still have your Project Person entries the way they were set up originally, then error was fixed.