### PR TITLE
dependabot-discovered-vulnerability-fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ mccabe==0.7.0
 oauthlib==3.2.2
 oscrypto==1.3.0
 packaging==21.0
-pillow==10.2.0
+pillow>=10.3.0
 pluggy==1.4.0
 protobuf==3.18.3
 psycopg2-binary==2.9.9


### PR DESCRIPTION
This updates pillow to resolve a dependabot [discovered](https://github.com/localcontexts/localcontextshub/security/dependabot/34) vulnerability.

Updating this did not require updates to any other packages.