### PR TITLE
#8688uhz5x Removed unnecessary error field from project page

### DIFF
--- a/templates/partials/_add-projectperson.html
+++ b/templates/partials/_add-projectperson.html
@@ -38,9 +38,9 @@
 
     {% endfor %}
 
-    {% if formset.errors %}
-        {% for error in formset.errors %}
+    {% for error in formset.errors %}
+        {% if error %}
             <div class="msg-red w-50"><small>{{ error.as_text }}</small></div> 
-        {% endfor %}
-    {% endif %}
+        {% endif %}
+    {% endfor %}
 </div>


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8688zhx0f)**

**Description:**
Extra error field showing under contributors section:
![image](https://github.com/localcontexts/localcontextshub/assets/145371882/3e02a9a5-912b-4409-bb6d-988e43ccb59c)

**Solution:**
- Updated the conditional statement to check if there is an error present or not. 

**Before:**

https://github.com/localcontexts/localcontextshub/assets/145371882/9b3b5e9a-21dd-4f97-b880-292b9670acb5

**After:**

https://github.com/localcontexts/localcontextshub/assets/145371882/af9bbdc6-3fd7-4910-9295-ebec5dbd1541


