### PR TITLE
#8688zphtr Subscriptions branch: researcher/institution subnav card gap

### DIFF
--- a/templates/institutions/projects.html
+++ b/templates/institutions/projects.html
@@ -1,5 +1,5 @@
 {% extends 'account-base.html' %} {% block title %} Projects {% endblock %}{% load static %} {% load custom_institution_tags %} {% block institution_content %}
-<div class="dashcard-alerts">
+<div class="{% if messages %}dashcard-alerts{% else %}hide{% endif %}">
 {% include 'partials/_alerts.html' %}
 </div>
 {% institution_contributing_projects institution as institution_projects_contrib %}

--- a/templates/researchers/projects.html
+++ b/templates/researchers/projects.html
@@ -1,5 +1,5 @@
 {% extends 'account-base.html' %} {% block title %} Projects {% endblock %}{% load static %}{% load custom_researcher_tags %}{% block researcher_content %}
-<div class="dashcard-alerts">
+<div class="{% if messages %}dashcard-alerts{% else %}hide{% endif %}">
     {% include 'partials/_alerts.html' %}
 </div>
 {% researcher_contributing_projects researcher as researcher_projects_contrib %}


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8688zphtr)**

**Description:**
On the Projects page for the researcher and institution accounts, the gap between the subnav and bottom card is greater than if you go to the Notices or Connections pages.
![image](https://github.com/user-attachments/assets/dfd6d81e-3900-4380-9fc9-2cf91b07893d)
![image](https://github.com/user-attachments/assets/159b31eb-92a7-4d7f-bac2-fa4e7e8e4b93)


**Solution:**
- Updated the conditional statement to render alerts div

**After:**
- **Institution:**

![image](https://github.com/user-attachments/assets/66cede49-5c44-46be-b015-831738bef03e)

- **Researcher:**

![image](https://github.com/user-attachments/assets/61f11729-7657-496c-a764-a2c3b47631c3)

