### PR TITLE
#8688wzakr Error when removing notice from project

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -257,6 +257,7 @@ def crud_notices(request, selected_notices, selected_translations, organization,
                 has_changes = True
                 notice.delete()
                 ProjectActivity.objects.create(project=project, activity=f'{notice.name} was removed from the Project by {name}')
+                continue
             update_notice_translation(notice, selected_translations)
         create_notices(existing_notice_types)
         return has_changes


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8688wzakr)**

**Description:**
When I attempted to remove the notice from the project, I encountered an error.
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/075b2c7f-e2c4-4395-a3d0-92489917516f)



**Solution:**
- Adjusted the loop on deleting notice.

**Before:**

https://github.com/localcontexts/localcontextshub/assets/145371882/09bdf52a-9f2e-4329-a1de-791a827b4136

**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/37b72de3-2bfe-45ff-9fac-28a2899b1905

