### PR TITLE
#8688jznmy Bug Fix: Researcher create project error

### DIFF
--- a/communities/urls.py
+++ b/communities/urls.py
@@ -39,9 +39,9 @@ urlpatterns = [
 
     path('projects/<str:pk>/', views.projects, name="community-projects"),
 
-    path('projects/create-project/<str:pk>/<uuid:source_proj_uuid>/<str:related>', views.create_project, name="create-project"),
-    path('projects/create-project/<str:pk>/<uuid:source_proj_uuid>/', views.create_project, name="create-project"),
-    path('projects/create-project/<str:pk>/', views.create_project, name="create-project"),
+    path('projects/create-project/<str:pk>/<uuid:source_proj_uuid>/<str:related>', views.create_project, name="community-create-project"),
+    path('projects/create-project/<str:pk>/<uuid:source_proj_uuid>/', views.create_project, name="community-create-project"),
+    path('projects/create-project/<str:pk>/', views.create_project, name="community-create-project"),
     
     path('projects/edit-project/<str:pk>/<uuid:project_uuid>/', views.edit_project, name="edit-project"),
     path('projects/actions/<str:pk>/<uuid:project_uuid>/', views.project_actions, name="community-project-actions"),

--- a/templates/partials/_project-actions.html
+++ b/templates/partials/_project-actions.html
@@ -437,7 +437,7 @@
                                             class="primary-btn white-btn"
 
                                             {% if community %}
-                                                href="{% url 'create-project' community.id project.unique_id 'related' %}"
+                                                href="{% url 'community-create-project' community.id project.unique_id 'related' %}"
                                             {% endif %}
                                             {% if institution %}
                                                 href="{% url 'inst-create-project' institution.id project.unique_id 'related' %}"
@@ -629,7 +629,7 @@
                                         a-disabled
                                     {% endif %}"
                                 {% if community %}
-                                    href="{% url 'create-project' community.id project.unique_id %}"
+                                    href="{% url 'community-create-project' community.id project.unique_id %}"
                                 {% endif %}
                                 {% if institution %}
                                     href="{% url 'inst-create-project' institution.id project.unique_id %}"

--- a/templates/projects/projects.html
+++ b/templates/projects/projects.html
@@ -21,7 +21,7 @@
                                     Create a Project <i class="fa fa-arrow-right"></i>
                                 </a>
                             {% endif %}
-                            {% if institution%}
+                            {% if institution %}
                                 {% if not institution.is_subscribed or subscription.project_count == 0 %}
                                     <span class="btn-help-text">
                                         {% if institution.is_subscribed == False %}
@@ -38,13 +38,13 @@
             {% else %}
             <div class="btn-with-helptext">
                 {% if researcher%}
-                    <a class="{% if not researcher.is_subscribed or subscription.project_count == 0 %} primary-btn disabled-btn margin-top-2 helptext{% else %} primary-btn green-btn margin-top-2 {% endif %}"
-                        href="{% if researcher.is_subscribed and subscription.project_count != 0 %} {% url 'researcher-create-project' researcher.id %} {% else %} javascript:void(0){% endif %}">
+                    <a class="{% if not researcher.is_subscribed or subscription.project_count == 0 %} primary-btn disabled-btn margin-top-2 helptext {% else %} primary-btn green-btn margin-top-2 {% endif %}"
+                        href="{% if researcher.is_subscribed and subscription.project_count != 0 %} {% url 'researcher-create-project' researcher.id %} {% else %} javascript:void(0) {% endif %}">
                         Create a Project <i class="fa fa-arrow-right"></i>
                     </a>
                 {% else %}
                     <a class="primary-btn green-btn margin-top-2 "
-                        href="{% url 'create-project' community.id %}">
+                        href="{% url 'researcher-create-project' researcher.id %}">
                         Create a Project <i class="fa fa-arrow-right"></i>
                     </a>
                 {% endif %}

--- a/templates/projects/projects.html
+++ b/templates/projects/projects.html
@@ -17,7 +17,7 @@
                                 </a>
                             {% else %}
                                 <a class="primary-btn green-btn margin-top-2 "
-                                    href="{% url 'create-project' community.id %}">
+                                    href="{% url 'community-create-project' community.id %}">
                                     Create a Project <i class="fa fa-arrow-right"></i>
                                 </a>
                             {% endif %}


### PR DESCRIPTION
**From an error Ashley had:**

> When you Create a Project by clicking the button on the Researcher page it creates the project under a community account. 

<hr>

**In this PR:**
- Fixed the template link where clicking on Create a Project in a researcher account would take you to creating a community Project instead.
- Renamed the community create Project path name from `create-project` to `community-create-project` to create distinction between where the path will take the user in the templates.

<hr>

**After:**

https://github.com/localcontexts/localcontextshub/assets/41635757/26b616d6-9d3a-4e49-92b9-fff982b8db03
