### PR TITLE
#86899db6e Inquiry Type: Account creation form

### DIFF
--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -162,6 +162,7 @@ def confirm_subscription(request, user, form, account_type):
         isbusiness = True
     elif account_type == "researcher_account":
         hub_id = str(user.id) + "_r"
+        isbusiness = False
     elif account_type == "service_provider_account":
         hub_id = str(user.id) + "_sp"
         isbusiness = True

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -705,31 +705,18 @@ def decrypt_api_key(key):
     api_key = force_str(urlsafe_base64_decode(key))
     return api_key
 
-def form_initiation(request,account_type=""):
+def form_initiation(request):
     fields_to_update = {
         "first_name": request.user._wrapped.first_name,
         "last_name": request.user._wrapped.last_name,
     }
     user_form = UserCreateProfileForm(request.POST or None, initial=fields_to_update)
 
-    if account_type == "institution_action":
-        exclude_choices = {"member", "service_provider"}
-    elif account_type == "researcher_action":
-        exclude_choices = {"member", "service_provider", "cc_only"}
-    else:
-        exclude_choices = set()
-
-    subscription_form = SubscriptionForm()
-    subscription_form.fields["inquiry_type"].choices = [
-        choice for choice in SubscriptionForm.INQUIRY_TYPE_CHOICES
-        if choice[0] not in exclude_choices
-    ]
-
     for field, value in fields_to_update.items():
         if value:
             user_form.fields[field].widget.attrs.update({"class": "w-100 readonly-input"})
 
-    return user_form, subscription_form
+    return user_form
 
 def check_subscription(request, subscriber_type, id):
     subscriber_field_mapping = {

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -113,7 +113,8 @@ def preparation_step(request):
 @login_required(login_url="login")
 def create_institution(request):
     form = CreateInstitutionForm()
-    user_form,subscription_form  = form_initiation(request, "institution_action")    
+    user_form = form_initiation(request)
+    subscription_form = SubscriptionForm()
     env = dev_prod_or_local(request.get_host())
     
     if request.method == "POST":
@@ -125,6 +126,7 @@ def create_institution(request):
                 "last_name": user_form.cleaned_data['last_name'],
                 "email": request.user._wrapped.email,
                 "account_type": "institution_account",
+                "inquiry_type": request.POST['inquiry_type'],
                 "organization_name": form.cleaned_data['institution_name'],
             }
             
@@ -149,7 +151,8 @@ def create_institution(request):
 @login_required(login_url="login")
 def create_custom_institution(request):
     noror_form = CreateInstitutionNoRorForm()
-    user_form,subscription_form  = form_initiation(request, "institution_action")
+    user_form = form_initiation(request)
+    subscription_form = SubscriptionForm()
     env = dev_prod_or_local(request.get_host())
 
     if request.method == "POST":
@@ -161,6 +164,7 @@ def create_custom_institution(request):
             "last_name": user_form.cleaned_data['last_name'],
             "email": request.user._wrapped.email,
             "account_type": "institution_account",
+            "inquiry_type": request.POST['inquiry_type'],
             "organization_name": noror_form.cleaned_data['institution_name'],
             }
             

--- a/researchers/views.py
+++ b/researchers/views.py
@@ -50,7 +50,7 @@ def preparation_step(request):
 def connect_researcher(request):
     researcher = is_user_researcher(request.user)
     form = ConnectResearcherForm(request.POST or None)
-    user_form, subscription_form  = form_initiation(request, "researcher_action")
+    user_form = form_initiation(request)
     
     env = dev_prod_or_local(request.get_host())
     
@@ -62,6 +62,7 @@ def connect_researcher(request):
                 "first_name": user_form.cleaned_data['first_name'],
                 "last_name": user_form.cleaned_data['last_name'],
                 "email": request.user._wrapped.email,
+                "inquiry_type": "subscriber",
                 "account_type": "researcher_account",
                 "organization_name": get_users_name(request.user),
                 }
@@ -80,7 +81,7 @@ def connect_researcher(request):
                         "Something went wrong. Please Try again later.",
                     )
                     return redirect('dashboard')
-        context = {'form': form, 'env': env, 'subscription_form': subscription_form, 'user_form': user_form}
+        context = {'form': form, 'env': env, 'user_form': user_form}
         return render(request, 'researchers/connect-researcher.html', context)
     else:
         return redirect('researcher-notices', researcher.id)

--- a/serviceproviders/views.py
+++ b/serviceproviders/views.py
@@ -53,9 +53,7 @@ def preparation_step(request):
 @login_required(login_url="login")
 def create_service_provider(request):
     form = CreateServiceProviderForm()
-    user_form,subscription_form  = form_initiation(
-        request, "service_provider_action"
-    )
+    user_form = form_initiation(request)
     env = dev_prod_or_local(request.get_host())
 
     if request.method == "POST":
@@ -67,6 +65,7 @@ def create_service_provider(request):
             "first_name": user_form.cleaned_data['first_name'],
             "last_name": user_form.cleaned_data['last_name'],
             "email": request.user._wrapped.email,
+            "inquiry_type": "service_provider",
             "account_type": "service_provider_account",
             "organization_name": form.cleaned_data['name'],
             }
@@ -90,7 +89,6 @@ def create_service_provider(request):
         "serviceproviders/create-service-provider.html",
         {
             "form": form,
-            "subscription_form": subscription_form,
             "user_form": user_form,
         },
     )

--- a/templates/institutions/create-custom-institution.html
+++ b/templates/institutions/create-custom-institution.html
@@ -87,13 +87,24 @@
                 <label class="pad-top-1-5" for="country">Country</label><br>
                 {{ noror_form.country }}
             </div>
-            <div class="w-50">
-                <label for="inquiry_type">Inquiry type<span class="orange-text required-label" title="">*</span></label>
+        </div>
+        <div class="w-100">
+            <div class="pad-top-1-5 radio-group mb-1p">
+                <label for="inquiry_type" class="inquiry-label">Inquiry Type<span class="orange-text required-label" title="">*</span></label>
                 <div class="tooltip"><strong>i</strong>
-                    <span class="tooltiptext left-tooltip">An institution inquiry type allows you to select the desired role for the subscription process.</span>
+                    <span class="tooltiptext">An institution inquiry type allows you to select the desired role for the subscription process.</span>
                 </div>
                 <br>
-                {{ subscription_form.inquiry_type }}
+                <div class="flex-this row ">
+                    <label class="radio-container w-50 mt-2p">
+                        <input class="pointer" type="radio" name="inquiry_type" value="subscriber">
+                        <span class="ml-5">Subscription</span>
+                    </label>
+                    <label class="radio-container w-50 mt-2p">
+                        <input class="pointer" type="radio" name="inquiry_type" value="cc_only">
+                        <span class="ml-5">Collections Care Notices</span>
+                    </label>
+                </div>
             </div>
         </div>
 

--- a/templates/institutions/create-institution.html
+++ b/templates/institutions/create-institution.html
@@ -68,15 +68,6 @@
                 <label class="pad-top-1-5" for="country">Country</label><br>
                 {{ form.country }}
             </div>
-
-            <div class="w-50">
-                <label for="inquiry_type">Inquiry type<span class="orange-text required-label" title="">*</span></label>
-                <div class="tooltip"><strong>i</strong>
-                    <span class="tooltiptext left-tooltip">An institution inquiry type allows you to select the desired role for the subscription process.</span>
-                </div>
-                <br>
-                {{ subscription_form.inquiry_type }}
-            </div>
         </div>
 
         <div class="mt-8">
@@ -86,7 +77,25 @@
                 <div class="msg-red w-50"><small>{{ form.website.errors.as_text }}</small></div>
             {% endif %}
         </div>
-
+        <div class="w-100">
+            <div class="pad-top-1-5 radio-group mb-1p">
+                <label for="inquiry_type" class="inquiry-label">Inquiry Type<span class="orange-text required-label" title="">*</span></label>
+                <div class="tooltip"><strong>i</strong>
+                    <span class="tooltiptext">An institution inquiry type allows you to select the desired role for the subscription process.</span>
+                </div>
+                <br>
+                <div class="flex-this row ">
+                    <label class="radio-container w-50 mt-2p">
+                        <input class="pointer" type="radio" name="inquiry_type" value="subscriber">
+                        <span class="ml-5">Subscription</span>
+                    </label>
+                    <label class="radio-container w-50 mt-2p">
+                        <input class="pointer" type="radio" name="inquiry_type" value="cc_only">
+                        <span class="ml-5">Collections Care Notices</span>
+                    </label>
+                </div>
+            </div>
+        </div>
         <div class="w-100">
             <div class="pad-top-1-5">
                 <label for="description">Institution Description<span class="orange-text required-label" title="">*</span></label>

--- a/templates/researchers/connect-researcher.html
+++ b/templates/researchers/connect-researcher.html
@@ -67,7 +67,7 @@
             </div>
         </div>
         <div class="flex-this w-100 space-between mt-2p">
-            <div class='w-50 mr-1p'>
+            <div class='w-100 mr-1p'>
                 <label for="primary_institution">Primary Institution</label>
                 <div class="tooltip"><strong>i</strong>
                     <span class="tooltiptext">If you are associated with an institution, please list your primary institution.</span>
@@ -76,14 +76,6 @@
                 {% if form.primary_institution.errors %}
                     <div class="msg-red w-80"><small>{{ form.primary_institution.errors.as_text }}</small></div> 
                 {% endif %}
-            </div>
-            <div class="w-50 ml-1p">
-                <label for="inquiry_type">Inquiry type<span class="orange-text required-label" title="">*</span></label>
-                <div class="tooltip"><strong>i</strong>
-                    <span class="tooltiptext left-tooltip">An institution inquiry type allows you to select the desired role for the subscription process.</span>
-                </div>
-                <br>
-                {{ subscription_form.inquiry_type }}
             </div>
 
         </div>

--- a/templates/serviceproviders/create-service-provider.html
+++ b/templates/serviceproviders/create-service-provider.html
@@ -58,17 +58,6 @@
             </div>
         </div>
 
-        <div class="mt-8 w-100 flex-this">
-            <div class="w-100">
-                <label for="inquiry_type">Inquiry type<span class="orange-text required-label" title="">*</span></label>
-                <div class="tooltip"><strong>i</strong>
-                    <span class="tooltiptext left-tooltip">A service provider inquiry type allows you to select the desired role for the subscription process.</span>
-                </div>
-                <br>
-                {{ subscription_form.inquiry_type }}
-            </div>
-        </div>
-
         <div class="w-100">
             <div class="pad-top-1-5">
                 <label for="description">Service Provider Description<span class="orange-text required-label" title="">*</span></label>


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/86899db6e)**

**Description:**
Currently, the inquiry type for account creation has extra options that are not necessarily needed.
![image](https://github.com/user-attachments/assets/d2767dc8-3095-43f3-8600-13d697390fc5)


For this task:
Remove The inquiry type in all account creation forms (Researcher, Institution, Service Provider, Community) but NOT the anonymous user form (this form will work as it is now).
Send the inquiry type automatically to SF based on the kind of account it is.
- Community inquiry type: Membership
- Institution inquiry type: Add 2 radio buttons. Option 1: Subscription. Option 2: Collections Care Notices Only. Then send to SF 
whichever was selected.
- Researcher inquiry type: Subscription 
- Service Provider inquiry type: Service Provider


**Solution:**
- Updated the template for institution and non-ROR institution account creation form to include radio buttons
- Handled the radio button inputs on back-end to pass the inquiry_type to SF
- Remove the inputs for subscription inquiry on Researcher and Service Provider account creation forms
- Hard coded the inquiry_type on back-end for Researcher and Service Provider accounts

**Before:**

https://github.com/user-attachments/assets/7551d389-4b0a-47b2-b285-6fa9e0aad9b3

**After:**

https://github.com/user-attachments/assets/95de63a8-39e9-4016-a26e-a186f2536f77

**Lead_data examples:**

lead_data for institute ( on selecting Collection_Care_Notice):

`{'hubId': '6_i', 'companyName': 'Air Force Test Center', 'email': 'sabeen.ammar+9090@localcontexts.org', 'firstname': 'TEst', 'lastName': 'account', 'oppName': 'Air Force Test Center', 'inquiryType': 'cc_only', 'isBusinessTrue': True}`
lead_data for institute(NON ROR on selecting subscription):

`{'hubId': '7_i', 'companyName': 'TESTING FROM SABEEN ACCOUNT', 'email': 'sabeen.ammar+9090@localcontexts.org', 'firstname': 'TEst', 'lastName': 'Acccount', 'oppName': 'TESTING FROM SABEEN ACCOUNT', 'inquiryType': 'subscriber', 'isBusinessTrue': True}`
lead_data for researcher account:

`{'hubId': '14_r', 'companyName': 'institute', 'email': 'sabeen.ammar+9090@localcontexts.org', 'firstname': 'Test', 'lastName': 'Account', 'oppName': 'institute', 'inquiryType': 'subscriber', 'isBusinessTrue': False}`
lead_data for Service Provider:

`{'hubId': '2_sp', 'companyName': 'TEST SERVICE PROVIDER', 'email': 'sabeen.ammar+9090@localcontexts.org', 'firstname': 'TEst', 'lastName': 'Account', 'oppName': 'TEST SERVICE PROVIDER', 'inquiryType': 'service_provider', 'isBusinessTrue': True}`
