### PR TITLE
#8688faqx4 Country package issue blocking profile related pages from loading

### DIFF
--- a/localcontexts/settings.py
+++ b/localcontexts/settings.py
@@ -300,3 +300,8 @@ LOGIN_REDIRECT_URL= '/dashboard/'
 ACCOUNT_ADAPTER = 'accounts.adapters.CustomAccountAdapter'
 
 SOCIALACCOUNT_ADAPTER = 'accounts.adapters.CustomSocialAccountAdapter'
+
+from django_countries.widgets import LazyChoicesMixin
+
+LazyChoicesMixin.get_choices = lambda self: self._choices
+LazyChoicesMixin.choices = property(LazyChoicesMixin.get_choices, LazyChoicesMixin.set_choices)


### PR DESCRIPTION
Keep getting the error below for all profile related templates that seems to be an issue with the countries package and Django 5.0 (see StackOverflow discussion and temp fix [here](https://stackoverflow.com/a/77859948))
![image](https://github.com/localcontexts/localcontextshub/assets/60452620/58011343-16ce-46d2-ad0e-c550be4725ed)