### PR TITLE
Resolved vulnerability discovered by dependabot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ astroid==3.0.1
 boto3==1.26.77
 botocore==1.29.77
 cachetools==4.2.4
-certifi==2023.7.22
+certifi==2024.07.04
 charset-normalizer==2.0.6
 coverage==7.4.2
 cryptography==42.0.4


### PR DESCRIPTION
Certifi 2024.07.04 removes root certificates from "GLOBALTRUST" from the root store. These are in the process of being removed from Mozilla's trust store.