### PR TITLE
#8687q3kfw Bold and lengthen activity cards on account dashboard

### DIFF
--- a/localcontexts/static/css/dashboard.css
+++ b/localcontexts/static/css/dashboard.css
@@ -40,7 +40,7 @@
     height: 190px;
 }
 
-.dashcard-text-container { width: 70%;}
+.dashcard-text-container { min-width: 51%;}
 
 .dashcard-h3 {
     font-weight: bold;

--- a/localcontexts/static/css/main.css
+++ b/localcontexts/static/css/main.css
@@ -231,6 +231,7 @@ input:focus {
 /* MARGIN & PADDING */
 .margin-top-1 { margin-top: 1%; }
 .margin-right-1 { margin-right: 1%; }
+.margin-right-2 { margin-right: 2%;}
 .margin-left-1 { margin-left: 1%; }
 .margin-top-2 { margin-top: 2%; }
 .margin-bottom-2 { margin-bottom: 2%; }
@@ -238,6 +239,7 @@ input:focus {
 .no-top-margin { margin-top: 0; }
 .no-bottom-margin { margin-bottom: 0; }
 .no-margin { margin: 0 !important; }
+.no-right-margin {margin-right: 0 !important;}
 .margin-top-8 { margin-top: 8px; }
 .margin-top-10 { margin-top: 10px; }
 .margin-bottom-8 { margin-bottom: 8px; }
@@ -674,7 +676,7 @@ visibility: visible;
 
 /* Count cards on dashcards on profiles */
 .stats-card-container {
-    width: 240px; 
+    width: 22%; 
     margin: 10px;
 }
 

--- a/templates/partials/infocards/_community-dashcard.html
+++ b/templates/partials/infocards/_community-dashcard.html
@@ -27,8 +27,8 @@
             
         </div>
             <!-- Image, headers, description -->
-        <div class="flex-this">
-
+        <div class="flex-this space-between">
+            <div class="flex-this">
                 <div class="dashcard-img-container">
                     <img loading="lazy" 
                         class="profile-img" 
@@ -48,7 +48,7 @@
                     </div>
                     <div><p class="dashcard-description description-sm">{% if community.description %}{{ community.description }} {% else %} No description provided. {% endif %}</p></div>
                 </div>
-
+            </div>
                 <!-- Count cards -->
                 <div class="flex-this column stats-card-container  bold no-right-margin">
 

--- a/templates/partials/infocards/_community-dashcard.html
+++ b/templates/partials/infocards/_community-dashcard.html
@@ -50,9 +50,9 @@
                 </div>
 
                 <!-- Count cards -->
-                <div class="flex-this column stats-card-container">
+                <div class="flex-this column stats-card-container  bold no-right-margin">
 
-                    <div class="stats-card flex-this space-between">
+                    <div class="stats-card flex-this flex-start">
                         <div>
                             <p>
                                 <!-- How many Labels has the community applied to projects -->
@@ -60,10 +60,10 @@
                                 {% if label_count < 10 %}0{{ label_count }}{% else %}{{ label_count }}{% endif %}
                             </p>
                         </div>
-                        <div><span>Labels</span></div>
+                        <div class="margin-left-16"><span>Labels</span></div>
                     </div>
     
-                    <div class="stats-card flex-this space-between">
+                    <div class="stats-card flex-this flex-start">
                         <div>
                             <p>
                                 <!-- Notices that a community has been notified about -->
@@ -71,17 +71,17 @@
                                 {% if notice_count < 10 %}0{{ notice_count }}{% else %}{{ notice_count }}{% endif %}
                             </p>
                         </div>
-                        <div><span>Notices</span></div>
+                        <div class="margin-left-16"><span>Notices</span></div>
                     </div>
     
-                    <div class="stats-card flex-this space-between">
+                    <div class="stats-card flex-this flex-start">
                         <div>
                             <p>
                                 {% connections_count community as connect_count %}
                                 {% if connect_count < 10 %}0{{ connect_count }}{% else %}{{ connect_count }}{% endif %}
                             </p>
                         </div>
-                        <div><span>Connections</span></div>
+                        <div class="margin-left-16"><span>Connections</span></div>
                     </div>
                 </div>
 

--- a/templates/partials/infocards/_institution-dashcard.html
+++ b/templates/partials/infocards/_institution-dashcard.html
@@ -26,8 +26,8 @@
             
         </div>
             <!-- Image, headers, description -->
-        <div class="flex-this">
-
+        <div class="flex-this space-between">
+            <div class="flex-this">
                 <div class="dashcard-img-container">
                     <img loading="lazy" 
                         class="profile-img" 
@@ -46,7 +46,7 @@
                     </div>
                     <div><p class="dashcard-description description-sm">{% if institution.description %}{{ institution.description }} {% else %} No description provided. {% endif %}</p></div>
                 </div>
-
+            </div>
                 <!-- Count cards -->
                 <div class="flex-this column stats-card-container bold no-right-margin">
 

--- a/templates/partials/infocards/_institution-dashcard.html
+++ b/templates/partials/infocards/_institution-dashcard.html
@@ -48,30 +48,30 @@
                 </div>
 
                 <!-- Count cards -->
-                <div class="flex-this column stats-card-container">
+                <div class="flex-this column stats-card-container bold no-right-margin">
 
                     <!-- Count of Labels that have been applied to institution projects -->
                     {% get_labels_count institution as total_labels %}
-                    <div class="stats-card flex-this space-between">
+                    <div class="stats-card flex-this flex-start">
                         <div><p>{% if total_labels < 10 %} 0{{ total_labels }} {% else %} {{ total_labels }} {% endif %}</p></div>
-                        <div><span>Labels</span></div>
+                        <div class="margin-left-16"><span>Labels</span></div>
                     </div>
                     
                     <!-- Count of Notices institution has placed -->
                     {% get_notices_count institution as total_notices %}
-                    <div class="stats-card flex-this space-between">
+                    <div class="stats-card flex-this flex-start">
                         <div><p>{% if total_notices < 10 %} 0{{ total_notices }} {% else %} {{ total_notices }} {% endif %}</p></div>
-                        <div><span>Notices</span></div>
+                        <div class="margin-left-16"><span>Notices</span></div>
                     </div>
     
-                    <div class="stats-card flex-this space-between">
+                    <div class="stats-card flex-this flex-start">
                         <div>
                             <p>
                                 {% connections_count institution as connect_count %}
                                 {% if connect_count < 10 %}0{{ connect_count }}{% else %}{{ connect_count }}{% endif %}
                             </p>
                         </div>
-                        <div><span>Connections</span></div>
+                        <div class="margin-left-16"><span>Connections</span></div>
                     </div>
                 </div>
 

--- a/templates/partials/infocards/_researcher-card.html
+++ b/templates/partials/infocards/_researcher-card.html
@@ -1,34 +1,36 @@
 {% load static %}
 <div class="dashcard">
-  <div class="flex-this">
-    <div class="researcher-img-container">
-      <img
-        loading="lazy"
-        class="profile-img"
-        src=" {% if researcher.image %} {{ researcher.image.url }} {% else %} {% static 'images/placeholders/researcher-place.jpg' %} {% endif %}"
-        alt="{{ researcher.researcher_name }} image"
-      />
-    </div>
-    <div class="flex-this column dashcard-text-container">
-      <div>
-        <h3 class="dashcard-h3 darkteal-text">
-          {% firstof researcher.user.get_full_name researcher.user.username %}
-        </h3>
+  <div class="flex-this space-between">
+    <div class="flex-this">
+      <div class="researcher-img-container">
+        <img
+          loading="lazy"
+          class="profile-img"
+          src=" {% if researcher.image %} {{ researcher.image.url }} {% else %} {% static 'images/placeholders/researcher-place.jpg' %} {% endif %}"
+          alt="{{ researcher.researcher_name }} image"
+        />
       </div>
-      <div>
-        <p class="dashcard-subheader">
-          Researcher | Location: {{ researcher.user.user_profile.get_location }}
-        </p>
-      </div>
-      <div>
-        <p class="dashcard-description description-sm">
-          {% if researcher.description %}{{ researcher.description }} {% else %}
-          No description provided. {% endif %}
-        </p>
+      <div class="flex-this column dashcard-text-container">
+        <div>
+          <h3 class="dashcard-h3 darkteal-text">
+            {% firstof researcher.user.get_full_name researcher.user.username %}
+          </h3>
+        </div>
+        <div>
+          <p class="dashcard-subheader">
+            Researcher | Location: {{ researcher.user.user_profile.get_location }}
+          </p>
+        </div>
+        <div>
+          <p class="dashcard-description description-sm">
+            {% if researcher.description %}{{ researcher.description }} {% else %}
+            No description provided. {% endif %}
+          </p>
+        </div>
       </div>
     </div>
 
-    <div class="dashcard-btn-container">
+    <div class="dashcard-btn-container margin-right-2">
 
       <div class="flex-this gap-half">
         {% if '/registry/' in request.path %}

--- a/templates/partials/infocards/_researcher-dashcard.html
+++ b/templates/partials/infocards/_researcher-dashcard.html
@@ -25,91 +25,92 @@
             
         </div>
             <!-- Image, headers, description -->
-        <div class="flex-this">
-            <div class="researcher-img-container">
-                <img loading="lazy" 
-                    src=" {% if researcher.image %} {{ researcher.image.url }} {% else %} {% static 'images/placeholders/researcher-place.jpg' %} {% endif %}" 
-                    alt="{{ researcher.researcher_name }} image"
-                >
-            </div>
+        <div class="flex-this space-between">
+            <div class="flex-this">
+                <div class="researcher-img-container">
+                    <img loading="lazy" 
+                        src=" {% if researcher.image %} {{ researcher.image.url }} {% else %} {% static 'images/placeholders/researcher-place.jpg' %} {% endif %}" 
+                        alt="{{ researcher.researcher_name }} image"
+                    >
+                </div>
 
-            <div class="flex-this column dashcard-text-container">
-                    <div>
-                        <h3 class="dashcard-h3 darkteal-text">{% firstof researcher.user.get_full_name researcher.user.username %}</h3>
-                    </div>
-                    <div>
-                        <p class="dashcard-subheader">Researcher | {% if researcher.primary_institution %}{{ researcher.primary_institution }}{% endif %}<br>
-                            Location: {{ researcher.user.user_profile.get_location }}
-                        </p>
-                    </div>
-
-                    <!-- ORCID display based on how it sits in the db -->
-                    {% if researcher.orcid %}
-                        <div itemscope itemtype="https://schema.org/Person">
-                            <a 
-                                class="default-a" 
-                                itemprop="sameAs" 
-                                target="orcid.widget" 
-                                rel="me noopener noreferrer" 
-                                style="vertical-align:top;"
-                                {% if 'https://sandbox.orcid.org/' in researcher.orcid or 'https://orcid.org/' in researcher.orcid %}
-                                    content="{{ researcher.orcid }}" 
-                                    href="{{ researcher.orcid }}" 
-                                {% elif 'X' in researcher.orcid %}
-                                    content="https://sandbox.orcid.org/{{ researcher.orcid }}" 
-                                    href="https://sandbox.orcid.org/{{ researcher.orcid }}"
-                                {% else %}
-                                    content="https://orcid.org/{{ researcher.orcid }}" 
-                                    href="https://orcid.org/{{ researcher.orcid }}" 
-                                {% endif %}
-                            >
-                                <img loading="lazy" src="https://orcid.org/sites/default/files/images/orcid_16x16.png" style="width:1em;margin-right:.5em;" alt="ORCID iD icon">
-                                {% if 'https://sandbox.orcid.org/' in researcher.orcid or 'https://orcid.org/' in researcher.orcid %}
-                                    {{ researcher.orcid }}
-                                {% elif 'X' in researcher.orcid %}
-                                    https://sandbox.orcid.org/{{ researcher.orcid }} 
-                                {% else %}
-                                    https://orcid.org/{{ researcher.orcid }}
-                                {% endif %}
-                            </a>
-                        </div>
-                    {% else %}
+                <div class="flex-this column dashcard-text-container">
                         <div>
-                            <img loading="lazy" src="https://orcid.org/sites/default/files/images/orcid_16x16.png" style="width:1em;margin-right:.5em;" alt="ORCID iD icon"> <small>No ORCiD specified</small>
+                            <h3 class="dashcard-h3 darkteal-text">{% firstof researcher.user.get_full_name researcher.user.username %}</h3>
                         </div>
-                    {% endif %}
+                        <div>
+                            <p class="dashcard-subheader">Researcher | {% if researcher.primary_institution %}{{ researcher.primary_institution }}{% endif %}<br>
+                                Location: {{ researcher.user.user_profile.get_location }}
+                            </p>
+                        </div>
 
-                    <div>
-                        <p class="dashcard-description description-sm">{% if researcher.description %}{{ researcher.description }} {% else %} No description provided. {% endif %}</p>
-                    </div>
+                        <!-- ORCID display based on how it sits in the db -->
+                        {% if researcher.orcid %}
+                            <div itemscope itemtype="https://schema.org/Person">
+                                <a 
+                                    class="default-a" 
+                                    itemprop="sameAs" 
+                                    target="orcid.widget" 
+                                    rel="me noopener noreferrer" 
+                                    style="vertical-align:top;"
+                                    {% if 'https://sandbox.orcid.org/' in researcher.orcid or 'https://orcid.org/' in researcher.orcid %}
+                                        content="{{ researcher.orcid }}" 
+                                        href="{{ researcher.orcid }}" 
+                                    {% elif 'X' in researcher.orcid %}
+                                        content="https://sandbox.orcid.org/{{ researcher.orcid }}" 
+                                        href="https://sandbox.orcid.org/{{ researcher.orcid }}"
+                                    {% else %}
+                                        content="https://orcid.org/{{ researcher.orcid }}" 
+                                        href="https://orcid.org/{{ researcher.orcid }}" 
+                                    {% endif %}
+                                >
+                                    <img loading="lazy" src="https://orcid.org/sites/default/files/images/orcid_16x16.png" style="width:1em;margin-right:.5em;" alt="ORCID iD icon">
+                                    {% if 'https://sandbox.orcid.org/' in researcher.orcid or 'https://orcid.org/' in researcher.orcid %}
+                                        {{ researcher.orcid }}
+                                    {% elif 'X' in researcher.orcid %}
+                                        https://sandbox.orcid.org/{{ researcher.orcid }} 
+                                    {% else %}
+                                        https://orcid.org/{{ researcher.orcid }}
+                                    {% endif %}
+                                </a>
+                            </div>
+                        {% else %}
+                            <div>
+                                <img loading="lazy" src="https://orcid.org/sites/default/files/images/orcid_16x16.png" style="width:1em;margin-right:.5em;" alt="ORCID iD icon"> <small>No ORCiD specified</small>
+                            </div>
+                        {% endif %}
 
+                        <div>
+                            <p class="dashcard-description description-sm">{% if researcher.description %}{{ researcher.description }} {% else %} No description provided. {% endif %}</p>
+                        </div>
+
+                </div>
             </div>
-
             <!-- Count cards -->
-            <div class="flex-this column stats-card-container">
+            <div class="flex-this column stats-card-container bold no-right-margin">
 
                 <!-- Count of Labels applied to researcher projects -->
                 {% get_labels_count researcher as total_labels %}
-                <div class="stats-card flex-this space-between">
+                <div class="stats-card flex-this flex-start">
                     <div><p>{% if total_labels < 10 %} 0{{ total_labels }} {% else %} {{ total_labels }} {% endif %}</p></div>
-                    <div><span>Labels</span></div>
+                    <div class="margin-left-16"><span>Labels</span></div>
                 </div>
 
                 <!-- Count of notices placed by researcher -->
                 {% get_notices_count researcher as total_notices %}
-                <div class="stats-card flex-this space-between">
+                <div class="stats-card flex-this flex-start">
                     <div><p>{% if total_notices < 10 %} 0{{ total_notices }} {% else %} {{ total_notices }} {% endif %}</p></div>
-                    <div><span>Notices</span></div>
+                    <div class="margin-left-16"><span>Notices</span></div>
                 </div>
     
-                <div class="stats-card flex-this space-between">
+                <div class="stats-card flex-this flex-start">
                     <div>
                         <p>
                             {% connections_count researcher as connect_count %}
                             {% if connect_count < 10 %}0{{ connect_count }}{% else %}{{ connect_count }}{% endif %}
                         </p>
                     </div>
-                    <div>
+                    <div class="margin-left-16">
                         <span>Connections</span>
                     </div>
                 </div>


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8687q3kfw)**

**Description:**
Current design in hub 04/03/2024
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/0479cf5a-4c0f-4eab-b936-1d934839a655)
Actual design in Figma 04/03/2024
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/d6b5f984-d1fe-425a-8f78-775950155b80)

**Solution:**
- Updated CSS to decrease width of dashcard text
- Updated HTML to render the required design 

**Before:**

[ui(before).webm](https://github.com/localcontexts/localcontextshub/assets/145371882/a64b79bb-5753-4c54-9c7c-db3f92e464a7)

**After:**

[ui(after).webm](https://github.com/localcontexts/localcontextshub/assets/145371882/2dac33bf-103e-4887-839d-33474a44dbcc)
