### PR TITLE
Updated the email for failed subscription report

### DIFF
--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -83,15 +83,16 @@ def send_simple_email(email, subject, template):
     )
 
 # Send error info
-def send_subscription_fail_email(subject, template):
-    return requests.post(
-        settings.MAILGUN_BASE_URL,
-        auth=("api", settings.MAILGUN_API_KEY),
-        data={"from": "Local Contexts Hub <no-reply@localcontextshub.org>",
-            "to": "tech@localcontexts.org",
-            "subject": subject,
-            "html": template}
-    )
+def send_subscription_fail_email(request, subject, template):
+    if dev_prod_or_local(request.get_host()) == 'PROD':
+        return requests.post(
+            settings.MAILGUN_BASE_URL,
+            auth=("api", settings.MAILGUN_API_KEY),
+            data={"from": "Local Contexts Hub <no-reply@localcontextshub.org>",
+                "to": "support@localcontexts.org",
+                "subject": subject,
+                "html": template}
+        )
 
 # Send email with attachment
 def send_email_with_attachment(file, to_email, subject, template):

--- a/helpers/emails.py
+++ b/helpers/emails.py
@@ -88,7 +88,7 @@ def send_subscription_fail_email(subject, template):
         settings.MAILGUN_BASE_URL,
         auth=("api", settings.MAILGUN_API_KEY),
         data={"from": "Local Contexts Hub <no-reply@localcontextshub.org>",
-            "to": "support@localcontexts.org",
+            "to": "tech@localcontexts.org",
             "subject": subject,
             "html": template}
     )

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -623,7 +623,7 @@ def create_salesforce_account_or_lead(request, hubId="", data="", isbusiness=Tru
                     "error_syntax": error_syntax,
                 }
             template = render_to_string('snippets/emails/internal/subscription-failed-info.html', context)
-            send_subscription_fail_email(subject, template)
+            send_subscription_fail_email(request, subject, template)
             raise Exception(reason)
     except urllib.error.HTTPError as e:
         reason= "Unable to get token of access from Salesforce"
@@ -640,7 +640,7 @@ def create_salesforce_account_or_lead(request, hubId="", data="", isbusiness=Tru
                 "error_syntax": error_syntax,
             }
         template = render_to_string('snippets/emails/internal/subscription-failed-info.html', context)
-        send_subscription_fail_email(subject, template)
+        send_subscription_fail_email(request, subject, template)
         raise Exception(reason)
 
         


### PR DESCRIPTION
**Issue:**
Failed Subscription report to tech team

**Description:**
The unsuccessful attempt to subscribe is reported to `support@localcontexts.org` in every environment, which is now only limited to PROD

**Solution:**
 - Added the conditional statement to filter out PROD environment 