### PR TITLE
#8688q2mz6 allow anonymous subscription form

### DIFF
--- a/accounts/decorators.py
+++ b/accounts/decorators.py
@@ -1,4 +1,6 @@
 from django.shortcuts import redirect
+from django.contrib import messages
+from researchers.utils import is_user_researcher
 
 
 def unauthenticated_user(view_func):
@@ -7,6 +9,32 @@ def unauthenticated_user(view_func):
         # If user is authenticated, takes the user to dashboard,
         # otherwise shows desired view.
         if request.user.is_authenticated:
+            return redirect('dashboard')
+        else:
+            return view_func(request, *args, **kwargs)
+
+    return wrapper_func
+
+
+def zero_account_user(view_func):
+
+    def wrapper_func(request, *args, **kwargs):
+        user = request.user
+        affiliations = (
+            user.user_affiliations.prefetch_related(
+                "institutions",
+            )
+            .all()
+        )
+        has_institutions = any(
+            affiliation.institutions.exists()
+            for affiliation in affiliations
+        )
+        if has_institutions or is_user_researcher(user):
+            messages.add_message(
+                request,
+                messages.INFO,
+                "Try creating account from Create an account button.")
             return redirect('dashboard')
         else:
             return view_func(request, *args, **kwargs)

--- a/accounts/decorators.py
+++ b/accounts/decorators.py
@@ -19,24 +19,27 @@ def unauthenticated_user(view_func):
 def zero_account_user(view_func):
 
     def wrapper_func(request, *args, **kwargs):
-        user = request.user
-        affiliations = (
-            user.user_affiliations.prefetch_related(
-                "institutions",
+        if request.user.is_authenticated:
+            user = request.user
+            affiliations = (
+                user.user_affiliations.prefetch_related(
+                    "institutions",
+                )
+                .all()
             )
-            .all()
-        )
-        has_institutions = any(
-            affiliation.institutions.exists()
-            for affiliation in affiliations
-        )
-        if has_institutions or is_user_researcher(user):
-            messages.add_message(
-                request,
-                messages.INFO,
-                "Try creating account from Create an account button.")
-            return redirect('dashboard')
-        else:
+            has_institutions = any(
+                affiliation.institutions.exists()
+                for affiliation in affiliations
+            )
+            if has_institutions or is_user_researcher(user):
+                messages.add_message(
+                    request,
+                    messages.INFO,
+                    "Try creating account from Create an account button.")
+                return redirect('dashboard')
+            else:
+                return view_func(request, *args, **kwargs)
+        elif not request.user.is_authenticated:
             return view_func(request, *args, **kwargs)
 
     return wrapper_func

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -35,7 +35,7 @@ from unidecode import unidecode
 from institutions.models import Institution
 from localcontexts.utils import dev_prod_or_local
 from researchers.models import Researcher
-from .decorators import unauthenticated_user
+from .decorators import unauthenticated_user, zero_account_user
 
 from communities.models import InviteMember, Community
 from helpers.models import HubActivity
@@ -938,7 +938,7 @@ def newsletter_unsubscription(request, emailb64):
         return redirect("login")
 
 
-@unauthenticated_user
+@zero_account_user
 def subscription_inquiry(request):
     form = SubscriptionForm(request.POST or None)
     form.fields.pop('account_type', None)

--- a/templates/partials/headers/header-content.html
+++ b/templates/partials/headers/header-content.html
@@ -11,14 +11,12 @@
             <div class='menu-button'></div>
         </label>
         <ul class="menu ul-no-bullets">
-            {% if not user.is_authenticated %}
             <li>
                 <a 
                     class="{% if '/subscription-inquiry/' in request.path %} active-link bold {% endif %} white-text upper" 
                     href="{% url 'subscription-inquiry' %}"> Subscription
                 </a>
             </li> 
-            {% endif %}
             <li>
                 <a 
                     class="{% if '/registry/' in request.path %} active-link bold {% endif %} white-text upper" 


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8688q2mz6)**

**Description:**
Use case:
User has a profile created but not an account yet but is interested in subscriptions. Maybe this user does not know what kind of account they should create.

The subscription form at /subscribtion-inquiry should be available to logged-in users. Currently it is only available to anon users and if someone who is logged in tries to access that URL, they are redirected to the dashboard.

**Solution:**
- Updated the decorator from ```unauthenticateduser``` to ```zero_account_user```
- Performs check if the user is associated to any institution or researcher account 
- If the association is present the user is redirected to dashboard else continue to ` /subscription-inquiry/ ` URL  

**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/08abd83c-dfb0-419e-9a3b-b86de4a142da

