### PR TITLE
#8689bxfry display accounts

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -401,8 +401,21 @@ def deactivate_user(request):
         )
         return redirect('login')
 
+    affiliations = UserAffiliation.objects.prefetch_related(
+        'communities', 'institutions', 'communities__community_creator',
+        'institutions__institution_creator'
+    ).get(user=request.user)
+    researcher = Researcher.objects.none()
+    users_name = get_users_name(request.user)
+    if Researcher.objects.filter(user=request.user).exists():
+        researcher = Researcher.objects.get(user=request.user)
+
     return render(request, 'accounts/deactivate.html', {
-        'profile': profile, 'user_role': user_role
+        'profile': profile,
+        'user_role': user_role,
+        'affiliations': affiliations,
+        'researcher': researcher,
+        'users_name': users_name
     })
 
 

--- a/templates/accounts/deactivate.html
+++ b/templates/accounts/deactivate.html
@@ -36,7 +36,6 @@
                         <a id="openCommLeaveAcctBtn_{{community.id}}" class="leave-acct-btn block darkteal-text bold pointer leaveCommunityBtn"><small class="block">Leave account</small></a>
                     {% endif %}
                 </div>
-                {% include 'snippets/modals/leave-account-modal.html' %}
             {% endfor %}
 
             {% for institution in affiliations.institutions.all %}
@@ -46,8 +45,11 @@
                         <a id="openInstLeaveAcctBtn_{{institution.id}}" class="leave-acct-btn block darkteal-text bold pointer leaveInstitutionBtn"><small class="block">Leave account</small></a>
                     {% endif %}
                 </div>
-                {% include 'snippets/modals/leave-account-modal.html' %}
             {% endfor %}
+
+            {% if affiliations.institutions.count or affiliations.communities.count %}
+                {% include 'snippets/modals/leave-account-modal.html' %}
+            {% endif %}
 
             <br>
             {% csrf_token %}

--- a/templates/accounts/deactivate.html
+++ b/templates/accounts/deactivate.html
@@ -22,6 +22,34 @@
                     Your profile and its associated data will be deleted 30 days after deactivation.
                 {% endif %}
             </p>
+
+            {% if researcher %}
+                <div class="flex-this space-between border-top-bottom-grey w-100 align-center">
+                    <div class="w-70"><h3>{{ users_name }} | Researcher</h3></div>
+                </div>
+            {% endif %}
+
+            {% for community in affiliations.communities.all %}
+                <div class="flex-this space-between border-top-bottom-grey w-100 align-center">
+                    <div class="w-70"><h3>{{ community.community_name }} | Community</h3></div>
+                    {% if not request.user == community.community_creator %}
+                        <a id="openCommLeaveAcctBtn_{{community.id}}" class="leave-acct-btn block darkteal-text bold pointer leaveCommunityBtn"><small class="block">Leave account</small></a>
+                    {% endif %}
+                </div>
+                {% include 'snippets/modals/leave-account-modal.html' %}
+            {% endfor %}
+
+            {% for institution in affiliations.institutions.all %}
+                <div class="flex-this space-between border-top-bottom-grey w-100 align-center">
+                    <div class="w-70"><h3>{{ institution.institution_name }} | Institution</h3></div>
+                    {% if not request.user == institution.institution_creator %}
+                        <a id="openInstLeaveAcctBtn_{{institution.id}}" class="leave-acct-btn block darkteal-text bold pointer leaveInstitutionBtn"><small class="block">Leave account</small></a>
+                    {% endif %}
+                </div>
+                {% include 'snippets/modals/leave-account-modal.html' %}
+            {% endfor %}
+
+            <br>
             {% csrf_token %}
             <button id="submitDeactivation" class="primary-btn white-btn
                 {% if user_role != 'default' %}disabled-btn pointer-event-none{% endif %}">

--- a/templates/accounts/deactivate.html
+++ b/templates/accounts/deactivate.html
@@ -32,24 +32,14 @@
             {% for community in affiliations.communities.all %}
                 <div class="flex-this space-between border-top-bottom-grey w-100 align-center">
                     <div class="w-70"><h3>{{ community.community_name }} | Community</h3></div>
-                    {% if not request.user == community.community_creator %}
-                        <a id="openCommLeaveAcctBtn_{{community.id}}" class="leave-acct-btn block darkteal-text bold pointer leaveCommunityBtn"><small class="block">Leave account</small></a>
-                    {% endif %}
                 </div>
             {% endfor %}
 
             {% for institution in affiliations.institutions.all %}
                 <div class="flex-this space-between border-top-bottom-grey w-100 align-center">
                     <div class="w-70"><h3>{{ institution.institution_name }} | Institution</h3></div>
-                    {% if not request.user == institution.institution_creator %}
-                        <a id="openInstLeaveAcctBtn_{{institution.id}}" class="leave-acct-btn block darkteal-text bold pointer leaveInstitutionBtn"><small class="block">Leave account</small></a>
-                    {% endif %}
                 </div>
             {% endfor %}
-
-            {% if affiliations.institutions.count or affiliations.communities.count %}
-                {% include 'snippets/modals/leave-account-modal.html' %}
-            {% endif %}
 
             <br>
             {% csrf_token %}


### PR DESCRIPTION
Accounts are displayed for creators and members similar to the accounts page

for creators:


https://github.com/user-attachments/assets/5565ae60-8f05-41f3-b0df-83f794996b4e



---

for members:

![image](https://github.com/user-attachments/assets/35a9c915-d10d-44fc-af93-09b2e5f7b824)

----

for non creator and non member

![image](https://github.com/user-attachments/assets/e1118489-724e-4cfb-b1a8-469f62345c70)
