### PR TITLE
#8688t720h subscriptions handling in sandbox

### DIFF
--- a/accounts/decorators.py
+++ b/accounts/decorators.py
@@ -1,6 +1,7 @@
 from django.shortcuts import redirect
 from django.contrib import messages
 from researchers.utils import is_user_researcher
+from localcontexts.utils import dev_prod_or_local
 
 
 def unauthenticated_user(view_func):
@@ -19,6 +20,12 @@ def unauthenticated_user(view_func):
 def zero_account_user(view_func):
 
     def wrapper_func(request, *args, **kwargs):
+        if dev_prod_or_local(request.get_host()) == "SANDBOX":
+            messages.add_message(
+                    request,
+                    messages.INFO,
+                    "This page is not available on the sandbox site. ")
+            return redirect('login')
         if request.user.is_authenticated:
             user = request.user
             affiliations = (

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -12,6 +12,7 @@ from accounts.models import Subscription
 from unidecode import unidecode
 from django.utils import timezone
 
+
 def get_users_name(user):
     if user:
         return user.get_full_name() or user.username
@@ -196,8 +197,10 @@ def confirm_subscription(request, user, join_flag, form, account_type):
     return redirect('dashboard')
 
 
-def handle_confirmation_and_subscription(request, subscription_form, user, env):
-    from helpers.emails import send_hub_admins_application_email
+def handle_confirmation_and_subscription(
+    request, subscription_form, user, env
+):
+    from helpers.emails import send_hub_admins_account_creation_email
     join_flag = False
     first_name = subscription_form.cleaned_data["first_name"]
     if not subscription_form.cleaned_data["last_name"]:
@@ -213,14 +216,14 @@ def handle_confirmation_and_subscription(request, subscription_form, user, env):
             user.is_subscribed = True
             user.save()
             response = Subscription.objects.create(
-            researcher=user,
-            users_count=-1,
-            api_key_count=-1,
-            project_count=-1,
-            notification_count=-1,
-            start_date=timezone.now(),
-            end_date=None
-            )
+                researcher=user,
+                users_count=-1,
+                api_key_count=-1,
+                project_count=-1,
+                notification_count=-1,
+                start_date=timezone.now(),
+                end_date=None
+                )
             return response
         elif isinstance(user, Institution):
             response = confirm_subscription(

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -8,8 +8,9 @@ from django.contrib import messages
 from communities.models import Community
 from institutions.models import Institution
 from researchers.models import Researcher
+from accounts.models import Subscription
 from unidecode import unidecode
-
+from django.utils import timezone
 
 def get_users_name(user):
     if user:
@@ -178,8 +179,6 @@ def confirm_subscription(request, user, join_flag, form, account_type):
         hubId=hub_id,
         data=form.cleaned_data
     ):
-        user.is_submitted = True
-        user.save()
         messages.add_message(
             request,
             messages.INFO,
@@ -197,17 +196,30 @@ def confirm_subscription(request, user, join_flag, form, account_type):
     return redirect('dashboard')
 
 
-def handle_confirmation_and_subscription(request, subscription_form, user):
-    from helpers.emails import send_hub_admins_account_creation_email
+def handle_confirmation_and_subscription(request, subscription_form, user, env):
+    from helpers.emails import send_hub_admins_application_email
     join_flag = False
     first_name = subscription_form.cleaned_data["first_name"]
     if not subscription_form.cleaned_data["last_name"]:
         subscription_form.cleaned_data["last_name"] = first_name
     try:
-        if isinstance(user, Researcher):
+        if isinstance(user, Researcher) and env != 'SANDBOX':
             response = confirm_subscription(
                 request, user, join_flag,
                 subscription_form, 'researcher_account'
+            )
+            return response
+        elif isinstance(user, Researcher) and env == 'SANDBOX':
+            user.is_subscribed = True
+            user.save()
+            response = Subscription.objects.create(
+            researcher=user,
+            users_count=-1,
+            api_key_count=-1,
+            project_count=-1,
+            notification_count=-1,
+            start_date=timezone.now(),
+            end_date=None
             )
             return response
         elif isinstance(user, Institution):

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -104,7 +104,7 @@ def connect_researcher(request):
                     action_type="New Researcher"
                 )
                 if subscription_form.is_valid():
-                    handle_confirmation_and_subscription(request, subscription_form, data)
+                    handle_confirmation_and_subscription(request, subscription_form, data, env)
                     return redirect('dashboard')
                 else:
                     error_messages = []


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8688t720h)**

**Description:**
Since the sandbox is a more of a demo space for users to see how the hub works, we need to ensure that subscriptions functionality is completely bypassed / disabled and/or hidden in the sandbox environment so that users can test workflows without needing an active subscription, counts, etc.

There is some functionality across the hub that is already set up for the sandbox (ie. environment-specific content, email sending, download limitation, contacting other accounts, etc.) which can stay as is but we need to make sure that each account can create/edit Projects, add contributors to Projects, be able to customize Labels and add them to Projects (if they are a community), and add/remove members without needing counts or a subscription instance.

In account creation a user should be able to create any account type, and the account creation will not send anything to SF sandbox and should grant them the immediate access to most of the features in the sandbox.

Any subscription-specific tasks or pages (such as subscription-inquiry  page or subscription tab in account settings should either be disabled and greyed out or the URL completely unaccessible.

**Solution:**
 - Updated the ```zero_account_user``` decorator for `/subscription-inquiry/ ` to deny access on sandbox environment 
 - Updated the condition of account creation  based on environment 
 - While on Sandbox environment created grandfather account also for the accounts in Subscription table
 
 **After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/72df6e46-f17a-404f-ae87-a8c366e3c0b9

