### PR TITLE
#8687u2kp0 Make caret larger on Labels dropdown on Project Action Page

### DIFF
--- a/templates/partials/_project-actions.html
+++ b/templates/partials/_project-actions.html
@@ -313,7 +313,7 @@
                                     </p>                                
                                 </div>
                                 <div>
-                                    <i id="{{community.id}}" onclick="showProjectLabels(this)" class="fa-solid fa-angle-down pointer" aria-label="Show Project Labels"></i>
+                                    <i id="{{community.id}}" onclick="showProjectLabels(this)" class="fa-solid fa-angle-down pointer fa-2x" aria-label="Show Project Labels"></i>
                                 </div>
                             </div>
                             <div id="showContent-{{community.id}}" class="hide">


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8687u2kp0)**

**Description:**
When Labels have been applied to a Project, the small caret is hard for folks to see so it needs to be made more prominent.
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/1e6d6860-33f6-4b6a-ba68-65a96d7e12fc)

**Solution:**
- Updated the size of down pointer

**Before:**

![image](https://github.com/localcontexts/localcontextshub/assets/145371882/13c8b580-06d2-4c9f-b2b4-8b240379c4b5)
**After:**

![image](https://github.com/localcontexts/localcontextshub/assets/145371882/47aec015-87d7-4c81-8f49-eb21b7e5b143)
