### PR TITLE
#8687tx2w0 Added Api call to update Salesforce

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -6,6 +6,7 @@ from helpers.models import LabelTranslation, Notice, NoticeTranslation
 from projects.models import Project, ProjectCreator
 from institutions.models import Institution
 from researchers.models import Researcher
+from accounts.models import Subscription
 from django.contrib.auth.models import User
 
 class InstitutionSerializer(serializers.ModelSerializer):
@@ -132,3 +133,8 @@ class GetUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('id', 'username', 'email', 'first_name', 'last_name')
+
+class GetSubscriptionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Subscription
+        fields = ['institution', 'community', 'researcher', 'users_count', 'api_key_count', 'project_count', 'notification_count', 'start_date', 'end_date', 'date_last_updated']


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8687wa0f0)**
 
**Description:**
Create a call for the subscriptions model that uses the date last updated as a param and gets all the items after that date so that SF can pull numbers from that call only for items after a specific date daily or twice daily.

As a user does any action that lower's a subscription count (creates a project, adds an admin/editor, creates an API key, etc., the Date Updated field in Subscriptions model is updated along with the associated count being affected.
When Rohit submits an API Call for subscribed users, the datetime that this call was last run by SF would be added as a parameter.
The Hub will use that datetime as a start datetime to query the Subscriptions model. If any of the datetimes in the Date Updated field are after the datetime passed from SF, then Rohit will get back a list of those accounts with the approprate information to update SF (account ID with appended account type, all counts)

**Solution:**
- Created an end-point
- Added date_last_updated as param so Rohit can retrieve data using the end-point from the HUB

**End Point**

![image](https://github.com/localcontexts/localcontextshub/assets/145371882/6e3015f7-3488-4c09-ba1e-4ec319704f02)
