### PR TITLE
#8687zzy47 Added subscription settings page

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -71,4 +71,5 @@ urlpatterns = [
         ),
         name="password_reset_complete"
     ),
+    path('subscription/<str:pk>/<str:account_type>/', views.subscription, name="subscription"),
 ]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -71,5 +71,9 @@ urlpatterns = [
         ),
         name="password_reset_complete"
     ),
-    path('subscription/<str:pk>/<str:account_type>/', views.subscription, name="subscription"),
+    path(
+        "subscription/<str:pk>/<str:account_type>/",
+        views.subscription,
+        name="subscription"
+    ),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -46,7 +46,7 @@ from institutions.utils import get_institution
 from localcontexts.utils import dev_prod_or_local
 from researchers.utils import is_user_researcher
 from helpers.utils import (accept_member_invite, validate_email, validate_recaptcha, check_member_role)
-
+from institutions.decorators import member_required
 from .models import SignUpInvitation, Profile, UserAffiliation, Subscription
 from helpers.models import HubActivity
 from projects.models import Project
@@ -848,8 +848,11 @@ def subscription_inquiry(request):
 
 
 @login_required(login_url="login")
-# @member_required(roles=["admin"])
+@member_required(roles=["admin"])
 def subscription(request, pk, account_type, related=None):
+    if dev_prod_or_local(request.get_host()) == "SANDBOX":
+        return redirect("dashboard")
+
     if account_type == 'institution':
         institution = get_institution(pk)
         member_role = check_member_role(request.user, institution)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -882,9 +882,9 @@ def subscription(request, pk, account_type, related=None):
         }
     if account_type == 'researcher':
         researcher = Researcher.objects.get(id=pk)
-        try:
-            subscription = Subscription.objects.get(researcher=researcher)
-        except Subscription.DoesNotExist:
+        if researcher.is_subscribed:
+            subscription = Subscription.objects.filter(researcher=researcher).first()
+        else:
             subscription = None
         renew = (
             subscription.end_date < timezone.now() if subscription is not None

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -45,8 +45,9 @@ from .utils import (
 from institutions.utils import get_institution
 from localcontexts.utils import dev_prod_or_local
 from researchers.utils import is_user_researcher
-from helpers.utils import (accept_member_invite, validate_email, validate_recaptcha, check_member_role)
-from institutions.decorators import member_required
+from helpers.utils import (
+    accept_member_invite, validate_email, validate_recaptcha, check_member_role
+)
 from .models import SignUpInvitation, Profile, UserAffiliation, Subscription
 from helpers.models import HubActivity
 from projects.models import Project
@@ -848,12 +849,15 @@ def subscription_inquiry(request):
 
 
 @login_required(login_url="login")
-@member_required(roles=["admin"])
 def subscription(request, pk, account_type, related=None):
     if dev_prod_or_local(request.get_host()) == "SANDBOX":
         return redirect("dashboard")
 
-    if account_type == 'institution':
+    if account_type == 'institution' and (
+        request.user in get_institution(pk).get_admins()
+        or
+        request.user == get_institution(pk).institution_creator
+    ):
         institution = get_institution(pk)
         member_role = check_member_role(request.user, institution)
         try:
@@ -878,7 +882,10 @@ def subscription(request, pk, account_type, related=None):
         }
     if account_type == 'researcher':
         researcher = Researcher.objects.get(id=pk)
-        subscription = Subscription.objects.get(researcher=researcher)
+        try:
+            subscription = Subscription.objects.get(researcher=researcher)
+        except Subscription.DoesNotExist:
+            subscription = None
         renew = (
             subscription.end_date < timezone.now() if subscription is not None
             else False

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -854,24 +854,41 @@ def subscription(request, pk, account_type, related=None):
         institution = get_institution(pk)
         member_role = check_member_role(request.user, institution)
         subscription = Subscription.objects.get(institution=institution)
-        renew = subscription.end_date < timezone.now() if subscription.end_date else False
+        renew = (
+            subscription.end_date < timezone.now() if subscription.end_date
+            else False
+        )
         context = {
-            "institution": institution, 
+            "institution": institution,
             "subscription": subscription,
-            "start_date": subscription.start_date.strftime('%d %B %Y') if subscription.start_date else None,
-            "end_date": subscription.end_date.strftime('%d %B %Y') if subscription.end_date else None,
-            "renew": renew
+            "start_date": subscription.start_date.strftime('%d %B %Y')
+            if subscription.start_date
+            else None,
+            "end_date": subscription.end_date.strftime('%d %B %Y')
+            if subscription.end_date
+            else None,
+            "renew": renew,
+            "member_role": member_role,
         }
     if account_type == 'researcher':
         researcher = Researcher.objects.get(id=pk)
         subscription = Subscription.objects.get(researcher=researcher)
-        renew = subscription.end_date < timezone.now() if subscription.end_date else False
+        renew = (
+            subscription.end_date < timezone.now() if subscription.end_date
+            else False
+        )
         context = {
-            "researcher": researcher, 
+            "researcher": researcher,
             "subscription": subscription,
-            "start_date": subscription.start_date.strftime('%d %B %Y') if subscription.start_date else None,
-            "end_date": subscription.end_date.strftime('%d %B %Y') if subscription.end_date else None,
+            "start_date": subscription.start_date.strftime('%d %B %Y')
+            if subscription.start_date
+            else None,
+            "end_date": subscription.end_date.strftime('%d %B %Y')
+            if subscription.end_date
+            else None,
             "renew": renew
         }
-
-    return render(request, 'account_settings_pages/_subscription.html', context)
+    return render(
+        request, 'account_settings_pages/_subscription.html',
+        context
+    )

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -853,19 +853,22 @@ def subscription(request, pk, account_type, related=None):
     if account_type == 'institution':
         institution = get_institution(pk)
         member_role = check_member_role(request.user, institution)
-        subscription = Subscription.objects.get(institution=institution)
+        try:
+            subscription = Subscription.objects.get(institution=institution)
+        except Subscription.DoesNotExist:
+            subscription = None
         renew = (
-            subscription.end_date < timezone.now() if subscription.end_date
+            subscription.end_date < timezone.now() if subscription is not None
             else False
         )
         context = {
             "institution": institution,
             "subscription": subscription,
             "start_date": subscription.start_date.strftime('%d %B %Y')
-            if subscription.start_date
+            if subscription is not None
             else None,
             "end_date": subscription.end_date.strftime('%d %B %Y')
-            if subscription.end_date
+            if subscription is not None
             else None,
             "renew": renew,
             "member_role": member_role,
@@ -874,17 +877,17 @@ def subscription(request, pk, account_type, related=None):
         researcher = Researcher.objects.get(id=pk)
         subscription = Subscription.objects.get(researcher=researcher)
         renew = (
-            subscription.end_date < timezone.now() if subscription.end_date
+            subscription.end_date < timezone.now() if subscription is not None
             else False
         )
         context = {
             "researcher": researcher,
             "subscription": subscription,
             "start_date": subscription.start_date.strftime('%d %B %Y')
-            if subscription.start_date
+            if subscription is not None
             else None,
             "end_date": subscription.end_date.strftime('%d %B %Y')
-            if subscription.end_date
+            if subscription is not None
             else None,
             "renew": renew
         }

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -853,6 +853,8 @@ def subscription(request, pk, account_type, related=None):
     if dev_prod_or_local(request.get_host()) == "SANDBOX":
         return redirect("dashboard")
 
+    renew = False
+
     if account_type == 'institution' and (
         request.user in get_institution(pk).get_admins()
         or
@@ -864,18 +866,17 @@ def subscription(request, pk, account_type, related=None):
             subscription = Subscription.objects.get(institution=institution)
         except Subscription.DoesNotExist:
             subscription = None
-        renew = (
-            subscription.end_date < timezone.now() if subscription is not None
-            else False
-        )
+        if subscription is not None:
+            if subscription.end_date and subscription.end_date < timezone.now():
+                renew = True
         context = {
             "institution": institution,
             "subscription": subscription,
             "start_date": subscription.start_date.strftime('%d %B %Y')
-            if subscription is not None
+            if subscription and subscription.start_date is not None
             else None,
             "end_date": subscription.end_date.strftime('%d %B %Y')
-            if subscription is not None
+            if subscription and subscription.end_date is not None
             else None,
             "renew": renew,
             "member_role": member_role,
@@ -886,18 +887,17 @@ def subscription(request, pk, account_type, related=None):
             subscription = Subscription.objects.filter(researcher=researcher).first()
         else:
             subscription = None
-        renew = (
-            subscription.end_date < timezone.now() if subscription is not None
-            else False
-        )
+        if subscription is not None:
+            if subscription.end_date and subscription.end_date < timezone.now():
+                renew = True
         context = {
             "researcher": researcher,
             "subscription": subscription,
             "start_date": subscription.start_date.strftime('%d %B %Y')
-            if subscription is not None
+            if subscription and subscription.start_date is not None
             else None,
             "end_date": subscription.end_date.strftime('%d %B %Y')
-            if subscription is not None
+            if subscription and subscription.end_date is not None
             else None,
             "renew": renew
         }

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -334,6 +334,7 @@ def public_institution_view(request, pk):
 def update_institution(request, pk):
     institution = get_institution(pk)
     member_role = check_member_role(request.user, institution)
+    envi = dev_prod_or_local(request.get_host())
 
     if request.method == "POST":
         update_form = UpdateInstitutionForm(
@@ -356,6 +357,7 @@ def update_institution(request, pk):
         "institution": institution,
         "update_form": update_form,
         "member_role": member_role,
+        "envi": envi,
     }
     return render(request, 'account_settings_pages/_update-account.html', context)
 
@@ -1555,6 +1557,7 @@ def api_keys(request, pk):
     institution = get_institution(pk)
     member_role = check_member_role(request.user, institution)
     remaining_api_key_count = 0
+    envi = dev_prod_or_local(request.get_host())
     
     try:
         if institution.is_subscribed:
@@ -1613,7 +1616,8 @@ def api_keys(request, pk):
             "form" : form,
             "account_keys" : account_keys,
             "member_role" : member_role,
-            "remaining_api_key_count" : remaining_api_key_count,
+            "subscription_api_key_count" : remaining_api_key_count,
+            "envi": envi,
         }
         return render(request, 'account_settings_pages/_api-keys.html', context)
     except:

--- a/localcontexts/static/css/dashboard.css
+++ b/localcontexts/static/css/dashboard.css
@@ -226,7 +226,7 @@
     flex-grow: 1;
 }
 
-.subscription-details h6,
+.subscription-details h5,
 .subscription-details p {
     margin-top: 0;
     margin-bottom: 0;
@@ -237,7 +237,7 @@
     padding-left: 10px;
 }
 
-.subscription-activity h6,
+.subscription-activity h5,
 .subscription-activity p {
     margin-top: 0;
     margin-bottom: 0;

--- a/localcontexts/static/css/dashboard.css
+++ b/localcontexts/static/css/dashboard.css
@@ -217,7 +217,6 @@
 .subscription-details {
     border: 1px solid #E0E1E1;
     border-radius: 4px;
-    width: 35%;
     padding: 10px;
     background-color: #F8FAFF;
 }
@@ -235,7 +234,7 @@
 
 .subscription-activity > div {
     margin-right: 10px;
-    padding-left: 20px;
+    padding-left: 10px;
 }
 
 .subscription-activity h6,

--- a/localcontexts/static/css/dashboard.css
+++ b/localcontexts/static/css/dashboard.css
@@ -213,3 +213,41 @@
     width: 360px;
     height: 91px;
 }
+
+.subscription-details {
+    border: 1px solid #E0E1E1;
+    border-radius: 4px;
+    width: 250px;
+    padding: 10px;
+    background-color: #F8FAFF;
+}
+
+.subscription-details > div {
+    margin-right: 10px;
+}
+
+.subscription-details h6,
+.subscription-details p {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.subscription-activity > div {
+    margin-right: 10px;
+    padding-left: 20px;
+}
+
+.subscription-activity h6,
+.subscription-activity p {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.vl {
+    border-left: 1px solid #E0E1E1;
+    height: 100%;
+}
+
+.margin-5 { margin: 5px; }
+
+.set-height-empty-dash { height: 200px; }

--- a/localcontexts/static/css/dashboard.css
+++ b/localcontexts/static/css/dashboard.css
@@ -217,13 +217,14 @@
 .subscription-details {
     border: 1px solid #E0E1E1;
     border-radius: 4px;
-    width: 250px;
+    width: 35%;
     padding: 10px;
     background-color: #F8FAFF;
 }
 
 .subscription-details > div {
     margin-right: 10px;
+    flex-grow: 1;
 }
 
 .subscription-details h6,

--- a/templates/account-settings-base.html
+++ b/templates/account-settings-base.html
@@ -116,7 +116,7 @@
                     </a>
                 {% endif %}
                 
-                {% if institution %}
+                {% if institution and envi != "SANDBOX" %}
                 <a class="side-nav-a" href="{% if institution %}{% url 'subscription' institution.id 'institution' %}{% else %}{% url 'subscription' researcher.id 'researcher' %}{% endif %}">
                         <div class="side-nav-item {% if 'subscription' in request.path %} selected {% else %} grey-text {% endif %}">
                             <div class="w-20 margin-right-8"><i class="fa fa-calendar-check-o fa-3x" aria-hidden="true"></i></div>

--- a/templates/account-settings-base.html
+++ b/templates/account-settings-base.html
@@ -115,7 +115,17 @@
                         </div>
                     </a>
                 {% endif %}
-
+                
+                {% if institution %}
+                <a class="side-nav-a" href="{% if institution %}{% url 'subscription' institution.id 'institution' %}{% else %}{% url 'subscription' researcher.id 'researcher' %}{% endif %}">
+                        <div class="side-nav-item {% if 'subscription' in request.path %} selected {% else %} grey-text {% endif %}">
+                            <div class="w-20 margin-right-8"><i class="fa fa-calendar-check-o fa-3x" aria-hidden="true"></i></div>
+                            <div class="w-80">
+                                <p class="no-top-margin"><strong>Subscription</strong><br>Subscription details, subscription activity</p>
+                            </div>
+                        </div>
+                    </a>
+                {% endif %}
             </div>
 
 

--- a/templates/account-settings-base.html
+++ b/templates/account-settings-base.html
@@ -90,6 +90,17 @@
                     </a>
                 {% endif %}
 
+                {% if institution or researcher and envi != "SANDBOX" %}
+                <a class="side-nav-a" href="{% if institution %}{% url 'subscription' institution.id 'institution' %}{% else %}{% url 'subscription' researcher.id 'researcher' %}{% endif %}">
+                        <div class="flex-this  side-nav-item {% if 'subscription' in request.path %} selected {% else %} grey-text {% endif %}">
+                            <div class="w-20 margin-right-8"><i class="fa fa-calendar-check-o fa-3x" aria-hidden="true"></i></div>
+                            <div class="w-80">
+                                <p class="mt-0"><strong>Subscription</strong><br>Subscription details and activity</p>
+                            </div>
+                        </div>
+                    </a>
+                {% endif %}
+
                 <!-- Manage API Keys -->
                 <a href="{% if community %}{% url 'community-api-key' community.id %}{% endif %}{% if institution %}{% url 'institution-api-key' institution.id %}{% endif %}{% if researcher %}{% url 'researcher-api-key' researcher.id %}{% endif %}{% if service_provider %}{% url 'service-provider-api-key' service_provider.id %}{% endif %}">
                     <div class="flex-this side-nav-item {% if '/api-key/' in request.path %} selected {% else %} grey-text {% endif %}">
@@ -116,16 +127,6 @@
                     </a>
                 {% endif %}
                 
-                {% if institution and envi != "SANDBOX" %}
-                <a class="side-nav-a" href="{% if institution %}{% url 'subscription' institution.id 'institution' %}{% else %}{% url 'subscription' researcher.id 'researcher' %}{% endif %}">
-                        <div class="flex-this  side-nav-item {% if 'subscription' in request.path %} selected {% else %} grey-text {% endif %}">
-                            <div class="w-20 margin-right-8"><i class="fa fa-calendar-check-o fa-3x" aria-hidden="true"></i></div>
-                            <div class="w-80">
-                                <p class="mt-0"><strong>Subscription</strong><br>Subscription details, subscription activity</p>
-                            </div>
-                        </div>
-                    </a>
-                {% endif %}
             </div>
 
 

--- a/templates/account-settings-base.html
+++ b/templates/account-settings-base.html
@@ -118,10 +118,10 @@
                 
                 {% if institution and envi != "SANDBOX" %}
                 <a class="side-nav-a" href="{% if institution %}{% url 'subscription' institution.id 'institution' %}{% else %}{% url 'subscription' researcher.id 'researcher' %}{% endif %}">
-                        <div class="side-nav-item {% if 'subscription' in request.path %} selected {% else %} grey-text {% endif %}">
+                        <div class="flex-this  side-nav-item {% if 'subscription' in request.path %} selected {% else %} grey-text {% endif %}">
                             <div class="w-20 margin-right-8"><i class="fa fa-calendar-check-o fa-3x" aria-hidden="true"></i></div>
                             <div class="w-80">
-                                <p class="no-top-margin"><strong>Subscription</strong><br>Subscription details, subscription activity</p>
+                                <p class="mt-0"><strong>Subscription</strong><br>Subscription details, subscription activity</p>
                             </div>
                         </div>
                     </a>

--- a/templates/account_settings_pages/_subscription.html
+++ b/templates/account_settings_pages/_subscription.html
@@ -27,20 +27,20 @@
             Your institution is Large Organization.
         </span>
       </span> </small></p></div> {% endcomment %}
-      <div class="pad-left-2"><h6>Start Date</h6> <p><small>{{ start_date }}</small></p></div>
-      <div class="vl pad-left-2"><h6 class="ml-8 ">End Date</h6> <p class="ml-8 "><small>{{ end_date }}</small></p></div>
+      <div class="pad-left-2"><h5>Start Date</h5> <p>{{ start_date }}</p></div>
+      <div class="vl pad-left-2"><h5 class="ml-8 ">End Date</h5> <p class="ml-8 ">{{ end_date }}</p></div>
     </div>
     <div class="flex-this space-between">
       <div><h4 class="mb-0">Subscription Activity</h4></div>
     </div>
-    <p class="mt-0"><small>See an overview of the activities happening within your subscription</small></p>
-    <div class="flex-this subscription-activity subscription-details w-70">
-      <div><h6>Users Added</h6> <p><small>{% if subscription.users_count != -1 %}{{ subscription.users_count }}{% else %}Unlimited{% endif %}</small></p></div>
-      <div class="vl"><h6>Projects Created</h6> <p><small>{% if subscription.project_count != -1 %}{{ subscription.project_count }}{% else %}Unlimited{% endif %}</small></p></div>
-      <div class="vl"><h6>Notifications Sent</h6> <p><small>{% if subscription.notification_count != -1 %}{{ subscription.notification_count }}{% else %}Unlimited{% endif %}</small></p></div>
-      <div class="vl"><h6>Notices and Labels</h6> <p><small>Unlimited</small></p></div>
-      <div class="vl"><h6>API Keys</h6> <p><small>{% if subscription.api_key_count != -1 %}{{ subscription.api_key_count }}{% else %}Unlimited{% endif %}</small></p></div>
+    <p class="mt-0">See an overview of the activities happening within your subscription</p>
+    <div class="flex-this subscription-activity subscription-details w-80">
+      <div><h5>Users Added</h5> <p>{% if subscription.users_count != -1 %}{{ subscription.users_count }}{% else %}Unlimited{% endif %}</p></div>
+      <div class="vl"><h5>Projects Created</h5> <p>{% if subscription.project_count != -1 %}{{ subscription.project_count }}{% else %}Unlimited{% endif %}</p></div>
+      <div class="vl"><h5>Notifications Sent</h5> <p>{% if subscription.notification_count != -1 %}{{ subscription.notification_count }}{% else %}Unlimited{% endif %}</p></div>
+      <div class="vl"><h5>Notices and Labels</h5> <p>Unlimited</p></div>
+      <div class="vl"><h5>API Keys</h5> <p>{% if subscription.api_key_count != -1 %}{{ subscription.api_key_count }}{% else %}Unlimited{% endif %}</p></div>
     </div>
-    <p><small>Need help? Please contact us at  <a href="mailto:support@localcontexts.org" class="default-a">support@localcontexts.org</a></small></p>
+    <p>Need help? Please contact us at  <a href="mailto:support@localcontexts.org" class="default-a">support@localcontexts.org</a></p>
   {% endif %}
 {% endblock %}

--- a/templates/account_settings_pages/_subscription.html
+++ b/templates/account_settings_pages/_subscription.html
@@ -2,12 +2,12 @@
 
 {% block account_settings %}
   <div class="flex-this space-between">
-    <div><h3 class="no-top-margin">Subscription</h3></div>
+    <div><h3 class="mt-0">Subscription</h3></div>
   </div>
-  <p class="no-top-margin {% if subscription is None %} red-text {% endif %}">Subscriptions enable any museum, repository, university, or other organizations to work collaboratively with Indigenous communities on the Local Contexts Hub. <a class="default-a" href="https://localcontexts.org/members-subscribers-and-service-providers/" target="_blank"> Read more about subscriptions </a>.</p>
+  <p class="mt-0 {% if subscription is None %} red-text {% endif %}">Subscriptions enable any museum, repository, university, or other organizations to work collaboratively with Indigenous communities on the Local Contexts Hub. <a class="default-a" href="https://localcontexts.org/members-subscribers-and-service-providers/" target="_blank"> Read more about subscriptions </a>.</p>
   {% if subscription is not None %}
   <div class="flex-this space-between">
-    <div><h4 class="no-bottom-margin no-top-margin">Subscription Details</h4></div>
+    <div><h4 class="mb-0 mt-0">Subscription Details</h4></div>
   </div>
   {% endif %}
   {% if renew %}
@@ -21,37 +21,25 @@
     <button type="submit" class="primary-btn action-btn" name="generatebtn">Fill out Subscription Form</button>
   </div> 
   {% else %}
-    <div class="flex-this w-50 subscription-details">
-      <div><h6>Entity Type</h6> <p><small>Large Organization <span class="tooltip" style="margin-top: 6px; margin-left: 5px;"><strong>i</strong>
+    <div class="flex-this w-60 subscription-details">
+      {% comment %} <div><h6>Entity Type</h6> <p><small>Large Organization <span class="tooltip" style="margin-top: 6px; margin-left: 5px;"><strong>i</strong>
         <span class="tooltiptext">
             Your institution is Large Organization.
         </span>
-      </span> </small></p></div>
-      <div class="vl pad-left-2"><h6>Start Date</h6> <p><small>{{ start_date }}</small></p></div>
-      <div class="vl pad-left-2"><h6 class="margin-left-8">End Date</h6> <p class="margin-left-8"><small>{{ end_date }}</small></p></div>
+      </span> </small></p></div> {% endcomment %}
+      <div class="pad-left-2"><h6>Start Date</h6> <p><small>{{ start_date }}</small></p></div>
+      <div class="vl pad-left-2"><h6 class="ml-8 ">End Date</h6> <p class="ml-8 "><small>{{ end_date }}</small></p></div>
     </div>
     <div class="flex-this space-between">
-      <div><h4 class="no-bottom-margin">Subscription Activity</h4></div>
+      <div><h4 class="mb-0">Subscription Activity</h4></div>
     </div>
-    <p class="no-top-margin"><small>See an overview of the activities happening within your subscription</small></p>
-    <div class="flex-this subscription-activity subscription-details w-70 margin-5">
+    <p class="mt-0"><small>See an overview of the activities happening within your subscription</small></p>
+    <div class="flex-this subscription-activity subscription-details w-70">
       <div><h6>Users Added</h6> <p><small>{% if subscription.users_count != -1 %}{{ subscription.users_count }}{% else %}Unlimited{% endif %}</small></p></div>
       <div class="vl"><h6>Projects Created</h6> <p><small>{% if subscription.project_count != -1 %}{{ subscription.project_count }}{% else %}Unlimited{% endif %}</small></p></div>
       <div class="vl"><h6>Notifications Sent</h6> <p><small>{% if subscription.notification_count != -1 %}{{ subscription.notification_count }}{% else %}Unlimited{% endif %}</small></p></div>
       <div class="vl"><h6>Notices and Labels</h6> <p><small>Unlimited</small></p></div>
       <div class="vl"><h6>API Keys</h6> <p><small>{% if subscription.api_key_count != -1 %}{{ subscription.api_key_count }}{% else %}Unlimited{% endif %}</small></p></div>
-    </div>
-    <div class="flex-this space-between">
-      <div><h4 class="no-bottom-margin">Edit Subscription</h4></div>
-    </div>
-    <p class="no-top-margin"><small>Manage and edit your subscription plan</small></p>
-    <div class="flex-this">
-      <div>
-          <button type="submit" class="primary-btn action-btn" name="generatebtn">Update Subscription</button>
-      </div>        
-      <div class="margin-left-1">
-        <button type="submit" class="primary-btn white-btn" name="generatebtn">Cancel Subscription</button>
-      </div>                
     </div>
     <p><small>Need help? Please contact us at  <a href="mailto:support@localcontexts.org" class="default-a">support@localcontexts.org</a></small></p>
   {% endif %}

--- a/templates/account_settings_pages/_subscription.html
+++ b/templates/account_settings_pages/_subscription.html
@@ -35,11 +35,11 @@
     </div>
     <p class="mt-0">See an overview of the activities happening within your subscription</p>
     <div class="flex-this subscription-activity subscription-details w-80">
-      <div><h5>Users Added</h5> <p>{% if subscription.users_count != -1 %}{{ subscription.users_count }}{% else %}Unlimited{% endif %}</p></div>
-      <div class="vl"><h5>Projects Created</h5> <p>{% if subscription.project_count != -1 %}{{ subscription.project_count }}{% else %}Unlimited{% endif %}</p></div>
-      <div class="vl"><h5>Notifications Sent</h5> <p>{% if subscription.notification_count != -1 %}{{ subscription.notification_count }}{% else %}Unlimited{% endif %}</p></div>
-      <div class="vl"><h5>Notices and Labels</h5> <p>Unlimited</p></div>
-      <div class="vl"><h5>API Keys</h5> <p>{% if subscription.api_key_count != -1 %}{{ subscription.api_key_count }}{% else %}Unlimited{% endif %}</p></div>
+      <div><h5>Users Remaining</h5> <p>{% if subscription.users_count != -1 %}{{ subscription.users_count }}{% else %}Unlimited{% endif %}</p></div>
+      <div class="vl"><h5>Projects Remaining</h5> <p>{% if subscription.project_count != -1 %}{{ subscription.project_count }}{% else %}Unlimited{% endif %}</p></div>
+      <div class="vl"><h5>Notifications Remaining</h5> <p>{% if subscription.notification_count != -1 %}{{ subscription.notification_count }}{% else %}Unlimited{% endif %}</p></div>
+      <div class="vl"><h5>Notices Remaining</h5> {% if subscription.notification_count != -1 %}{{ subscription.notification_count }}{% else %}Unlimited{% endif %}</div>
+      <div class="vl"><h5>API Keys Remaining</h5> <p>{% if subscription.api_key_count != -1 %}{{ subscription.api_key_count }}{% else %}Unlimited{% endif %}</p></div>
     </div>
     <p>Need help? Please contact us at  <a href="mailto:support@localcontexts.org" class="default-a">support@localcontexts.org</a></p>
   {% endif %}

--- a/templates/account_settings_pages/_subscription.html
+++ b/templates/account_settings_pages/_subscription.html
@@ -21,20 +21,25 @@
     <button type="submit" class="primary-btn action-btn" name="generatebtn">Fill out Subscription Form</button>
   </div> 
   {% else %}
-    <div class="flex-this subscription-details">
-      <div><h6>Start Date</h6> <p><small>{{ start_date }}</small></p></div>
+    <div class="flex-this w-50 subscription-details">
+      <div><h6>Entity Type</h6> <p><small>Large Organization <span class="tooltip" style="margin-top: 6px; margin-left: 5px;"><strong>i</strong>
+        <span class="tooltiptext">
+            Your institution is Large Organization.
+        </span>
+      </span> </small></p></div>
+      <div class="vl pad-left-2"><h6>Start Date</h6> <p><small>{{ start_date }}</small></p></div>
       <div class="vl pad-left-2"><h6 class="margin-left-8">End Date</h6> <p class="margin-left-8"><small>{{ end_date }}</small></p></div>
     </div>
     <div class="flex-this space-between">
       <div><h4 class="no-bottom-margin">Subscription Activity</h4></div>
     </div>
     <p class="no-top-margin"><small>See an overview of the activities happening within your subscription</small></p>
-    <div class="flex-this subscription-activity margin-5">
-      <div><h6>Users Added</h6> <p><small>{{ subscription.users_count }}</small></p></div>
-      <div class="vl"><h6>Projects Created</h6> <p><small>{{ subscription.project_count }}</small></p></div>
-      <div class="vl"><h6>Notifications Sent</h6> <p><small>{{ subscription.notification_count }}</small></p></div>
-      <div class="vl"><h6>Notices Sent</h6> <p><small>{{ end_date }}</small></p></div>
-      <div class="vl"><h6>API Keys</h6> <p><small>{{ subscription.api_key_count }}</small></p></div>
+    <div class="flex-this subscription-activity subscription-details w-70 margin-5">
+      <div><h6>Users Added</h6> <p><small>{% if subscription.users_count != -1 %}{{ subscription.users_count }}{% else %}Unlimited{% endif %}</small></p></div>
+      <div class="vl"><h6>Projects Created</h6> <p><small>{% if subscription.project_count != -1 %}{{ subscription.project_count }}{% else %}Unlimited{% endif %}</small></p></div>
+      <div class="vl"><h6>Notifications Sent</h6> <p><small>{% if subscription.notification_count != -1 %}{{ subscription.notification_count }}{% else %}Unlimited{% endif %}</small></p></div>
+      <div class="vl"><h6>Notices and Labels</h6> <p><small>Unlimited</small></p></div>
+      <div class="vl"><h6>API Keys</h6> <p><small>{% if subscription.api_key_count != -1 %}{{ subscription.api_key_count }}{% else %}Unlimited{% endif %}</small></p></div>
     </div>
     <div class="flex-this space-between">
       <div><h4 class="no-bottom-margin">Edit Subscription</h4></div>

--- a/templates/account_settings_pages/_subscription.html
+++ b/templates/account_settings_pages/_subscription.html
@@ -8,7 +8,7 @@
   <div class="flex-this space-between">
     <div><h4 class="no-bottom-margin no-top-margin">Subscription Details</h4></div>
   </div>
-  {% if True %}
+  {% if renew %}
     <p class="italic red-text"><small>This subscription for this account has expired. Please renew your subscription.</small></p>
     <div>
       <button type="submit" class="primary-btn action-btn" name="generatebtn">Renew Subscription</button>

--- a/templates/account_settings_pages/_subscription.html
+++ b/templates/account_settings_pages/_subscription.html
@@ -4,15 +4,22 @@
   <div class="flex-this space-between">
     <div><h3 class="no-top-margin">Subscription</h3></div>
   </div>
-  <p class="no-top-margin">Subscriptions enable any museum, repository, university, or other organizations to work collaboratively with Indigenous communities on the Local Contexts Hub. <a class="default-a" href="https://localcontexts.org/members-subscribers-and-service-providers/" target="_blank"> Read more about subscriptions </a>.</p>
+  <p class="no-top-margin {% if subscription is None %} red-text {% endif %}">Subscriptions enable any museum, repository, university, or other organizations to work collaboratively with Indigenous communities on the Local Contexts Hub. <a class="default-a" href="https://localcontexts.org/members-subscribers-and-service-providers/" target="_blank"> Read more about subscriptions </a>.</p>
+  {% if subscription is not None %}
   <div class="flex-this space-between">
     <div><h4 class="no-bottom-margin no-top-margin">Subscription Details</h4></div>
   </div>
+  {% endif %}
   {% if renew %}
     <p class="italic red-text"><small>This subscription for this account has expired. Please renew your subscription.</small></p>
     <div>
       <button type="submit" class="primary-btn action-btn" name="generatebtn">Renew Subscription</button>
-    </div>     
+    </div> 
+  {% elif subscription is None  %}    
+  <p class='red-text'>To unlock more activities in your account please subscribe</p>
+  <div>
+    <button type="submit" class="primary-btn action-btn" name="generatebtn">Fill out Subscription Form</button>
+  </div> 
   {% else %}
     <div class="flex-this subscription-details">
       <div><h6>Start Date</h6> <p><small>{{ start_date }}</small></p></div>

--- a/templates/account_settings_pages/_subscription.html
+++ b/templates/account_settings_pages/_subscription.html
@@ -1,0 +1,46 @@
+{% extends 'account-settings-base.html' %}{% load static %}
+
+{% block account_settings %}
+  <div class="flex-this space-between">
+    <div><h3 class="no-top-margin">Subscription</h3></div>
+  </div>
+  <p class="no-top-margin">Subscriptions enable any museum, repository, university, or other organizations to work collaboratively with Indigenous communities on the Local Contexts Hub. <a class="default-a" href="https://localcontexts.org/members-subscribers-and-service-providers/" target="_blank"> Read more about subscriptions </a>.</p>
+  <div class="flex-this space-between">
+    <div><h4 class="no-bottom-margin no-top-margin">Subscription Details</h4></div>
+  </div>
+  {% if True %}
+    <p class="italic red-text"><small>This subscription for this account has expired. Please renew your subscription.</small></p>
+    <div>
+      <button type="submit" class="primary-btn action-btn" name="generatebtn">Renew Subscription</button>
+    </div>     
+  {% else %}
+    <div class="flex-this subscription-details">
+      <div><h6>Start Date</h6> <p><small>{{ start_date }}</small></p></div>
+      <div class="vl pad-left-2"><h6 class="margin-left-8">End Date</h6> <p class="margin-left-8"><small>{{ end_date }}</small></p></div>
+    </div>
+    <div class="flex-this space-between">
+      <div><h4 class="no-bottom-margin">Subscription Activity</h4></div>
+    </div>
+    <p class="no-top-margin"><small>See an overview of the activities happening within your subscription</small></p>
+    <div class="flex-this subscription-activity margin-5">
+      <div><h6>Users Added</h6> <p><small>{{ subscription.users_count }}</small></p></div>
+      <div class="vl"><h6>Projects Created</h6> <p><small>{{ subscription.project_count }}</small></p></div>
+      <div class="vl"><h6>Notifications Sent</h6> <p><small>{{ subscription.notification_count }}</small></p></div>
+      <div class="vl"><h6>Notices Sent</h6> <p><small>{{ end_date }}</small></p></div>
+      <div class="vl"><h6>API Keys</h6> <p><small>{{ subscription.api_key_count }}</small></p></div>
+    </div>
+    <div class="flex-this space-between">
+      <div><h4 class="no-bottom-margin">Edit Subscription</h4></div>
+    </div>
+    <p class="no-top-margin"><small>Manage and edit your subscription plan</small></p>
+    <div class="flex-this">
+      <div>
+          <button type="submit" class="primary-btn action-btn" name="generatebtn">Update Subscription</button>
+      </div>        
+      <div class="margin-left-1">
+        <button type="submit" class="primary-btn white-btn" name="generatebtn">Cancel Subscription</button>
+      </div>                
+    </div>
+    <p><small>Need help? Please contact us at  <a href="mailto:support@localcontexts.org" class="default-a">support@localcontexts.org</a></small></p>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8687zzy47)**

**Description:**
This should be only available to main admin of the account
The information on the Subscriptions Settings page should be:

 **Subscribed Account:**
- Subscription type: Individual, Small, Medium, Large, CC Notice Only(?)
- Counts of how much of each item is left
  - Projects
  - Users
  - Notifications
  - Notices and Labels
  - API Keys
- Start and end date of the subscription
- Bundle inquiry
  - Select bundle type, then send account id, contact info to which email? (support? subscriptions?)
- Cancellation Inquiry
  - Should this be a link to a form or who to email?
  - Do we have cancellation information available somewhere to link to?

**Unsubscribed account:**
- some information on subscriptions
- link to webform? (or embed webform?)


**Solution:**
- Added a backend view for the subscription view
- Added a template for subscription settings on frontend to display subscription information

**After:**
![subscribed-institute](https://github.com/user-attachments/assets/5450dba6-cce6-4e64-971a-adf5b27458c2)
![unsubscribed-institute](https://github.com/user-attachments/assets/f7d6672b-b035-4be8-a27f-ac8730e44c61)


https://github.com/user-attachments/assets/99353f8b-7050-4e1d-9f19-30d21914d942

