### PR TITLE
#86880yzda Broken Admin Tables link in Admin Dashboard

### DIFF
--- a/localcontexts/admin.py
+++ b/localcontexts/admin.py
@@ -77,18 +77,16 @@ class MyAdminSite(admin.AdminSite):
         return render(request, 'admin/dashboard.html', context)
     
     # change the title of the page (the name that shows on the tab)
-    def app_index(self, request, app_label, extra_context = None):
-        app_dict = self._build_app_dict(request, app_label)
+    def app_index(self, request, app_label, extra_context=None):
+        app_dict = self.get_app_list(request, app_label)
         if not app_dict:
-            raise Http404('The requested admin page does not exist.')
-        # Sort the models alphabetically within each app.
-        app_dict['models'].sort(key = lambda x: x['name'])
+            raise Http404("The requested admin page does not exist.")
         app_name = apps.get_app_config(app_label).verbose_name
         context = {
             **self.each_context(request),
-            'title': _('%(app)s') % {'app': app_name},
-            'app_list': [app_dict],
-            'app_label': app_label,
+            "title": _("%(app)s") % {"app": app_name},
+            "app_list": app_dict,
+            "app_label": app_label,
             **(extra_context or {}),
         }
 

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -13,7 +13,7 @@
             &rsaquo; Dashboard
         </div>
         <div>
-            <a href="/admin/admin/">Admin Tables</a>
+            <a href="/admin/">Admin Tables</a>
         </div>
     </div>
 {% endblock %}

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -13,7 +13,7 @@
             &rsaquo; Dashboard
         </div>
         <div>
-            <a href="/admin/">Admin Tables</a>
+            <a href="/admin/admin/">Admin Tables</a>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/86880yzda)**

**Description:**
The link to the admin table is broken and giving back 500 error.

**Solution:**
- Updated the link with correct URL.

**Before:**

https://github.com/localcontexts/localcontextshub/assets/145371882/ef79fd83-50a9-4f43-abb4-cf4baa1c6976

 
**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/9575e9ea-d819-4be0-af1c-1576f917a9bd
