### PR TITLE
#8688wgz4k Subscription Code Clean-Up

### DIFF
--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -192,4 +192,3 @@ def confirm_subscription(request, user, form, account_type):
             " Please contact support@localcontexts.org.")
 
     return redirect('dashboard')
-

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -8,9 +8,7 @@ from django.contrib import messages
 from communities.models import Community
 from institutions.models import Institution
 from researchers.models import Researcher
-from accounts.models import Subscription
 from unidecode import unidecode
-from django.utils import timezone
 
 
 def get_users_name(user):

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -106,10 +106,7 @@ def institute_account_subscription(
                 messages.INFO,
                 "Your Account already exists on Hub. Please login.",
             )
-            return redirect(
-                "confirm-subscription-institution",
-                institution_id=institution.id,
-            )
+            return redirect("dashboard")
         elif account_exist and institution:
             next_url = reverse(
                 "public-institution", kwargs={"pk": institution.id}

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -163,7 +163,7 @@ def institute_account_subscription(
             return redirect("subscription-inquiry")
 
 
-def confirm_subscription(request, user, join_flag, form, account_type):
+def confirm_subscription(request, user, form, account_type):
     from helpers.utils import create_salesforce_account_or_lead
     if account_type == "institution_account":
         hub_id = str(user.id) + "_i"
@@ -193,52 +193,3 @@ def confirm_subscription(request, user, join_flag, form, account_type):
 
     return redirect('dashboard')
 
-
-def handle_confirmation_and_subscription(
-    request, subscription_form, user, env
-):
-    from helpers.emails import send_hub_admins_account_creation_email
-    join_flag = False
-    first_name = subscription_form.cleaned_data["first_name"]
-    if not subscription_form.cleaned_data["last_name"]:
-        subscription_form.cleaned_data["last_name"] = first_name
-    try:
-        if isinstance(user, Researcher) and env != 'SANDBOX':
-            response = confirm_subscription(
-                request, user, join_flag,
-                subscription_form, 'researcher_account'
-            )
-            return response
-        elif isinstance(user, Researcher) and env == 'SANDBOX':
-            user.is_subscribed = True
-            user.save()
-            response = Subscription.objects.create(
-                researcher=user,
-                users_count=-1,
-                api_key_count=-1,
-                project_count=-1,
-                notification_count=-1,
-                start_date=timezone.now(),
-                end_date=None
-                )
-            return response
-        elif isinstance(user, Institution):
-            response = confirm_subscription(
-                request, user, join_flag,
-                subscription_form, 'institution_account'
-            )
-            data = Institution.objects.get(
-                institution_name=user.institution_name
-            )
-            send_hub_admins_account_creation_email(
-                request, data
-            )
-            return response
-    except Exception:
-        messages.add_message(
-            request,
-            messages.ERROR,
-            "An unexpected error has occurred here."
-            " Please contact support@localcontexts.org.",
-        )
-        return redirect("dashboard")

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -41,6 +41,7 @@ from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.utils.encoding import force_bytes, force_str
 import traceback
 import re
+from django.http import HttpResponseForbidden
 
 class SalesforceAPIError(Exception):
     pass

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -29,7 +29,7 @@ from accounts.forms import UserCreateProfileForm, SubscriptionForm
 
 from accounts.utils import get_users_name, confirm_subscription
 from notifications.utils import send_user_notification_member_invite_accept
-from helpers.emails import send_membership_email, send_subscription_fail_email
+from helpers.emails import send_membership_email, send_subscription_fail_email, send_hub_admins_account_creation_email
 from django.contrib.staticfiles import finders
 from django.shortcuts import get_object_or_404
 
@@ -741,8 +741,8 @@ def handle_confirmation_and_subscription(request, subscription_form, user):
             data = Institution.objects.get(
                 institution_name=user.institution_name
             )
-            send_hub_admins_application_email(
-                request, user, data
+            send_hub_admins_account_creation_email(
+                request, data
             )
             return response
     except Exception:

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -25,6 +25,8 @@ from .exceptions import UnsubscribedAccountException
 from .models import Notice
 from notifications.models import *
 
+from accounts.forms import UserCreateProfileForm, SubscriptionForm
+
 from accounts.utils import get_users_name
 from notifications.utils import send_user_notification_member_invite_accept
 from helpers.emails import send_membership_email, send_subscription_fail_email
@@ -661,3 +663,37 @@ def encrypt_api_key(key):
 def decrypt_api_key(key):
     api_key = force_str(urlsafe_base64_decode(key))
     return api_key
+
+def form_initiation(request,account_type=""):
+    subscription_form = SubscriptionForm()
+    if account_type == "institution_action":
+        fields_to_update = {
+            "first_name": request.user._wrapped.first_name,
+            "last_name": request.user._wrapped.last_name,
+        }
+        user_form = UserCreateProfileForm(request.POST or None, initial=fields_to_update)
+        exclude_choices = {"member", "service_provider"}
+        
+        modified_inquiry_type_choices = [
+            choice
+            for choice in SubscriptionForm.INQUIRY_TYPE_CHOICES
+            if choice[0] not in exclude_choices
+        ]
+        subscription_form.fields["inquiry_type"].choices = modified_inquiry_type_choices
+        for field, value in fields_to_update.items():
+            if value:
+                user_form.fields[field].widget.attrs.update({"class": "w-100 readonly-input"})
+            
+        return  user_form,subscription_form
+    elif account_type == "researcher_action":
+        subscription_form = SubscriptionForm()
+        exclude_choices = {"member", "service_provider", "cc_only"}
+        modified_inquiry_type_choices = [
+            choice
+            for choice in SubscriptionForm.INQUIRY_TYPE_CHOICES
+            if choice[0] not in exclude_choices
+            
+        ]
+        subscription_form.fields["inquiry_type"].choices = modified_inquiry_type_choices
+        
+        return subscription_form

--- a/institutions/urls.py
+++ b/institutions/urls.py
@@ -6,7 +6,6 @@ urlpatterns = [
     path('connect-institution/', views.connect_institution, name="connect-institution"),
     path('create-institution/', views.create_institution, name="create-institution"),
     path('create-institution/noROR', views.create_custom_institution, name="create-custom-institution"),
-    path('confirm-subscription-institution/<str:institution_id>/', views.confirm_subscription_institution, name="confirm-subscription-institution"),
 
     # Public view
     path('view/<str:pk>/', views.public_institution_view, name="public-institution"),

--- a/institutions/utils.py
+++ b/institutions/utils.py
@@ -3,7 +3,7 @@ from django.db.models import Q
 from django.contrib import messages
 from .models import Institution
 from accounts.models import Subscription, UserAffiliation
-from helpers.utils import change_member_role, SalesforceAPIError, create_salesforce_account_or_lead, handle_confirmation_and_subscription
+from helpers.utils import change_member_role, SalesforceAPIError, handle_confirmation_and_subscription
 from helpers.emails import send_hub_admins_application_email
 from institutions.models import Institution
 from helpers.models import HubActivity

--- a/institutions/utils.py
+++ b/institutions/utils.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from .models import Institution
 from accounts.models import Subscription, UserAffiliation
 from helpers.utils import change_member_role, SalesforceAPIError, handle_confirmation_and_subscription
-from helpers.emails import send_hub_admins_application_email
+from helpers.emails import  send_hub_admins_account_creation_email
 from institutions.models import Institution
 from helpers.models import HubActivity
 from django.db import transaction

--- a/institutions/utils.py
+++ b/institutions/utils.py
@@ -1,4 +1,3 @@
-from django.http import HttpResponseForbidden
 from django.shortcuts import render, redirect
 from django.db.models import Q
 from django.contrib import messages

--- a/institutions/utils.py
+++ b/institutions/utils.py
@@ -8,7 +8,6 @@ from helpers.utils import change_member_role, SalesforceAPIError, create_salesfo
 from helpers.emails import send_hub_admins_account_creation_email
 from institutions.models import Institution
 from helpers.models import HubActivity
-from accounts.forms import UserCreateProfileForm, SubscriptionForm
 from django.db import transaction
 from django.utils import timezone
 from localcontexts.utils import dev_prod_or_local
@@ -17,28 +16,6 @@ from localcontexts.utils import dev_prod_or_local
 def get_institution(pk):
     return Institution.objects.select_related('institution_creator').prefetch_related('admins', 'editors', 'viewers').get(id=pk)
 
-
-def form_initiation(request):
-    subscription_form = SubscriptionForm()
-
-    fields_to_update = {
-        "first_name": request.user._wrapped.first_name,
-        "last_name": request.user._wrapped.last_name,
-    }
-    user_form = UserCreateProfileForm(request.POST or None, initial=fields_to_update)
-    exclude_choices = {"member", "service_provider"}
-    
-    modified_inquiry_type_choices = [
-        choice
-        for choice in SubscriptionForm.INQUIRY_TYPE_CHOICES
-        if choice[0] not in exclude_choices
-    ]
-    subscription_form.fields["inquiry_type"].choices = modified_inquiry_type_choices
-    for field, value in fields_to_update.items():
-        if value:
-            user_form.fields[field].widget.attrs.update({"class": "w-100 readonly-input"})
-        
-    return  user_form,subscription_form
 
 def handle_institution_creation(request, form, subscription_form ):
     try:

--- a/institutions/utils.py
+++ b/institutions/utils.py
@@ -4,8 +4,7 @@ from django.db.models import Q
 from django.contrib import messages
 from .models import Institution
 from accounts.models import Subscription, UserAffiliation
-from helpers.utils import change_member_role, SalesforceAPIError, create_salesforce_account_or_lead
-from accounts.utils import confirm_subscription, handle_confirmation_and_subscription
+from helpers.utils import change_member_role, SalesforceAPIError, create_salesforce_account_or_lead, handle_confirmation_and_subscription
 from helpers.emails import send_hub_admins_application_email
 from institutions.models import Institution
 from helpers.models import HubActivity
@@ -92,27 +91,3 @@ def add_user(request, institution, member, current_role, new_role):
         messages.add_message(request, messages.ERROR, 
                             'Your institution has reached its editors and admins limit. '
                             'Please upgrade your subscription plan to add more editors and admins.')
-
-         
-def check_subscription(request, subscriber_type, id):
-    subscriber_field_mapping = {
-        'institution': 'institution_id',
-        'researcher': 'researcher_id',
-        'community': 'community_id'
-    }
-    
-    if subscriber_type not in subscriber_field_mapping:
-        raise ValueError("Invalid subscriber type provided.")
-    
-    subscriber_field = subscriber_field_mapping[subscriber_type]
-    
-    try:
-        subscription = Subscription.objects.get(**{subscriber_field: id})
-    except Subscription.DoesNotExist:
-        messages.add_message(request, messages.ERROR, 'The subscription process of your account is not completed yet. Please wait for the completion of subscription process.')
-        return HttpResponseForbidden('Forbidden: Subscription process isnt completed. ')
-
-    if subscription.project_count == 0:
-        messages.add_message(request, messages.ERROR, 'Your account has reached its Project limit. '
-                            'Please upgrade your subscription plan to create more Projects.')
-        return HttpResponseForbidden('Forbidden: Project limit of account is reached. ')

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -190,65 +190,6 @@ def create_custom_institution(request):
         },
     )
 
-@login_required(login_url="login")
-def confirm_subscription_institution(request, institution_id):
-    join_flag = False
-    institution = get_object_or_404(Institution, id=institution_id)
-    initial_data = {
-        "first_name": request.user._wrapped.first_name,
-        "last_name": request.user._wrapped.last_name,
-        "email": request.user._wrapped.email,
-        "account_type": "institution_account",
-        "organization_name": institution.institution_name,
-    }
-    modified_inquiry_type_choices = [
-        choice
-        for choice in SubscriptionForm.INQUIRY_TYPE_CHOICES
-        if choice[0] != "member"
-    ]
-    form = SubscriptionForm(request.POST or None, initial=initial_data)
-    form.fields["inquiry_type"].choices = modified_inquiry_type_choices
-    form.fields["account_type"].widget.attrs.update({"class": "w-100 readonly-input"})
-    form.fields["organization_name"].widget.attrs.update({"class": "readonly-input"})
-    form.fields["email"].widget.attrs.update({"class": "readonly-input"})
-    if request.method == "POST":
-        if validate_recaptcha(request) and form.is_valid():
-            account_type_key = form.cleaned_data["account_type"]
-            inquiry_type_key = form.cleaned_data["inquiry_type"]
-
-            account_type_display = dict(form.fields["account_type"].choices).get(
-                account_type_key, ""
-            )
-            inquiry_type_display = dict(form.fields["inquiry_type"].choices).get(
-                inquiry_type_key, ""
-            )
-            form.cleaned_data["account_type"] = account_type_display
-            form.cleaned_data["inquiry_type"] = inquiry_type_display
-
-            first_name = form.cleaned_data["first_name"]
-            if not form.cleaned_data["last_name"]:
-                form.cleaned_data["last_name"] = first_name
-            try:
-                response = confirm_subscription(request, institution, join_flag, form)
-                return response
-            except:
-                messages.add_message(
-                    request,
-                    messages.ERROR,
-                    "An unexpected error has occurred. Please contact support@localcontexts.org.",
-                )
-                return redirect("dashboard")
-    return render(
-        request,
-        "accounts/confirm-subscription.html",
-        {
-            "form": form,
-            "account": institution,
-            "subscription_url": 'confirm-subscription-institution',
-            "join_flag": join_flag,
-        },
-    )
-
 
 def public_institution_view(request, pk):
     try:

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -113,7 +113,7 @@ def preparation_step(request):
 @login_required(login_url="login")
 def create_institution(request):
     form = CreateInstitutionForm()
-    user_form,subscription_form  = form_initiation(request)
+    user_form,subscription_form  = form_initiation(request, "institution_action")
    
     if request.method == "POST":
         form = CreateInstitutionForm(request.POST)
@@ -154,7 +154,7 @@ def create_institution(request):
 @login_required(login_url="login")
 def create_custom_institution(request):
     noror_form = CreateInstitutionNoRorForm()
-    user_form,subscription_form  = form_initiation(request)
+    user_form,subscription_form  = form_initiation(request, "institution_action")
 
     if request.method == "POST":
         noror_form = CreateInstitutionNoRorForm(request.POST)

--- a/localcontexts/static/javascript/main.js
+++ b/localcontexts/static/javascript/main.js
@@ -2372,35 +2372,33 @@ if (window.location.href.includes('subscription-inquiry')) {
         // Clear previous suggestions
         clearSuggestions()
         // Get the first 5 most relevant itemss
-        const combinedItems = items.concat(matchingInstitutions);
-        const relevantItems = combinedItems.some(
-          item =>
-            (typeof item === 'object' && item.name?.toLowerCase() === userInput.toLowerCase()) ||
-            (typeof item === 'object' &&
-              item.fields?.institution_name?.toLowerCase() === userInput.toLowerCase())
-        );
-  
-        if (relevantItems) {
-          const relevantItems = combinedItems.slice(0, 5);
-          displaySuggestions(relevantItems);
-        } else {
-          const suggestionItem = document.createElement('div');
-          suggestionItem.classList.add('suggestion-item');
-          suggestionItem.innerHTML = `${userInput} (Not Found in ROR List)`;
+        const combinedItems = [...matchingInstitutions, ...items];
 
-          suggestionItem.addEventListener('click', () => {
-            nameInputField.value = userInput;
-            clearSuggestions();
-          });
-  
-          suggestionsContainer.appendChild(suggestionItem);
-  
-          const relevantItems = items.slice(0, 5);
-          if (relevantItems.length > 0) {
-            displaySuggestions(relevantItems);
-          }
+        const filteredItems = combinedItems.filter(item =>
+            (typeof item === 'object' && item.name?.toLowerCase().includes(userInput.toLowerCase())) ||
+            (typeof item === 'object' && item.fields?.institution_name?.toLowerCase().includes(userInput.toLowerCase()))
+        );
+
+        // Check if any item exactly matches the user input
+        const exactMatch = combinedItems.some(item =>
+            (typeof item === 'object' && item.name?.toLowerCase() === userInput.toLowerCase()) ||
+            (typeof item === 'object' && item.fields?.institution_name?.toLowerCase() === userInput.toLowerCase())
+        );
+        const relevantItems = filteredItems.slice(0, 5);        
+        // If no exact match, show 'not found in ROR List' message
+        if (!exactMatch) {
+            const suggestionItem = document.createElement('div');
+            suggestionItem.classList.add('suggestion-item');
+            suggestionItem.innerHTML = `${userInput} (Not Found in ROR List)`;
+            suggestionItem.addEventListener('click', () => {
+                nameInputField.value = userInput;
+                clearSuggestions();
+                });
+                suggestionsContainer.appendChild(suggestionItem);
         }
-      }
+        displaySuggestions(relevantItems);
+    
+    }
   
       function displaySuggestions(items) {
         items.forEach(item => {

--- a/researchers/urls.py
+++ b/researchers/urls.py
@@ -6,7 +6,6 @@ urlpatterns = [
     path('connect-researcher/', views.connect_researcher, name="connect-researcher"),
     path('connect-orcid/', views.connect_orcid, name="connect-orcid"),
     path('disconnect-orcid/', views.disconnect_orcid, name="disconnect-orcid"),
-    path('confirm-subscription-researcher/<str:pk>/', views.confirm_subscription_researcher, name="confirm-subscription-researcher"),
     
     # Public view
     path('view/<str:pk>/', views.public_researcher_view, name="public-researcher"),

--- a/researchers/utils.py
+++ b/researchers/utils.py
@@ -1,7 +1,6 @@
 from .models import Researcher
 from django.contrib import messages
 from django.shortcuts import redirect
-from helpers.utils import create_salesforce_account_or_lead
 
 def is_user_researcher(user):
     if Researcher.objects.filter(user=user).exists():

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -51,16 +51,8 @@ def preparation_step(request):
 def connect_researcher(request):
     researcher = is_user_researcher(request.user)
     form = ConnectResearcherForm(request.POST or None)
-    subscription_form = SubscriptionForm()
-
-    exclude_choices = {"member", "service_provider", "cc_only"}
-    modified_inquiry_type_choices = [
-        choice
-        for choice in SubscriptionForm.INQUIRY_TYPE_CHOICES
-        if choice[0] not in exclude_choices
-        
-    ]
-    subscription_form.fields["inquiry_type"].choices = modified_inquiry_type_choices
+    subscription_form  = form_initiation(request, "researcher_action")
+    
     env = dev_prod_or_local(request.get_host())
     
     if not researcher:

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -9,9 +9,8 @@ from itertools import chain
 from localcontexts.utils import dev_prod_or_local
 from projects.utils import *
 from helpers.utils import *
-from accounts.utils import get_users_name, handle_confirmation_and_subscription, confirm_subscription
+from accounts.utils import get_users_name
 from notifications.utils import send_action_notification_to_project_contribs
-from institutions.utils import check_subscription
 
 from communities.models import Community
 from notifications.models import ActionNotification

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -58,24 +58,25 @@ def connect_researcher(request):
     if not researcher:
         if request.method == "POST":
             if form.is_valid() and validate_recaptcha(request):
-                mutable_post_data = request.POST.copy()
-                subscription_data = {
-                "first_name": request.user._wrapped.first_name,
-                "last_name": request.user._wrapped.last_name,
-                "email": request.user._wrapped.email,
-                "account_type": "researcher_account",
-                "organization_name": form.cleaned_data['primary_institution'],
-                }
-                mutable_post_data.update(subscription_data)
-                subscription_form = SubscriptionForm(mutable_post_data)
-                orcid_id = request.POST.get('orcidId')
-                orcid_token = request.POST.get('orcidIdToken')
-                
-                data = form.save(commit=False)
-                data.user = request.user
-                data.orcid_auth_token = orcid_token
-                data.orcid = orcid_id
-                data.save()
+                with transaction.atomic():
+                    mutable_post_data = request.POST.copy()
+                    subscription_data = {
+                    "first_name": request.user._wrapped.first_name,
+                    "last_name": request.user._wrapped.last_name,
+                    "email": request.user._wrapped.email,
+                    "account_type": "researcher_account",
+                    "organization_name": form.cleaned_data['primary_institution'],
+                    }
+                    mutable_post_data.update(subscription_data)
+                    subscription_form = SubscriptionForm(mutable_post_data)
+                    orcid_id = request.POST.get('orcidId')
+                    orcid_token = request.POST.get('orcidIdToken')
+                    
+                    data = form.save(commit=False)
+                    data.user = request.user
+                    data.orcid_auth_token = orcid_token
+                    data.orcid = orcid_id
+                    data.save()
 
                 # Mark current user as researcher
                 request.user.user_profile.is_researcher = True
@@ -182,71 +183,6 @@ def public_researcher_view(request, pk):
         return render(request, 'public.html', context)
     except:
         raise Http404()
-
-@login_required(login_url="login")
-def confirm_subscription_researcher(request, pk):
-    join_flag = False
-    researcher = get_object_or_404(Researcher, id=pk)
-    initial_data = {
-        "first_name": request.user._wrapped.first_name,
-        "last_name": request    .user._wrapped.last_name,
-        "email": request.user._wrapped.email,
-        "account_type": "researcher_account",
-        "organization_name": request.user._wrapped.first_name,
-    }
-    exclude_choices = {"member", "service_provider", "cc_only"}
-
-    modified_inquiry_type_choices = [
-        choice
-        for choice in SubscriptionForm.INQUIRY_TYPE_CHOICES
-        if choice[0] not in exclude_choices
-        
-    ]
-    form = SubscriptionForm(request.POST or None, initial=initial_data)
-    form.fields["inquiry_type"].choices = modified_inquiry_type_choices
-    form.fields["account_type"].widget.attrs.update({"class": "w-100 readonly-input"})
-    if request.user._wrapped.first_name:
-        form.fields["organization_name"].widget.attrs.update({"class": "readonly-input"})
-    form.fields["email"].widget.attrs.update({"class": "readonly-input"})
-    if request.method == "POST":
-        if validate_recaptcha(request) and form.is_valid():
-            account_type_key = form.cleaned_data["account_type"]
-            inquiry_type_key = form.cleaned_data["inquiry_type"]
-
-            account_type_display = dict(form.fields["account_type"].choices).get(
-                account_type_key, ""
-            )
-            inquiry_type_display = dict(form.fields["inquiry_type"].choices).get(
-                inquiry_type_key, ""
-            )
-            form.cleaned_data["account_type"] = account_type_display
-            form.cleaned_data["inquiry_type"] = inquiry_type_display
-            if form.cleaned_data["organization_name"] == '':
-                form.cleaned_data["organization_name"] = form.cleaned_data["first_name"]
-
-            first_name = form.cleaned_data["first_name"]
-            if not form.cleaned_data["last_name"]:
-                form.cleaned_data["last_name"] = first_name
-            try:
-                response = confirm_subscription(request, researcher, join_flag, form, 'researcher_account')
-                return response
-            except:
-                messages.add_message(
-                    request,
-                    messages.ERROR,
-                    "An unexpected error has occurred here. Please contact support@localcontexts.org.",
-                )
-                return redirect("dashboard")
-    return render(
-        request,
-        "accounts/confirm-subscription.html",
-        {
-            "form": form,
-            "account": researcher,
-            "subscription_url": 'confirm-subscription-researcher',
-            "join_flag": join_flag,
-        },
-    )
 
 @login_required(login_url='login')
 def connect_orcid(request):

--- a/templates/register-base.html
+++ b/templates/register-base.html
@@ -46,7 +46,7 @@
                             Select an account
                         </li>
                         <li>
-                            {% if 'connect-community' in request.path or 'create-community' in request.path or 'confirm-community' in request.path or 'connect-institution' in request.path or 'create-institution' in request.path or 'confirm-institution' in request.path or 'create-institution/no-ror/' in request.path or 'connect-researcher' in request.path or 'preparation-step' in request.path or 'community-boundary' in request.path or 'add-community-boundary' in request.path or 'upload-boundary-file' in request.path or 'confirm-subscription-institution' in request.path %}
+                            {% if 'connect-community' in request.path or 'create-community' in request.path or 'confirm-community' in request.path or 'connect-institution' in request.path or 'create-institution' in request.path or 'confirm-institution' in request.path or 'create-institution/no-ror/' in request.path or 'connect-researcher' in request.path or 'preparation-step' in request.path or 'community-boundary' in request.path or 'add-community-boundary' in request.path or 'upload-boundary-file' in request.path %}
                                 {% include 'snippets/bullet-big.html'%}
                             {% else %}
                                 {% include 'snippets/bullet.html'%}


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8688wgz4k)**

**Description:**
As discussed in Dev Team meeting on 6.25.24, there are some subscription and inquiry form functions that can be moved to helpers in a subscriptions specific file that helps manage the SF and subscription checks being done in the hub. This will be to reduce code redundancy. Here are some functions found that may need to be looked at:
check_subscription
form_initiation
handle_confirmation_and_subscription
confirm_subscription
institute_account_subscription
subscription_inquiry

If inquiry form specific (i.e sending information to SF or getting information from SF), this should include all 4 account types. If checking subscription model for existing object, this should be for subscriber accounts only (institution & researcher).


**Solution:**
- Removed extra code and moved the code to helper utils. 
- Clean these functions
   - check_subscription -> moved from institution/utils to helpers/utils as its used in both institution and researchers app
   - form_initiation -> moved from institution/utils to helpers/utils as its used in both institution and researchers app
   - handle_confirmation_and_subscription -> moved from institution/utils to helpers/utils as its used in both institution and researchers app
    - confirm_subscription -> removed the extra parameter i.e join_flag

