### PR TITLE
#8687ypkg0 View Label: return 404 instead of 500 if Label does not exist

### DIFF
--- a/communities/views.py
+++ b/communities/views.py
@@ -713,6 +713,7 @@ def view_label(request, pk, label_uuid):
     projects = Project.objects.none()
     creator_name = ''
     approver_name = ''
+    last_editor_name = '' 
     bclabels = BCLabel.objects.none()
     tklabels = TKLabel.objects.none()
     label_versions = LabelVersion.objects.none()
@@ -726,7 +727,7 @@ def view_label(request, pk, label_uuid):
         label_versions = LabelVersion.objects.filter(bclabel=bclabel).order_by('version')
         bclabels = BCLabel.objects.filter(community=community).exclude(unique_id=label_uuid).values('unique_id', 'name', 'label_type', 'is_approved')
         tklabels = TKLabel.objects.filter(community=community).values('unique_id', 'name', 'label_type', 'is_approved')
-    if TKLabel.objects.filter(unique_id=label_uuid).exists():
+    elif TKLabel.objects.filter(unique_id=label_uuid).exists():
         tklabel = TKLabel.objects.select_related('created_by', 'approved_by').get(unique_id=label_uuid)
         projects = tklabel.project_tklabels.all()
         creator_name = get_users_name(tklabel.created_by)
@@ -735,6 +736,8 @@ def view_label(request, pk, label_uuid):
         label_versions = LabelVersion.objects.filter(tklabel=tklabel).order_by('version')
         tklabels = TKLabel.objects.filter(community=community).exclude(unique_id=label_uuid).values('unique_id', 'name', 'label_type', 'is_approved')
         bclabels = BCLabel.objects.filter(community=community).values('unique_id', 'name', 'label_type', 'is_approved')
+    else:
+        return redirect('select-label', community.id)
 
     context = {
         'community': community,


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8687ypkg0)**
 
 **Description:**
Right now if you go to the View Label page after the Label was deleted, it throws a 500 error, but it should be throwing a 404 instead.


**Solution:**
- Added the missing variable 
- Updated the rendering conditions and redirection from page if label not found

**Before:**
![view-label(before)](https://github.com/localcontexts/localcontextshub/assets/145371882/31e1f068-9fd6-438e-acd5-58503e0384f4)

**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/9b3f566f-cefd-4be1-8b13-b38c394ed0b6

