### PR TITLE
#8687ypjdr Should not be able to save a Label if default text is empty

### DIFF
--- a/bclabels/forms.py
+++ b/bclabels/forms.py
@@ -13,6 +13,13 @@ class CustomizeBCLabelForm(forms.ModelForm):
             'audiofile': forms.ClearableFileInput(attrs={'class': 'w-100 hide', 'id': 'originalLabelAudioUploadBtn', 'onchange': 'showAudioFileName()'}),
         }
     
+    def clean(self):
+        super(CustomizeBCLabelForm, self).clean()
+        label_text =  self.cleaned_data.get('label_text')
+
+        if label_text == '':
+            self._errors['label_text'] = self.error_class(['Label text must not be empty.'])
+
     def clean_audiofile(self):
         audiofile = self.cleaned_data.get('audiofile')
         if audiofile:

--- a/communities/views.py
+++ b/communities/views.py
@@ -485,14 +485,15 @@ def customize_label(request, pk, label_code):
         return redirect('select-label', community.id)
     else:
         form_class, label_display, label_type = get_form_and_label_type(label_code)
-        form = form_class(request.POST or None, request.FILES)
         title = f"A {label_display} was customized by {name} and is waiting approval by another member of the community."
 
         if request.method == "GET":
             add_translation_formset = AddLabelTranslationFormSet(queryset=LabelTranslation.objects.none())
+            form = form_class()
 
         elif request.method == "POST":
             add_translation_formset = AddLabelTranslationFormSet(request.POST)
+            form = form_class(request.POST or None, request.FILES)
 
             if form.is_valid() and add_translation_formset.is_valid():
                 data = form.save(commit=False)

--- a/templates/communities/select-label.html
+++ b/templates/communities/select-label.html
@@ -127,7 +127,7 @@
         <div id="open-div-{{ bclabel.unique_id }}" style="height: 0px; overflow: hidden;" class="div-toggle">
             <div class="full-label-card flex-this">
                 <div class="margin-right-16"><img src="{{bclabel.img_url}}" class="label-large pointer-event-none" alt="{{ bclabel.alt_text }}"></div>
-                <div>
+                <div class="w-90">
                     <div class="flex-this space-between">
                         <div><h3 class="no-top-margin">{{ bclabel.name }}</h3></div>
 
@@ -187,7 +187,7 @@
                 <div class="margin-right-16">
                     <img src="{{ tklabel.img_url }}" class="label-large  pointer-event-none" alt="{{ tklabel.alt_text }}">
                 </div>
-                <div>
+                <div class="w-90">
                     <div class="flex-this space-between">
                         <div><h3 class="no-top-margin">{{ tklabel.name }}</h3></div>
 

--- a/templates/partials/_add-translation.html
+++ b/templates/partials/_add-translation.html
@@ -44,6 +44,8 @@
 
 {% if add_translation_formset.errors %}
     {% for error in add_translation_formset.errors %}
-        <div class="msg-red w-50"><small>{{ error.as_text }}</small></div> 
+        {% if error %}
+            <div class="msg-red w-50"><small>{{ error.as_text }}</small></div>
+        {% endif%} 
     {% endfor %}
 {% endif %}  

--- a/tklabels/forms.py
+++ b/tklabels/forms.py
@@ -13,6 +13,13 @@ class CustomizeTKLabelForm(forms.ModelForm):
             'audiofile': forms.ClearableFileInput(attrs={'class': 'w-100 hide', 'id': 'originalLabelAudioUploadBtn', 'onchange': 'showAudioFileName()'}),
         }
 
+    def clean(self):
+        super(CustomizeTKLabelForm, self).clean()
+        label_text =  self.cleaned_data.get('label_text')
+
+        if label_text == '':
+            self._errors['label_text'] = self.error_class(['Label text must not be empty.'])
+
     def clean_audiofile(self):
         audiofile = self.cleaned_data.get('audiofile')
         if audiofile:


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8687ypjdr)**
 
 **Description:**

![image](https://github.com/localcontexts/localcontextshub/assets/145371882/cddfc807-bf76-4f6c-8df1-8c08a83a22bf)

This was a customized Label that was saved with no default text or translations. 

Set up validation where something has to be in the default text field, otherwise it cannot be saved. Additionally, if there is not a lot of text in the text field (its a short default text), the buttons still appear as they should -- to the right of the container (image below).
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/88257319-c8bc-4c03-86f6-f458bbe40077)

**Solution:**

- Adjusted the width of the div containing label content.
- Added clean for Customize BCLabels and TKLabels to set up validation on the empty label text field.
- Updated the form call in the view to ensure that the form validation is being properly called. 

**Before:**

https://github.com/localcontexts/localcontextshub/assets/145371882/9f882953-162f-4972-8be0-65898cf0ac21

**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/f90f01a2-d0d8-4d89-b356-ec560e7ff997


