### PR TITLE
#8689ef9md-boundary-name-width

### DIFF
--- a/templates/boundary/show-remove-preexisting.html
+++ b/templates/boundary/show-remove-preexisting.html
@@ -35,7 +35,7 @@
         background-color: #fff;
         border: 1px solid #1f293700;
         border-radius: 4px;
-        max-width: 560px;
+        max-width: 700px;
         color: black;
     }
     #edit_name_icon {

--- a/templates/boundary/show-remove-preexisting.html
+++ b/templates/boundary/show-remove-preexisting.html
@@ -87,7 +87,7 @@
 
     <div class="center-boundary-container-item-vertically" style="width: calc(100% - 300px);">
         <div style="display: flex">
-            <input disabled class='name_of_boundary' value="{{ entity.name_of_boundary }}"
+            <input disabled class='name_of_boundary w-100' value="{{ entity.name_of_boundary }}"
                    onchange="shapeFileChange(this)"
                    onblur="disableNameInput(this)"
             >

--- a/templates/partials/_update-boundary-main-area.html
+++ b/templates/partials/_update-boundary-main-area.html
@@ -102,7 +102,7 @@
 
             <div class="center-boundary-container-item-vertically" style="width: calc(100% - 300px);">
                 <div style="display: flex">
-                    <input disabled class='name_of_boundary' value="{{ community.name_of_boundary }}"
+                    <input disabled class='name_of_boundary w-100' value="{{ community.name_of_boundary }}"
                            onchange="shapeFileChange(this)"
                            onblur="disableNameInput(this)"
                     >

--- a/templates/partials/_update-boundary-main-area.html
+++ b/templates/partials/_update-boundary-main-area.html
@@ -39,7 +39,7 @@
         background-color: #fff;
         border: 1px solid #1f293700;
         border-radius: 4px;
-        max-width: 700px;
+        max-width: 640px;
         color: black;
     }
 

--- a/templates/partials/_update-boundary-main-area.html
+++ b/templates/partials/_update-boundary-main-area.html
@@ -39,7 +39,7 @@
         background-color: #fff;
         border: 1px solid #1f293700;
         border-radius: 4px;
-        max-width: 560px;
+        max-width: 700px;
         color: black;
     }
 


### PR DESCRIPTION
This expands the boundary name width to take up the full width when necessary.

**On Project Boundary Page**
![image](https://github.com/user-attachments/assets/d1d6e71a-6991-4372-a0c7-c844a59fe18d)

----


**On Project Settings Page**
![image](https://github.com/user-attachments/assets/346c6c9d-2944-4882-bb30-46c87d011141)


