### PR TITLE
#86879gwuc Download Labels button help text floating away

### DIFF
--- a/localcontexts/static/css/main.css
+++ b/localcontexts/static/css/main.css
@@ -436,7 +436,8 @@ button[disabled],
 }
 .btn-help-text {
     position: absolute;
-    left: 1080px;
+    right: 295px;
+    z-index: 1;
     width: 250px;
     background-color: #EF6C00;
     padding: 8px 16px;


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/86879gwuc)**
 
 **Description:**
Help text should appear underneath the button and should not be transparent.
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/e4562e58-20cf-48e9-9e83-79a37e231a82)

**Solution:**

- Adjusted the CSS of that div to make it appear under the button and opaque.

**After:**
![btn-help-text](https://github.com/localcontexts/localcontextshub/assets/145371882/8dee9c24-3b50-471f-8674-bfeb09e6f32d)
