### PR TITLE
#8688uhct0 Non-User Project Contributor issues

### DIFF
--- a/researchers/views.py
+++ b/researchers/views.py
@@ -469,8 +469,13 @@ def edit_project(request, researcher, project_uuid):
 
             instances = formset.save(commit=False)
             for instance in instances:
-                instance.project = data
-                instance.save()
+                if instance.name or instance.email:
+                    instance.project = project
+                    instance.save()
+
+            # Delete instances marked for deletion
+            for instance in formset.deleted_objects:
+                instance.delete()
 
             # Add selected contributors to the ProjectContributors object
             add_to_contributors(request, researcher, data)


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8688uhct0)**

**Description:**
In prod, I went to edit a project that already had a contributor in it. But when I edited the project, I didnt do anything to the project, just saved the project and this is what showed up:
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/75c43f35-b36e-48b0-8ed2-ced10ea4d74e)
The contributor section is blank. This might be able to be fixed with  but not sure. I am also not able to delete the non-hub contributor I added.

View of Project when editing it and didnt change anything.
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/4386248b-8ece-4d2e-9e73-189d170089fd)

**Solution:**
- Updated the process of deleting contributors from project
 
**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/c4bfada4-02fc-490c-8d8e-11d3236c689e

