### PR TITLE
#86886vqv4 Corrected admin invite role

### DIFF
--- a/templates/accounts/member-invitations.html
+++ b/templates/accounts/member-invitations.html
@@ -50,7 +50,7 @@
                                         <i>
                                             {% if invite.role == 'viewer' %} Viewer {% endif %}
                                             {% if invite.role == 'editor' %} Editor {% endif %}
-                                            {% if invite.role == 'Admin' %} Administrator {% endif %}
+                                            {% if invite.role == 'admin' %} Administrator {% endif %}
                                         </i>
                                         <br>
 


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/86886vqv4)**

**Description:**
When the invite role is admin, the request doesn't show the user its proposed responsibility.
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/4dc2f6eb-2bbd-4ad8-b7d3-8f6be03d2c5f)

**Solution:**
- Corrected `invite.role` in template.

**Before:**
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/e247e913-0ebe-4e5d-b61d-4e5e4874bb67)

**After:**
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/ae5f80ef-e184-421a-8bac-af747f49a211)


