### PR TITLE
#8687ypnr4 Resolve Issue With Disappearing Button

### DIFF
--- a/communities/views.py
+++ b/communities/views.py
@@ -1312,9 +1312,11 @@ def download_labels(request, pk):
 @member_required(roles=['admin'])
 def update_community_boundary(request, pk):
     community = get_community(pk)
+    member_role = check_member_role(request.user, community)
     context = {
         'community': community,
         'main_area': 'boundary',
+        'member_role': member_role,
     }
     return render(request, 'communities/update-community.html', context)
 

--- a/templates/partials/infocards/_community-dashcard.html
+++ b/templates/partials/infocards/_community-dashcard.html
@@ -18,7 +18,7 @@
                 {% include 'snippets/notifications.html' with scope=community %}
 
                 <!-- Settings -->
-                {% if request.user == community.community_creator or request.user in community.get_admins %}
+                {% if request.user == community.community_creator or member_role == 'admin' %}
                     <div class="margin-left-8">
                         <a href="{% url 'update-community' community.id %}" class="darkteal-text primary-btn white-btn"> Settings <i class="fa fa-cog" aria-hidden="true"></i></a>
                     </div>

--- a/templates/partials/infocards/_community-dashcard.html
+++ b/templates/partials/infocards/_community-dashcard.html
@@ -18,7 +18,7 @@
                 {% include 'snippets/notifications.html' with scope=community %}
 
                 <!-- Settings -->
-                {% if request.user == community.community_creator or member_role == 'admin' %}
+                {% if request.user == community.community_creator or request.user in community.get_admins %}
                     <div class="margin-left-8">
                         <a href="{% url 'update-community' community.id %}" class="darkteal-text primary-btn white-btn"> Settings <i class="fa fa-cog" aria-hidden="true"></i></a>
                     </div>


### PR DESCRIPTION
How to duplicate bug.
* create a community
* invite another user as admin
* log-in as the invited user > navigate to community settings page > click on "Boundary Community Location" button
* observe 
  * the settings button in the top right corner disappears 
  * the user's role next to the image on the left disappears
-------------------------------------------------------


**Before Fix**
![image](https://github.com/localcontexts/localcontextshub/assets/145378945/87e69d50-6002-4233-b40b-fbfd8f9a7bbf)


**After Fix**
![image](https://github.com/localcontexts/localcontextshub/assets/145378945/3ba161b6-7af3-4bda-8bd8-111dfa47b15d)
