### PR TITLE
#8687zam2m Added notification count functionality for subscriptions

### DIFF
--- a/institutions/utils.py
+++ b/institutions/utils.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, redirect
 from django.db.models import Q
+from django.contrib import messages
 from .models import Institution
 from helpers.utils import create_salesforce_account_or_lead
 from django.contrib import messages
@@ -57,3 +58,20 @@ def add_user(request, institution, member, current_role, new_role):
         messages.add_message(request, messages.ERROR, 
                             'Your institution has reached its editors and admins limit. '
                             'Please upgrade your subscription plan to add more editors and admins.')
+
+def notification_condition(request, notification_count, communities_selected):
+    if notification_count < len(communities_selected):
+        remaining_notifications = len(communities_selected) - notification_count
+        if notification_count == 1 and remaining_notifications == 1:
+            messages.add_message(request, messages.INFO, f'You have successfully notified {notification_count} community. {remaining_notifications} community could not be notified due to subscription limit. Please upgrade your subscription plan to notify more communities.')
+        elif notification_count == 1:
+            messages.add_message(request, messages.INFO, f'You have successfully notified {notification_count} community. {remaining_notifications} communities could not be notified due to subscription limit. Please upgrade your subscription plan to notify more communities.')
+        elif remaining_notifications == 1:
+            messages.add_message(request, messages.INFO, f'You have successfully notified {notification_count} communities. {remaining_notifications} community could not be notified due to subscription limit. Please upgrade your subscription plan to notify more communities.')
+        else:
+            messages.add_message(request, messages.INFO, f'You have successfully notified {notification_count} communities. {remaining_notifications} communities could not be notified due to subscription limit. Please upgrade your subscription plan to notify more communities.')
+    else:
+        if notification_count == 1:
+            messages.add_message(request, messages.INFO, f'You have successfully notified {notification_count} community.')
+        else:
+            messages.add_message(request, messages.INFO, f'You have successfully notified {notification_count} communities.')

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -1244,9 +1244,9 @@ def project_actions(request, pk, project_uuid):
                 elif 'notify_btn' in request.POST:
                     subscription = Subscription.objects.get(institution=institution) 
                     if subscription.notification_count == 0:
-                        messages.add_message(request, messages.INFO, 'Your institution has reached its notification limit.'
+                        messages.add_message(request, messages.ERROR, 'Your institution has reached its notification limit.'
                             'Please upgrade your subscription plan to notify more communities.')
-                        return redirect('institution-projects', institution.id)
+                        return redirect('institution-project-actions', institution.id, project.unique_id)
                     # Set private project to contributor view
                     if project.project_privacy == "Private":
                         project.project_privacy = "Contributor"
@@ -1300,7 +1300,7 @@ def project_actions(request, pk, project_uuid):
                     notification_condition(request, notification_count, communities_selected)
                     subscription.notification_count -= notification_count
                     subscription.save()
-                    return redirect('institution-projects', institution.id)
+                    return redirect('institution-project-actions', institution.id, project.unique_id)
                 elif 'link_projects_btn' in request.POST:
                     selected_projects = request.POST.getlist('projects_to_link')
 

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -1239,20 +1239,23 @@ def project_actions(request, pk, project_uuid):
                         data.sender_affiliation = institution.institution_name
                         data.save()
                         send_action_notification_to_project_contribs(project)
-                        return redirect(
-                            "institution-project-actions",
-                            institution.id,
-                            project.unique_id,
-                        )
-
-                elif "notify_btn" in request.POST:
+                        return redirect('institution-project-actions', institution.id, project.unique_id)
+                
+                elif 'notify_btn' in request.POST:
+                    subscription = Subscription.objects.get(institution=institution) 
+                    if subscription.notification_count ==0:
+                        messages.add_message(request, messages.INFO, 'Your institution has reached its notification limit.'
+                            'Please upgrade your subscription plan to notify more communities.')
+                        return redirect('institution-projects', institution.id)
                     # Set private project to contributor view
                     if project.project_privacy == "Private":
                         project.project_privacy = "Contributor"
                         project.save()
 
-                    communities_selected = request.POST.getlist("selected_communities")
-
+                    communities_selected = request.POST.getlist('selected_communities')
+                    notification_count = len(communities_selected)
+                    subscription.notification_count = subscription.notification_count - notification_count
+                    subscription.save()
                     # Reference ID and title for notification
                     title = (
                         str(institution.institution_name)

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -1244,7 +1244,7 @@ def project_actions(request, pk, project_uuid):
                 elif 'notify_btn' in request.POST:
                     subscription = Subscription.objects.get(institution=institution) 
                     if subscription.notification_count == 0:
-                        messages.add_message(request, messages.ERROR, 'Your institution has reached its notification limit.'
+                        messages.add_message(request, messages.ERROR, 'Your institution has reached its notification limit. '
                             'Please upgrade your subscription plan to notify more communities.')
                         return redirect('institution-project-actions', institution.id, project.unique_id)
                     # Set private project to contributor view

--- a/localcontexts/static/css/main.css
+++ b/localcontexts/static/css/main.css
@@ -1670,3 +1670,8 @@ i[data-tooltip]:hover:after {
     opacity: 0.6;
     cursor: not-allowed;
 }
+
+.project-actions-alert {
+    margin: 8px auto;
+    width: 1250px;
+}

--- a/templates/partials/_project-actions.html
+++ b/templates/partials/_project-actions.html
@@ -20,7 +20,9 @@
         </div>
     {% endif %}
 {% endif %}
-
+<div class="project-actions-alert">
+    {% include 'partials/_alerts.html' %}
+</div>
 <div class="flex-this auto-margin" style="max-width: 1271px;">
 
     <!-- PROJECT -->


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8687zam2m)**
 
 **Description:**
 Notification count - notification per community notified
When a Project is created, in Project Actions there is an option to Notify Communities.
Count -1 per community added to notification modal.

**Solution:**
- Detected the number of communities notified by the institute and reduced that no from the institute's notification count.
- If the notification count is 0 disable the notifying communities process.
- Showed appropriate messages when the user tries to notify any community while the notification count is 0.

**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/96fea805-2dd9-462b-aa2a-8c3b418730ef

