### PR TITLE
#86897rv7h Update lead date for researcher

### DIFF
--- a/researchers/views.py
+++ b/researchers/views.py
@@ -63,7 +63,7 @@ def connect_researcher(request):
                 "last_name": user_form.cleaned_data['last_name'],
                 "email": request.user._wrapped.email,
                 "account_type": "researcher_account",
-                "organization_name": user_form.cleaned_data['first_name'],
+                "organization_name": get_users_name(request.user),
                 }
                 mutable_post_data.update(subscription_data)
                 subscription_form = SubscriptionForm(mutable_post_data)


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/86897rv7h)**

**Description:**
It was decided in this [thread](https://localcontexts.slack.com/archives/C05SU5R08R1/p1722452988738389?thread_ts=1722450545.341949&cid=C05SU5R08R1) to update the lead_data for the researcher account for organization_name from First_name to First_name + Last_name.

**Solution:**
- Updated the organization name in form from first name to get_users_name

**After:**
- **Sample lead_data with both first and last name:**
`{'hubId': '9_r', 'companyName': "Sabeen's Cmmounity Account", 'email': 'sabeen.ammar+990@localcontexts.org', 'firstname': "Sabeen's", 'lastName': 'Cmmounity Account', 'oppName': "Sabeen's Cmmounity Account", 'inquiryType': 'subscriber', 'isBusinessTrue': False}`

- **Sample lead_data with only first name:**

`{'hubId': '10_r', 'companyName': "Sabeen's", 'email': 'sabeen.ammar+990@localcontexts.org', 'firstname': "Sabeen's", 'lastName': "Sabeen's", 'oppName': "Sabeen's", 'inquiryType': 'subscriber', 'isBusinessTrue': False}` 