### PR TITLE
#86895xw7x researcher name bug

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -63,7 +63,9 @@ class UserUpdateForm(forms.ModelForm):
         fields = ["email", "first_name", "last_name"]
         widgets = {
             "email": forms.EmailInput(attrs={"class": "w-100"}),
-            "first_name": forms.TextInput(attrs={"class": "w-100", "required": True}),
+            "first_name": forms.TextInput(
+                attrs={"class": "w-100", "required": True}
+            ),
             "last_name": forms.TextInput(attrs={"class": "w-100"}),
         }
 

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -63,7 +63,7 @@ class UserUpdateForm(forms.ModelForm):
         fields = ["email", "first_name", "last_name"]
         widgets = {
             "email": forms.EmailInput(attrs={"class": "w-100"}),
-            "first_name": forms.TextInput(attrs={"class": "w-100"}),
+            "first_name": forms.TextInput(attrs={"class": "w-100", "required": True}),
             "last_name": forms.TextInput(attrs={"class": "w-100"}),
         }
 

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -706,59 +706,30 @@ def decrypt_api_key(key):
     return api_key
 
 def form_initiation(request,account_type=""):
-    subscription_form = SubscriptionForm()
+    fields_to_update = {
+        "first_name": request.user._wrapped.first_name,
+        "last_name": request.user._wrapped.last_name,
+    }
+    user_form = UserCreateProfileForm(request.POST or None, initial=fields_to_update)
+
     if account_type == "institution_action":
-        fields_to_update = {
-            "first_name": request.user._wrapped.first_name,
-            "last_name": request.user._wrapped.last_name,
-        }
-        user_form = UserCreateProfileForm(request.POST or None, initial=fields_to_update)
         exclude_choices = {"member", "service_provider"}
-        
-        modified_inquiry_type_choices = [
-            choice
-            for choice in SubscriptionForm.INQUIRY_TYPE_CHOICES
-            if choice[0] not in exclude_choices
-        ]
-        subscription_form.fields["inquiry_type"].choices = modified_inquiry_type_choices
-        for field, value in fields_to_update.items():
-            if value:
-                user_form.fields[field].widget.attrs.update({"class": "w-100 readonly-input"})
-            
-        return  user_form,subscription_form
-    
     elif account_type == "researcher_action":
-        subscription_form = SubscriptionForm()
         exclude_choices = {"member", "service_provider", "cc_only"}
-        modified_inquiry_type_choices = [
-            choice
-            for choice in SubscriptionForm.INQUIRY_TYPE_CHOICES
-            if choice[0] not in exclude_choices
-            
-        ]
-        subscription_form.fields["inquiry_type"].choices = modified_inquiry_type_choices
-        
-        return subscription_form
-    
-    elif account_type == "service_provider_action":
-        fields_to_update = {
-            "first_name": request.user._wrapped.first_name,
-            "last_name": request.user._wrapped.last_name,
-        }
-        user_form = UserCreateProfileForm(request.POST or None, initial=fields_to_update)
-        exclude_choices = {"member", "cc_only"}
-        
-        modified_inquiry_type_choices = [
-            choice
-            for choice in SubscriptionForm.INQUIRY_TYPE_CHOICES
-            if choice[0] not in exclude_choices
-        ]
-        subscription_form.fields["inquiry_type"].choices = modified_inquiry_type_choices
-        for field, value in fields_to_update.items():
-            if value:
-                user_form.fields[field].widget.attrs.update({"class": "w-100 readonly-input"})
-            
-        return  user_form,subscription_form
+    else:
+        return None, None
+
+    subscription_form = SubscriptionForm()
+    subscription_form.fields["inquiry_type"].choices = [
+        choice for choice in SubscriptionForm.INQUIRY_TYPE_CHOICES
+        if choice[0] not in exclude_choices
+    ]
+
+    for field, value in fields_to_update.items():
+        if value:
+            user_form.fields[field].widget.attrs.update({"class": "w-100 readonly-input"})
+
+    return user_form, subscription_form
 
 def check_subscription(request, subscriber_type, id):
     subscriber_field_mapping = {

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -63,7 +63,7 @@ def connect_researcher(request):
                 "last_name": user_form.cleaned_data['last_name'],
                 "email": request.user._wrapped.email,
                 "account_type": "researcher_account",
-                "organization_name": user_form.cleaned_data['first_name'],
+                "organization_name": get_users_name(request.user),
                 }
                 mutable_post_data.update(subscription_data)
                 subscription_form = SubscriptionForm(mutable_post_data)

--- a/templates/institutions/create-custom-institution.html
+++ b/templates/institutions/create-custom-institution.html
@@ -30,7 +30,7 @@
 
         <div class="w-100 flex-this mt-16">
             <div class="w-50 mr-1p">
-                <label class="pad-top-1-5" >First Name</label><br>
+                <label class="pad-top-1-5" >First Name<span class="orange-text required-label" title="">*</span></label><br>
                 {{ user_form.first_name }}
             </div>
 

--- a/templates/institutions/create-institution.html
+++ b/templates/institutions/create-institution.html
@@ -28,7 +28,7 @@
 
         <div class="w-100 flex-this mt-16">
             <div class="w-50 mr-1p">
-                <label class="pad-top-1-5" >First Name</label><br>
+                <label class="pad-top-1-5" >First Name<span class="orange-text required-label" title="">*</span></label><br>
                 {{ user_form.first_name }}
             </div>
 

--- a/templates/researchers/connect-researcher.html
+++ b/templates/researchers/connect-researcher.html
@@ -55,6 +55,17 @@
                 {% endif %}            
             </div>
 
+        <div class="w-100 flex-this space-between mt-2p">
+            <div class="w-50 mr-1p">
+                <label class="pad-top-1-5" >First Name<span class="orange-text required-label" title="">*</span></label><br>
+                {{ user_form.first_name }}
+            </div>
+
+            <div class="w-50 margin-left-1">
+                <label>Last Name</label><br>
+                {{ user_form.last_name }}
+            </div>
+        </div>
         <div class="flex-this w-100 space-between mt-2p">
             <div class='w-50 mr-1p'>
                 <label for="primary_institution">Primary Institution</label>


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8688zphtr)**

**Description:**
Herbert was able to remove both first name and last name from the settings page, which should not have happened as this will create an error in future subscription calls and also the users already present on the HUB may not have a first name and last name and their subscription calls will also generate the same error. The user should not be able to remove the first name and last name from settings as well, Researcher subscription journey should mimic the first name check like institution.
![image](https://github.com/user-attachments/assets/ed2f3e56-ced5-452f-b06e-202bb716fa50)


**Solution:**
- Updated UserUpdateForm's field first name to required true
- Updated the `connect-researcher/` page to include UserCreateProfileForm for first and last name
- Optimized the helper function for form initiation

**After:**
- **Institution(without first name):**

https://github.com/user-attachments/assets/85d3a6c2-6ed7-4857-b2ad-0dcef47464c1

- **Researcher(without first name):**

https://github.com/user-attachments/assets/14ff97d6-f88c-4d4f-8f70-d16338a9db0b

- **Researcher(with first name):**

https://github.com/user-attachments/assets/b8debffd-d56b-4c4a-9901-fe5e7d089a2d

