### PR TITLE
#86884w996 Bug: Project Board filter with Labels remove duplication

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -638,7 +638,7 @@ def projects_board(request, filtertype=None):
         else:
             if filtertype == 'labels':
                 results = projects.filter(
-                    Q(bc_labels__isnull=False) | 
+                    Q(bc_labels__isnull=False) |
                     Q(tk_labels__isnull=False)).distinct()
             elif filtertype == 'notices':
                 results = projects.filter(

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -638,7 +638,8 @@ def projects_board(request, filtertype=None):
         else:
             if filtertype == 'labels':
                 results = projects.filter(
-                    Q(bc_labels__isnull=False) | Q(tk_labels__isnull=False)).distinct()
+                    Q(bc_labels__isnull=False) | 
+                    Q(tk_labels__isnull=False)).distinct()
             elif filtertype == 'notices':
                 results = projects.filter(
                     project_notice__archived=False).distinct()

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -638,7 +638,7 @@ def projects_board(request, filtertype=None):
         else:
             if filtertype == 'labels':
                 results = projects.filter(
-                    Q(bc_labels__isnull=False) | Q(tk_labels__isnull=False))
+                    Q(bc_labels__isnull=False) | Q(tk_labels__isnull=False)).distinct()
             elif filtertype == 'notices':
                 results = projects.filter(
                     project_notice__archived=False).distinct()


### PR DESCRIPTION
Fixed Projects filtered by Labels in the Project Board were being duplicated if they had more than one Label attached.

Solution: added `.distinct()` to the query