### PR TITLE
#8688ahc1d Font Awesome Change Host

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,9 +18,8 @@
         <link rel="manifest" href="{% static 'images/favicons/site.webmanifest' %}">
 
         <!-- Font Awesome Icons -->
-        <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"> -->
-        <script src="https://kit.fontawesome.com/e4bd889de7.js" crossorigin="anonymous"></script>
-                
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
         <!-- CSS -->
         <link rel="stylesheet" type="text/css" href="{% static 'css/main.css' %}">
         <link rel="stylesheet" type="text/css" href="{% static 'css/register.css' %}">


### PR DESCRIPTION
We are using a Font Awesome kit which loads Font Awesome 6.5.2. But sometimes that would fail.

This change uses a CDN for 6.5.2 to load Font Awesome to increase reliability.

Below is an image that shows icons still work.

![image](https://github.com/localcontexts/localcontextshub/assets/145378945/f6f147db-2725-4631-8370-843d90b37585)
