### PR TITLE
#8688x1bc3 Added anchor to Project Labels or Notices section

### DIFF
--- a/templates/partials/_project-actions.html
+++ b/templates/partials/_project-actions.html
@@ -257,7 +257,7 @@
 
             {% if notices %}
                 <div class="project-header-div border-top-solid-teal border-bottom-solid-teal flex-this space-between">
-                    <h2>Project Notices</h2>
+                    <h2 id="notices">Project Notices</h2>
                     <h2 class="margin-right-8 pointer" onclick="toggleProjectInfo(this, 'projectNoticesDiv')"><i class="fa-solid fa-minus fa-xl darkteal-text"></i></h2>
                 </div>
                 <div id="projectNoticesDiv" style="height: auto; overflow: hidden;">
@@ -298,7 +298,7 @@
 
             {% if project.has_bclabels or project.has_tklabels %}
                 <div class="project-header-div border-top-solid-teal border-bottom-solid-teal flex-this space-between">
-                    <h2>Project Labels</h2>
+                    <h2 id="labels">Project Labels</h2>
                     <h2 class="margin-right-8 pointer" onclick="toggleProjectInfo(this, 'projectLabelsDiv')"><i class="fa-solid fa-minus fa-xl darkteal-text"></i></h2>
                 </div>
                 <div id="projectLabelsDiv" style="height: auto; overflow: hidden;">


### PR DESCRIPTION
While in discussions with @pbuttigieg on schema.org mappings, he indicated that since the Labels do not have a direct page for people to go to when going to look at the Label itself, it would at least be helpful to have a direct link to the section where the Labels are held so that it takes people directly there. Added to Notices section as well.

**Direct links to sections will look like the following:**
- Project Labels: localcontextshub.org/projects/{UUID}#labels
- Project Notices: localcontextshub.org/projects/{UUID}#notices