### PR TITLE
#8689c0ert 403 removing account bug fix

### DIFF
--- a/communities/decorators.py
+++ b/communities/decorators.py
@@ -11,6 +11,9 @@ def member_required(roles=[]):
             member_role = check_member_role(request.user, community)
             if member_role not in roles:
                 return redirect('restricted')
+
+            # update view function args
+            kwargs['callee_role'] = member_role
             return view_func(request, *args, **kwargs)
         return _wrapped_view
     return decorator

--- a/communities/decorators.py
+++ b/communities/decorators.py
@@ -11,9 +11,6 @@ def member_required(roles=[]):
             member_role = check_member_role(request.user, community)
             if member_role not in roles:
                 return redirect('restricted')
-
-            # update view function args
-            kwargs['callee_role'] = member_role
             return view_func(request, *args, **kwargs)
         return _wrapped_view
     return decorator

--- a/communities/views.py
+++ b/communities/views.py
@@ -415,13 +415,6 @@ def delete_join_request(request, pk, join_id):
 @member_required(roles=['admin'])
 def remove_member(request, pk, member_id):
     community = get_community(pk)
-
-    callee_role = check_member_role(request.user, community)
-    member_to_remove_is_self = str(request.user.id) == member_id
-    callee_is_admin = callee_role == 'admin'
-    if not callee_is_admin and not member_to_remove_is_self:
-        return redirect('restricted')
-
     member = User.objects.get(id=member_id)
     remove_user_from_account(user=member, account=community)
 

--- a/communities/views.py
+++ b/communities/views.py
@@ -412,7 +412,7 @@ def delete_join_request(request, pk, join_id):
     return redirect('member-requests', community.id)
 
 @login_required(login_url='login')
-@member_required(roles=['admin', 'editor', 'viewer'])
+@member_required(roles=['admin'])
 def remove_member(request, pk, member_id):
     community = get_community(pk)
 

--- a/communities/views.py
+++ b/communities/views.py
@@ -1,15 +1,6 @@
 from django.shortcuts import redirect
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
-from itertools import chain
-
-from django.contrib.auth.models import User
-from accounts.models import UserAffiliation
-from helpers.models import *
-from notifications.models import *
-from bclabels.models import BCLabel
-from tklabels.models import TKLabel
-from projects.models import *
 
 from helpers.forms import *
 from bclabels.forms import *
@@ -17,11 +8,10 @@ from tklabels.forms import *
 from projects.forms import *
 from accounts.forms import ContactOrganizationForm, SignUpInvitationForm
 
-from localcontexts.utils import dev_prod_or_local
 from projects.utils import *
 from helpers.utils import *
 from tklabels.utils import data as labels_data
-from accounts.utils import get_users_name
+from accounts.utils import remove_user_from_account
 from notifications.utils import *
 from helpers.downloads import download_labels_zip
 from helpers.emails import *
@@ -433,18 +423,7 @@ def remove_member(request, pk, member_id):
         return redirect('restricted')
 
     member = User.objects.get(id=member_id)
-    # what role does member have
-    # remove from role
-    if member in community.admins.all():
-        community.admins.remove(member)
-    if member in community.editors.all():
-        community.editors.remove(member)
-    if member in community.viewers.all():
-        community.viewers.remove(member)
-
-    # remove community from userAffiliation instance
-    affiliation = UserAffiliation.objects.get(user=member)
-    affiliation.communities.remove(community)
+    remove_user_from_account(user=member, account=community)
 
     # Delete join request for this community if exists
     if JoinRequest.objects.filter(user_from=member, community=community).exists():

--- a/communities/views.py
+++ b/communities/views.py
@@ -423,7 +423,12 @@ def delete_join_request(request, pk, join_id):
 
 @login_required(login_url='login')
 @member_required(roles=['admin', 'editor', 'viewer'])
-def remove_member(request, pk, member_id):
+def remove_member(request, pk, member_id, callee_role):
+    member_to_remove_is_self = str(request.user.id) == member_id
+    callee_is_admin = callee_role == 'admin'
+    if not callee_is_admin and not member_to_remove_is_self:
+        return redirect('restricted')
+
     community = get_community(pk)
     member = User.objects.get(id=member_id)
     # what role does member have

--- a/communities/views.py
+++ b/communities/views.py
@@ -422,7 +422,7 @@ def delete_join_request(request, pk, join_id):
     return redirect('member-requests', community.id)
 
 @login_required(login_url='login')
-@member_required(roles=['admin'])
+@member_required(roles=['admin', 'editor', 'viewer'])
 def remove_member(request, pk, member_id):
     community = get_community(pk)
     member = User.objects.get(id=member_id)

--- a/communities/views.py
+++ b/communities/views.py
@@ -423,13 +423,15 @@ def delete_join_request(request, pk, join_id):
 
 @login_required(login_url='login')
 @member_required(roles=['admin', 'editor', 'viewer'])
-def remove_member(request, pk, member_id, callee_role):
+def remove_member(request, pk, member_id):
+    community = get_community(pk)
+
+    callee_role = check_member_role(request.user, community)
     member_to_remove_is_self = str(request.user.id) == member_id
     callee_is_admin = callee_role == 'admin'
     if not callee_is_admin and not member_to_remove_is_self:
         return redirect('restricted')
 
-    community = get_community(pk)
     member = User.objects.get(id=member_id)
     # what role does member have
     # remove from role

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -460,6 +460,13 @@ def delete_join_request(request, pk, join_id):
 @member_required(roles=['admin'])
 def remove_member(request, pk, member_id):
     institution = get_institution(pk)
+
+    callee_role = check_member_role(request.user, institution)
+    member_to_remove_is_self = str(request.user.id) == member_id
+    callee_is_admin = callee_role == 'admin'
+    if not callee_is_admin and not member_to_remove_is_self:
+        return redirect('restricted')
+
     member = User.objects.get(id=member_id)
     # what role does member have
     # remove from role

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -457,13 +457,6 @@ def delete_join_request(request, pk, join_id):
 @member_required(roles=['admin'])
 def remove_member(request, pk, member_id):
     institution = get_institution(pk)
-
-    callee_role = check_member_role(request.user, institution)
-    member_to_remove_is_self = str(request.user.id) == member_id
-    callee_is_admin = callee_role == 'admin'
-    if not callee_is_admin and not member_to_remove_is_self:
-        return redirect('restricted')
-
     member = User.objects.get(id=member_id)
     remove_user_from_account(user=member, account=institution)
 


### PR DESCRIPTION
Currently, if a user is not an admin, he cannot remove himself from an account.

This change allows non-admin users to remove themselves from an account.