### PR TITLE
Resolved variables error of notices page

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -717,7 +717,7 @@ def form_initiation(request,account_type=""):
     elif account_type == "researcher_action":
         exclude_choices = {"member", "service_provider", "cc_only"}
     else:
-        return None, None
+        exclude_choices = set()
 
     subscription_form = SubscriptionForm()
     subscription_form.fields["inquiry_type"].choices = [

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -371,10 +371,9 @@ def institution_notices(request, pk):
     )
 
     try:
-        if institution.is_subscribed:
-            subscription = Subscription.objects.get(institution=institution)
-            not_approved_download_notice = None
-            not_approved_shared_notice = None
+        subscription = Subscription.objects.get(institution=institution)
+        not_approved_download_notice = None
+        not_approved_shared_notice = None
     except Subscription.DoesNotExist:
         subscription = None
         not_approved_download_notice = "Your institution account needs to be confirmed in order to download this Notice."

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -210,10 +210,9 @@ def researcher_notices(request, researcher):
     create_restricted_message = False
 
     try:
-        if researcher.is_subscribed:
-            subscription = Subscription.objects.get(researcher=researcher.id)
-            not_approved_download_notice = None
-            not_approved_shared_notice = None
+        subscription = Subscription.objects.get(researcher=researcher.id)
+        not_approved_download_notice = None
+        not_approved_shared_notice = None
     except Subscription.DoesNotExist:
         subscription = None
         not_approved_download_notice = "Your researcher account needs to be confirmed in order to download this Notice."


### PR DESCRIPTION
**Discription:**
When the notices page of the institute and researcher is opened, a variable [error](https://localcontexts.slack.com/files/USLACKBOT/F07FRKFSHT5/13) occurs. This PR is to resolve the backend issues that occurred during the rebasing of "subscription" with "develop" branch.


**Solution:**
- Updated the form_initiation function for the service provider account
- Updated the logic of getting the value of the variable

**Before:**
![institute_notices(error)](https://github.com/user-attachments/assets/f807769f-7f0e-4692-b25b-95b96c8778df)

![researcher_notices(error)](https://github.com/user-attachments/assets/aea21b82-567a-4c86-8a40-fc0abe38e159)

**After:**

https://github.com/user-attachments/assets/6ca3bf24-998c-4838-baba-392dc2bcf361

