### PR TITLE
#86884f3tq-public-community-nld-annotations

### DIFF
--- a/templates/public.html
+++ b/templates/public.html
@@ -110,6 +110,14 @@
         {% if community.boundary.coordinates %}
         <div>
             <h3>Community Location</h3>
+            {% if 'native-land.ca' in community.source_of_boundary %}
+                This community boundary originates from the
+                <a href="https://native-land.ca/contact"
+                   class="default-a" target="_blank" rel="noopener">
+                    Native Land Digital database
+                    <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i>
+                </a>.<br><br>
+            {% endif %}
             <iframe src="{% url 'community-boundary-view' community.id %}"
                     style="width: 100%; height: 450px; border: 1px solid cadetblue;">
             </iframe>


### PR DESCRIPTION
When public community has a boundary derived from Native Land Digital, it displays a message and link to: https://native-land.ca/contact

![image](https://github.com/localcontexts/localcontextshub/assets/145378945/1c55ce51-d59b-4b67-9e17-8c0a03bb353e)
