### PR TITLE
#8687c885q-alert-size-update

### DIFF
--- a/templates/partials/_alerts.html
+++ b/templates/partials/_alerts.html
@@ -17,7 +17,8 @@
         #toast-container .toast{
             display: block;
             width: 380px;
-            padding-top: 25px;
+            padding-top: 22px;
+            padding-bottom: 10px;
         }
         #toast-container> .fa-circle-info , .toast {
             background-color: #007385 !important;
@@ -32,7 +33,7 @@
             margin-top: -20px !important;
             margin-right: -8px !important;
             font-weight: 100;
-            padding: 20px !important;
+            padding: 20px  20px 0px 20px !important;
         }
         .toast-message {
             padding-right: 8px;
@@ -40,7 +41,7 @@
             margin-right: 38px;
             border-right: solid 1px;
             border-right-color: rgba(255,255,255,.8);
-            min-height: 64px;
+            min-height: 44px;
             max-height: 8em;
             line-height: 1.6em;
             font-size: 12px;


### PR DESCRIPTION
The min height has been updated. Looking at the dev tools inspector, the sum of the height is about 64px:

![image](https://github.com/user-attachments/assets/f20e5716-b44c-499b-997a-6da552eaa20e)

-------------------------

Here's what it looks like in action:

![image](https://github.com/user-attachments/assets/fdf734ec-4207-4102-b07f-f6ee94200528)
