### PR TITLE
#86887gk2m Adjusted institution account functionality

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -731,6 +731,7 @@ def projects_board(request, filtertype=None):
             is_approved=True
         ).values_list("id", flat=True)
 
+        public_projects_filter = Q(project_privacy="Public")
         institution_projects_filter = Q(
             project_creator_project__institution__in=institutions
         )
@@ -741,10 +742,10 @@ def projects_board(request, filtertype=None):
             project_creator_project__researcher__user__isnull=False,
             project_creator_project__researcher__is_subscribed=True
         )
-
         projects = (
             Project.objects.filter(
-                (
+                public_projects_filter
+                & (
                     institution_projects_filter
                     | community_projects_filter
                     | researcher_projects_filter

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -650,7 +650,7 @@ def registry(request, filtertype=None):
             .order_by("community_name")
         )
         i = (
-            Institution.subscribed.select_related("institution_creator")
+            Institution.objects.select_related("institution_creator")
             .prefetch_related("admins", "editors", "viewers")
             .all()
             .order_by("institution_name")
@@ -726,16 +726,13 @@ def registry(request, filtertype=None):
 
 def projects_board(request, filtertype=None):
     try:
-        subscribed_institutions = Institution.objects.filter(
-            is_subscribed=True
-        ).values_list("id", flat=True)
+        institutions = Institution.objects.all()
         approved_communities = Community.objects.filter(
             is_approved=True
         ).values_list("id", flat=True)
 
-        public_projects_filter = Q(project_privacy="Public")
         institution_projects_filter = Q(
-            project_creator_project__institution__in=subscribed_institutions
+            project_creator_project__institution__in=institutions
         )
         community_projects_filter = Q(
             project_creator_project__community__in=approved_communities
@@ -747,8 +744,7 @@ def projects_board(request, filtertype=None):
 
         projects = (
             Project.objects.filter(
-                public_projects_filter
-                & (
+                (
                     institution_projects_filter
                     | community_projects_filter
                     | researcher_projects_filter

--- a/projects/models.py
+++ b/projects/models.py
@@ -178,8 +178,6 @@ class ProjectCreator(models.Model):
         """
         if self.community:
             return self.community.is_approved
-        elif self.institution:
-            return self.institution.is_subscribed
         else:
             return True
 

--- a/projects/models.py
+++ b/projects/models.py
@@ -92,13 +92,11 @@ class Project(models.Model):
 
     def can_user_access(self, user):
         # returns either True, False, or 'partial'
-        if user == self.project_creator:
-            return True
-        elif self.project_privacy == 'Public':
+        if user == self.project_creator or  self.project_privacy == 'Public' or  self.project_privacy == 'Private':
             return True
         elif self.project_privacy == 'Contributor':
             return discoverable_project_view(self, user)
-        elif self.project_privacy == 'Private':
+        else:
             return False
 
     def get_template_name(self, user):
@@ -109,7 +107,7 @@ class Project(models.Model):
                 return 'partials/_project-actions.html'
             else:
                 return 'partials/_project-contributor-view.html'
-        elif self.project_privacy == 'Private' and user == self.project_creator:
+        elif self.project_privacy == 'Private':
             return 'partials/_project-actions.html'
         else:
             return None

--- a/projects/utils.py
+++ b/projects/utils.py
@@ -198,7 +198,4 @@ def can_download_project(request, project_creator_instance):
     elif project_creator_instance.community:
         if not project_creator_instance.community.is_approved:
             can_download = False
-    elif project_creator_instance.institution:
-        if not project_creator_instance.institution.is_subscribed:
-            can_download = False
     return can_download

--- a/templates/public.html
+++ b/templates/public.html
@@ -157,7 +157,7 @@
                             {% join_request_inst institution.id request.user as request_exists %}
                             {% if request_exists or institution in user_institutions %}
                                 <div class="primary-btn disabled-btn">Request sent <i class="fa fa-check" aria-hidden="true"></i></div>
-                            {% else %}
+                            {% elif institution.is_subscribed %}
                                 <div class="margin-top-8 margin-bottom-8">
                                     <a id="openRequestToJoinModalBtn" class="default-a">Request to join</a>
                                 </div>


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/86887gk2m)**

**Description:**
From the latest subscription meeting it was decided that some functionality was to be adjusted for accounts. This specific task relates to institutions only. 

- Public Projects can be viewed and downloaded regardless of subscription status
- Private Projects cannot be downloaded by anyone
- Institution accounts do appear in the registry but their public pages will contain content labelling them as Active (if subscription) and Inactive (if no subscription). Relevant task here: 
- Unsubscribed institutions cannot be added to Projects as contributors.
- Unsubscribed institutions cannot be joined via account creation process or from their public registry page.

**Solution:**
- Updated the Query for Projects on Project-board and for institutes on registry view
- Updated the Project model to get project access 
- Update the template to remove the Join button if Institute isn't subscribed

**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/a0da71e2-f3c5-4ece-a87a-2bf0ccc3588a

