### PR TITLE
#8689dru4t: Updated Researcher connections card bug

### DIFF
--- a/templates/communities/connections.html
+++ b/templates/communities/connections.html
@@ -84,7 +84,7 @@
                 <div class="flex-this column dashcard-text-container">
                     <div><h3 class="dashcard-h3 darkteal-text">{% firstof researcher.user.get_full_name researcher.user.username %}</h3></div>
                     <div>
-                        <p class="dashcard-subheader">Researcher | Location: {{ profile.get_location }} </p>
+                        <p class="dashcard-subheader">Researcher | Location: {{ researcher.user.user_profile.get_location }}</p>
                     </div>
                     <div><p class="dashcard-description description-sm">{% if researcher.description %}{{ researcher.description }} {% else %} No description provided. {% endif %}</p></div>
                 </div>

--- a/templates/institutions/connections.html
+++ b/templates/institutions/connections.html
@@ -81,7 +81,7 @@
             <div class="flex-this column dashcard-text-container">
                 <div><h3 class="dashcard-h3 darkteal-text">{% firstof researcher.user.get_full_name researcher.user.username %}</h3></div>
                 <div>
-                    <p class="dashcard-subheader">Researcher | Location: {{ profile.get_location }} </p>
+                    <p class="dashcard-subheader">Researcher | Location: {{ researcher.user.user_profile.get_location }}</p>
                 </div>
                 <div><p class="dashcard-description description-sm">{% if researcher.description %}{{ researcher.description }} {% else %} No description provided. {% endif %}</p></div>
             </div>

--- a/templates/researchers/connections.html
+++ b/templates/researchers/connections.html
@@ -90,7 +90,7 @@
                 <div class="flex-this column dashcard-text-container">
                     <div><h3 class="dashcard-h3 darkteal-text">{% firstof res.user.get_full_name res.user.username %}</h3></div>
                     <div>
-                        <p class="dashcard-subheader">Researcher | Location: {{ profile.get_location }} </p>
+                        <p class="dashcard-subheader">Researcher | Location: {{ researcher.user.user_profile.get_location }}</p>
                     </div>
                     <div><p class="dashcard-description description-sm">{% if res.description %}{{ res.description }} {% else %} No description provided. {% endif %}</p></div>
                 </div>


### PR DESCRIPTION
Previously Researcher cards were not showing location information.

Before:
![image](https://github.com/user-attachments/assets/a4abef46-9e89-4dd8-bdde-ed4a90a93315)

After:
![image](https://github.com/user-attachments/assets/7cbc110d-5ae7-4ac9-a363-31d167dbe7c3)
