### PR TITLE
#8688zhx0f Subscribed Check Mark Margin fix

### DIFF
--- a/localcontexts/static/css/main.css
+++ b/localcontexts/static/css/main.css
@@ -1695,7 +1695,7 @@ i[data-tooltip]:hover:after {
 /* For Subscribed Icon */
 .subscribed-icon{
     color: #ef6c00;
-    margin: 14px 0 0 15px;
+    margin: 14px 0 0 8px;
 }
 .subscribed-icon-wrapper{
     display: flex


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8688zhx0f)**

**Description:**
From HSM 7.2.24: update the spacing of the account name and the subscribed/confirmed/certified checkmark to be 8px instead of the current 14px.
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/43793c08-a21d-4ce5-8602-41b0356a71b8)

**Solution:**
- Updated CSS to decrease right margin of icon 

**After:**

![image](https://github.com/localcontexts/localcontextshub/assets/145371882/7d877a11-03c5-414b-a112-e56e8c7dad23)
