### PR TITLE
#868960ubn Account settings -> description field: add character limit counter

### DIFF
--- a/localcontexts/static/javascript/main.js
+++ b/localcontexts/static/javascript/main.js
@@ -42,27 +42,37 @@ if (window.location.href.includes('sandbox.localcontextshub')) {
     }
 }
 
-if (window.location.href.includes('create-community') || window.location.href.includes('create-institution') || window.location.href.includes('connect-researcher') ) {
-    let textArea = document.getElementById('id_description')
-    let characterCounter = document.getElementById('charCount')
-    const maxNumOfChars = 200
+document.addEventListener('DOMContentLoaded', () => {
+    const initializeCharacterCounter = (textAreaId, counterId, maxChars) => {
+        let textArea = document.getElementById(textAreaId);
+        let characterCounter = document.getElementById(counterId);
 
-    const countCharacters = () => {
-        let numOfEnteredChars = textArea.value.length
-        let counter = maxNumOfChars - numOfEnteredChars
-        characterCounter.textContent = counter + '/200'
+        const countCharacters = () => {
+            let numOfEnteredChars = textArea.value.length;
+            let counter = maxChars - numOfEnteredChars;
+            characterCounter.textContent = counter + '/' + maxChars;
 
-        if (counter < 0) {
-            characterCounter.style.color = 'red'
-        } else if (counter < 50) {
-            characterCounter.style.color = '#EF6C00'
-        } else {
-            characterCounter.style.color = 'black'
-        }
+            if (counter < 0) {
+                characterCounter.style.color = 'red';
+            } else if (counter < 50) {
+                characterCounter.style.color = '#EF6C00';
+            } else {
+                characterCounter.style.color = 'black';
+            }
+        };
+
+        countCharacters();
+        textArea.addEventListener('input', countCharacters);
+    };
+
+    const url = window.location.href;
+    const createPages = ['create-community', 'create-institution', 'connect-researcher'];
+    const updatePages = ['communities/update', 'institutions/update', 'researchers/update'];
+
+    if (createPages.some(page => url.includes(page)) || updatePages.some(page => url.includes(page))) {
+        initializeCharacterCounter('id_description', 'charCount', 200);
     }
-
-    textArea.addEventListener('input', countCharacters)
-}
+});
 
 // Get languages from the IANA directory
 function fetchLanguages() {

--- a/templates/partials/_update-account-main-area.html
+++ b/templates/partials/_update-account-main-area.html
@@ -75,6 +75,7 @@
         {% if update_form.description.errors %}
             <div class="msg-red w-80"><small>{{ update_form.description.errors.as_text }}</small></div>
         {% endif %}
+        <small id="charCount" class="block text-align-right">200/200</small>
     </div>
 
     <!-- Community entity -->


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/868960ubn)**

**Description:**
Currently in settings for all account types (researchers, communities, institution), there is no visual way to see that there is a character limit counter in settings. 
![image](https://github.com/user-attachments/assets/ff6cb8f8-e220-4d22-bc0c-7e983e722568)
This task will require to add the character counter to these fields. It should be consistent with account creation process UI:
![image](https://github.com/user-attachments/assets/9cfd6365-43aa-484d-8ed7-0fdc05cc64ee)


**Solution:**
- Added the count on template of `update-accounts`
- Updated the JS function to handle the count change

**After:**

https://github.com/user-attachments/assets/b1ab47ee-6d2c-401c-a43f-04222278df83

