### PR TITLE
Fix for subscription inquiry

### DIFF
--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -190,6 +190,7 @@ def confirm_subscription(request, user, form, account_type):
 
     return redirect('dashboard')
 
+
 def escape_single_quotes(data):
     if isinstance(data, dict):
         return {key: escape_single_quotes(value) for key, value in data.items()}

--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -189,3 +189,12 @@ def confirm_subscription(request, user, form, account_type):
             " Please contact support@localcontexts.org.")
 
     return redirect('dashboard')
+
+def escape_single_quotes(data):
+    if isinstance(data, dict):
+        return {key: escape_single_quotes(value) for key, value in data.items()}
+    elif isinstance(data, list):
+        return [escape_single_quotes(item) for item in data]
+    elif isinstance(data, str):
+        return data.replace("'", "\\'")
+    return data

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -39,7 +39,7 @@ from .forms import (
 
 from .utils import (
     get_next_path, get_users_name, return_registry_accounts, manage_mailing_list,
-    institute_account_subscription,
+    institute_account_subscription, escape_single_quotes
 )
 from localcontexts.utils import dev_prod_or_local
 from researchers.utils import is_user_researcher
@@ -791,6 +791,8 @@ def subscription_inquiry(request):
         "json", Institution.objects.filter(is_ror=False)
     )
     communities = serializers.serialize("json", Community.approved.all())
+    communities = escape_single_quotes(communities)
+    non_ror_institutes = escape_single_quotes(non_ror_institutes)
 
     if request.method == "POST":
         if validate_recaptcha(request) and form.is_valid():


### PR DESCRIPTION
**Description:**

When testing the subscription inquiry, I discovered that communities and non-ror institutions with apostrophes in their names are causing an error, which prevents the SalesForce call from executing.

![Subscription-inquiry-before(1)](https://github.com/user-attachments/assets/c6da1cb1-82bf-4358-8b28-40303c1ef867)
![subscription-inquiry-before(2)](https://github.com/user-attachments/assets/7e31aa81-f763-4b96-81cb-35ece45df9ac)

**Solution:**
- Appended the apostrophe with escaping slash in the data attributes before passing them to Front-end.
- Because of escaping slash the apostrophe sh showed in recommendations correctly

**After:**
![subscription-inquiry-after](https://github.com/user-attachments/assets/3ff5da14-95c2-4ffb-a318-2fe33dedccf8)
