### PR TITLE
#8688p5hjk Block Create Project URL hitting

### DIFF
--- a/helpers/views.py
+++ b/helpers/views.py
@@ -44,8 +44,8 @@ def download_open_collaborate_notice(request, perm, researcher_id=None, institut
     else:
         if researcher_id:
             researcher = get_object_or_404(Researcher, id=researcher_id)
-            validate_is_subscribed(researcher)
-            NoticeDownloadTracker.objects.create(researcher=researcher, user=request.user,open_to_collaborate_notice=True)
+            if researcher.is_subscribed:
+                NoticeDownloadTracker.objects.create(researcher=researcher, user=request.user,open_to_collaborate_notice=True)
 
         elif institution_id:
             institution = get_object_or_404(Institution, id=institution_id)

--- a/helpers/views.py
+++ b/helpers/views.py
@@ -13,7 +13,7 @@ from .models import NoticeDownloadTracker
 from institutions.models import Institution
 from researchers.models import Researcher
 from .utils import validate_is_subscribed
-
+from .exceptions import UnsubscribedAccountException
 
 def restricted_view(request, exception=None):
     return render(request, '403.html', status=403)
@@ -43,15 +43,21 @@ def download_open_collaborate_notice(request, perm, researcher_id=None, institut
         return redirect('restricted')
     else:
         if researcher_id:
-            researcher = get_object_or_404(Researcher, id=researcher_id)
-            if researcher.is_subscribed:
-                NoticeDownloadTracker.objects.create(researcher=researcher, user=request.user,open_to_collaborate_notice=True)
+            entity = get_object_or_404(Researcher, id=researcher_id)
+            entity_type = 'researcher'
+        if institution_id:
+            entity = get_object_or_404(Institution, id=institution_id)
+            entity_type = 'institution'
 
-        elif institution_id:
-            institution = get_object_or_404(Institution, id=institution_id)
-            NoticeDownloadTracker.objects.create(institution=institution, user=request.user, open_to_collaborate_notice=True)
-
-        return download_otc_notice(request)
+        if entity.is_subscribed:
+            entity_field = {entity_type: entity}
+            entity_field['user'] = request.user
+            entity_field['open_to_collaborate_notice'] = True
+            NoticeDownloadTracker.objects.create(**entity_field)
+            return download_otc_notice(request)   
+        else:
+            message = 'Account Is Not Subscribed'
+            raise UnsubscribedAccountException(message)
 
 
 @login_required(login_url='login')

--- a/institutions/utils.py
+++ b/institutions/utils.py
@@ -1,3 +1,4 @@
+from django.http import HttpResponseForbidden
 from django.shortcuts import render, redirect
 from django.db.models import Q
 from django.contrib import messages
@@ -155,8 +156,9 @@ def check_subscription(request, subscriber_type, id):
         subscription = Subscription.objects.get(**{subscriber_field: id})
     except Subscription.DoesNotExist:
         messages.add_message(request, messages.ERROR, 'The subscription process of your account is not completed yet. Please wait for the completion of subscription process.')
-        return True
+        return HttpResponseForbidden('Forbidden: Subscription process isnt completed. ')
+
     if subscription.project_count == 0:
         messages.add_message(request, messages.ERROR, 'Your account has reached its Project limit. '
                             'Please upgrade your subscription plan to create more Projects.')
-        return True
+        return HttpResponseForbidden('Forbidden: Project limit of account is reached. ')

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -154,8 +154,8 @@ def create_custom_institution(request):
         if noror_form.is_valid() and user_form.is_valid() and validate_recaptcha(request):
             mutable_post_data = request.POST.copy()
             subscription_data = {
-            "first_name": request.user._wrapped.first_name,
-            "last_name": request.user._wrapped.last_name,
+            "first_name": user_form.cleaned_data['first_name'],
+            "last_name": user_form.cleaned_data['last_name'],
             "email": request.user._wrapped.email,
             "account_type": "institution_account",
             "organization_name": noror_form.cleaned_data['institution_name'],

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -619,7 +619,6 @@ def member_requests(request, pk):
     if request.method == 'POST':
         selected_role = request.POST.get('selected_role')
         join_request_id = request.POST.get('join_request_id')
-        # redirection = check_subscription(request, institution)
         if check_subscription(request, institution) and selected_role.lower() in ('editor', 'administrator', 'admin'):
             messages.add_message(request, messages.ERROR, 'The subscription process of your institution is not completed yet. Please wait for the completion of subscription process.')
             return redirect('institution-members', institution.id)
@@ -917,18 +916,11 @@ def create_project(request, pk, source_proj_uuid=None, related=None):
     name = get_users_name(request.user)
     notice_translations = get_notice_translations()
     notice_defaults = get_notice_defaults()
-    redirection = check_subscription(request, institution)
-    if redirection:
-        messages.add_message(request, messages.ERROR, 'The subscription process of your institution is not completed yet. Please wait for the completion of subscription process.')
+    
+    if check_subscription(request, 'institution', pk):      
         return redirect('institution-projects', institution.id)
     
     subscription = Subscription.objects.get(institution=institution)
-    if subscription.project_count == 0:
-        messages.add_message(request, messages.ERROR, 'Your institution has reached its Project limit. '
-                            'Please upgrade your subscription plan to create more Projects.')
-        return redirect('institution-projects', institution.id)
-    
-
     if request.method == 'GET':
         form = CreateProjectForm(request.GET or None)
         formset = ProjectPersonFormset(queryset=ProjectPerson.objects.none())

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -167,18 +167,12 @@ def create_custom_institution(request):
                 handle_institution_creation(request, noror_form, subscription_form )
                 return redirect('dashboard')
             else:
-                error_messages = []
-                for field, errors in subscription_form.errors.items():
-                    for error in errors:
-                        error_messages.append(f"{field.capitalize()}: {error}")
-
-                concatenated_errors = "\n".join(error_messages)
                 messages.add_message(
-                                request,
-                                messages.ERROR,
-                                concatenated_errors,
-                            )
-                return redirect('confirm-subscription-institution',  data.id)
+                    request,
+                    messages.ERROR,
+                    "Something went wrong. Please Try again later.",
+                )
+                return redirect('dashboard')
     return render(
         request,
         "institutions/create-custom-institution.html",

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -10,6 +10,7 @@ from projects.utils import *
 from helpers.utils import *
 from accounts.utils import get_users_name, handle_confirmation_and_subscription, confirm_subscription
 from notifications.utils import send_action_notification_to_project_contribs
+from institutions.utils import check_subscription
 
 from communities.models import Community
 from notifications.models import ActionNotification
@@ -477,11 +478,10 @@ def create_project(request, pk, source_proj_uuid=None, related=None):
     notice_defaults = get_notice_defaults()
     notice_translations = get_notice_translations()
 
-    try:
-        subscription = Subscription.objects.get(researcher=researcher.id)
-    except Subscription.DoesNotExist:
-        subscription = None
-
+    if check_subscription(request, 'researcher', pk):
+        return redirect('researcher-projects', researcher.id)
+    
+    subscription = Subscription.objects.get(institution=institution)
     if request.method == "GET":
         form = CreateProjectForm(request.POST or None)
         formset = ProjectPersonFormset(queryset=ProjectPerson.objects.none())

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -481,7 +481,7 @@ def create_project(request, pk, source_proj_uuid=None, related=None):
     if check_subscription(request, 'researcher', pk):
         return redirect('researcher-projects', researcher.id)
     
-    subscription = Subscription.objects.get(institution=institution)
+    subscription = Subscription.objects.get(researcher=researcher)
     if request.method == "GET":
         form = CreateProjectForm(request.POST or None)
         formset = ProjectPersonFormset(queryset=ProjectPerson.objects.none())

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -472,13 +472,11 @@ def researcher_projects(request, pk):
 @is_researcher(pk_arg_name='pk')
 def create_project(request, pk, source_proj_uuid=None, related=None):
     researcher = Researcher.objects.get(id=pk)
-    bypass_validation = dev_prod_or_local(request.get_host()) == 'SANDBOX'
-    validate_is_subscribed(researcher, bypass_validation)
     name = get_users_name(request.user)
     notice_defaults = get_notice_defaults()
     notice_translations = get_notice_translations()
 
-    if check_subscription(request, 'researcher', pk):
+    if check_subscription(request, 'researcher', pk) and dev_prod_or_local(request.get_host()) != 'SANDBOX':
         return redirect('researcher-projects', researcher.id)
     
     subscription = Subscription.objects.get(researcher=researcher)
@@ -578,8 +576,6 @@ def create_project(request, pk, source_proj_uuid=None, related=None):
 @is_researcher(pk_arg_name='pk')
 def edit_project(request, pk, project_uuid):
     researcher = Researcher.objects.get(id=pk)
-    bypass_validation = dev_prod_or_local(request.get_host()) == 'SANDBOX'
-    validate_is_subscribed(researcher, bypass_validation)
 
     project = Project.objects.get(unique_id=project_uuid)
     form = EditProjectForm(request.POST or None, instance=project)

--- a/templates/researchers/projects.html
+++ b/templates/researchers/projects.html
@@ -1,4 +1,7 @@
 {% extends 'account-base.html' %} {% block title %} Projects {% endblock %}{% load static %}{% load custom_researcher_tags %}{% block researcher_content %}
+<div class="dashcard-alerts">
+    {% include 'partials/_alerts.html' %}
+</div>
 {% researcher_contributing_projects researcher as researcher_projects_contrib %}
     {% include 'projects/projects.html' %}
 {% endblock %}


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8688p5hjk)**

**Description:**
Tested an account where my project count was 0, so the Create Project button was disabled, but when I go directly to create-project (http://localhost:8000/researchers/projects/create-project/1/) I am still able to create a project. This needs to be blocked for Researchers and Institutions.
**Solution:**
- Performs checks on ```create-project/``` URL for institution and  researcher account to stop access of unauthorized users
- Removed unnecessary code to improve code base 

**After:**
**Institution Account:**

https://github.com/localcontexts/localcontextshub/assets/145371882/098a2b22-7e91-4255-bd9c-f49693ecc460

**Researcher Account:**

https://github.com/localcontexts/localcontextshub/assets/145371882/0ccce511-8837-4d7b-8ba5-d0d7190a2126

