### PR TITLE
#8688h60qg Anon User Subscription Form Adjustments

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -941,22 +941,17 @@ def newsletter_unsubscription(request, emailb64):
 @unauthenticated_user
 def subscription_inquiry(request):
     form = SubscriptionForm(request.POST or None)
+    form.fields.pop('account_type', None)
     non_ror_institutes = serializers.serialize(
         "json", Institution.objects.filter(is_ror=False)
     )
 
     if request.method == "POST":
         if validate_recaptcha(request) and form.is_valid():
-            account_type_key = form.cleaned_data["account_type"]
             inquiry_type_key = form.cleaned_data["inquiry_type"]
-
-            account_type_display = dict(
-                form.fields["account_type"].choices
-            ).get(account_type_key, "")
             inquiry_type_display = dict(
                 form.fields["inquiry_type"].choices
             ).get(inquiry_type_key, "")
-            form.cleaned_data["account_type"] = account_type_display
             form.cleaned_data["inquiry_type"] = inquiry_type_display
 
             first_name = form.cleaned_data["first_name"]

--- a/localcontexts/static/css/main.css
+++ b/localcontexts/static/css/main.css
@@ -1706,3 +1706,33 @@ i[data-tooltip]:hover:after {
     border-radius: 4px;
     padding: 16px;
 }
+
+.required-label {
+    position: relative;
+    cursor: pointer;
+}
+
+.required-label[title]::after {
+    content: "Required";
+    position: absolute;
+    bottom: 100%;
+    left: 89%;
+    transform: translateX(-50%);
+    background-color: #333;
+    color: #fff;
+    padding: 5px 10px;
+    border-radius: 5px;
+    white-space: nowrap;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s;
+    z-index: 1000;
+    pointer-events: none;
+}
+
+.required-label[title]:hover::after {
+    opacity: 1;
+    visibility: visible;
+    background-color: #EF6C00;
+    color: #fff;
+}

--- a/localcontexts/static/css/main.css
+++ b/localcontexts/static/css/main.css
@@ -1718,12 +1718,8 @@ i[data-tooltip]:hover:after {
     bottom: 100%;
     left: 89%;
     transform: translateX(-50%);
-    background-color: #333;
-    color: #fff;
     padding: 5px 10px;
     border-radius: 5px;
-    white-space: nowrap;
-    opacity: 0;
     visibility: hidden;
     transition: opacity 0.3s;
     z-index: 1000;
@@ -1731,7 +1727,6 @@ i[data-tooltip]:hover:after {
 }
 
 .required-label[title]:hover::after {
-    opacity: 1;
     visibility: visible;
     background-color: #EF6C00;
     color: #fff;

--- a/templates/accounts/subscription-inquiry.html
+++ b/templates/accounts/subscription-inquiry.html
@@ -32,7 +32,7 @@
         <div class="flex-this column w-100">
           <div class="flex-this w-100 space-between">
             <div class="w-50 margin-right-1">
-              <label for="id_first_name">First name</label>
+              <label for="id_first_name">First name<span class="orange-text required-label" title="">*</span></label>
               {{ form.first_name }}{% if form.first_name.errors %}
               <div class="msg-red w-50">
                 <small>{{ form.first_name.errors.as_text }}</small>
@@ -52,7 +52,7 @@
 
           <div class="flex-this w-100 space-between margin-top-2">
             <div class="w-100 ">
-              <label for="id_email">Email</label>
+              <label for="id_email">Email<span class="orange-text required-label" title="">*</span></label>
               {{ form.email }}{% if form.email.errors %}
               <div class="msg-red w-100">
                 <small>{{ form.email.errors.as_text }}</small>
@@ -63,17 +63,8 @@
           </div>
 
           <div class="flex-this w-100 space-between margin-top-2">
-            <div class="w-50 margin-right-1">
-              <label for="id_account_type">Account Type</label>
-              {{ form.account_type }}
-              {% if form.account_type.errors %}
-              <div class="msg-red w-50">
-                <small>{{ form.account_type.errors.as_text }}</small>
-              </div>
-              {% endif %}
-            </div>
-            <div class="w-50 margin-left-1">
-              <label for="id_inquiry_type">Inquiry Type</label>
+            <div class="w-100 ">
+              <label for="id_inquiry_type">Inquiry Type<span class="orange-text required-label" title="">*</span></label>
               {{ form.inquiry_type }}
               {% if form.inquiry_type.errors %}
               <div class="msg-red w-50">
@@ -85,7 +76,10 @@
           </div>
           <div class="flex-this w-100 space-between margin-top-2">
             <div id="ror-input-container" class="w-100">
-              <label for="id_organization_name">Organization Name</label>
+              <label for="id_organization_name">Affiliation's / Organization's <span class="orange-text font-size-12" >(Optional)</span></label>
+              <div class="tooltip"><strong>i</strong>
+                <span class="tooltiptext">An affiliation's or organization's name might be an archive, library, museum, historical society, gallery, data repository, university, or media production company.</span>
+            </div>
               {{ form.organization_name }}
               <div id="suggestionsContainer"></div>
             </div>

--- a/templates/accounts/subscription-inquiry.html
+++ b/templates/accounts/subscription-inquiry.html
@@ -76,7 +76,7 @@
           </div>
           <div class="flex-this w-100 space-between margin-top-2">
             <div id="ror-input-container" class="w-100">
-              <label for="id_organization_name">Affiliation's / Organization's <span class="orange-text font-size-12" >(Optional)</span></label>
+              <label for="id_organization_name">Affiliation(s) or Organization(s) <span class="orange-text font-size-12" >(Optional)</span></label>
               <div class="tooltip"><strong>i</strong>
                 <span class="tooltiptext">An affiliation's or organization's name might be an archive, library, museum, historical society, gallery, data repository, university, or media production company.</span>
             </div>


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8688h60qg)**

**Description:**
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/42b92ba3-7d95-48df-8cbb-f3de0db35dad)

- Remove account type since its not reflected in SF
- Asterisks need to be added to the required fields:
    - First name (confirm this)
    - Email
    - Inquiry Type

For the anon form it should create a lead first, making the organization name optional. If we need to pass something, just pass Unknown.

**Solution:**
- Updated the SubscriptionForm to remove account type in subscription-inquiry view
- Updated the template for subscription-inquiry to include the optional Affiliation's / Organization's form field with the tooltip description of field
- Added asterisk's with the required form fields
- Updated CSS to style the required text as title attribute
 
**After:**


https://github.com/localcontexts/localcontextshub/assets/145371882/9f06b8df-73a0-4d40-9d9f-17eeff8ee0e2



