### PR TITLE
Misc SP content updates

### DIFF
--- a/accounts/utils.py
+++ b/accounts/utils.py
@@ -178,9 +178,7 @@ def confirm_subscription(request, user, form, account_type):
         messages.add_message(
             request,
             messages.INFO,
-            "Thank you for your submission, our team will review and be in "
-            "contact with the subscription contract. You will be notified "
-            "once your subscription has been processed.",
+            "Thank you for your interest! Our team will review and be in contact soon."
         )
     else:
         messages.add_message(

--- a/localcontexts/static/css/dashboard.css
+++ b/localcontexts/static/css/dashboard.css
@@ -213,5 +213,3 @@
     width: 360px;
     height: 91px;
 }
-
-.set-height-empty-dash { height: 200px; }

--- a/serviceproviders/views.py
+++ b/serviceproviders/views.py
@@ -540,8 +540,8 @@ def api_keys(request, pk):
                         prefix=prefix).update(encrypted_key=encrypted_key)
 
                 else:
-                    message = "Your account is not confirmed. Your " \
-                        "account must be confirmed to create an API Key."
+                    message = "Your account is not certified. Your account must be certified " \
+                        "to create API Keys."
                     messages.add_message(
                         request,
                         messages.ERROR,

--- a/serviceproviders/views.py
+++ b/serviceproviders/views.py
@@ -195,10 +195,9 @@ def service_provider_notices(request, pk):
         not_approved_download_notice = None
         not_approved_shared_notice = None
     else:
-        not_approved_download_notice = "Your service provider account needs to be subscribed " \
-            "in order to download this Notice."
-        not_approved_shared_notice = "Your service provider account needs to be subscribed in " \
-            "order to share this Notice."
+        not_approved_download_notice = "Your account needs to be certified to download this " \
+            "Notice."
+        not_approved_shared_notice = "Your account needs to be certified to share this Notice."
 
     # sets permission to download OTC Notice
     if dev_prod_or_local(request.get_host()) == "SANDBOX":

--- a/templates/account_settings_pages/_api-keys.html
+++ b/templates/account_settings_pages/_api-keys.html
@@ -44,7 +44,19 @@
 {% endif %}
 
 <div class="flex-this mt-2p">
-    {% if institution.is_subscribed or researcher.is_subscribed or community.is_approved or service_provider.is_certified and remaining_api_key_count != 0 %}
+    {% if remaining_api_key_count != 0 and institution.is_subscribed %}
+        <div>
+            <button id="generateAPIKeybtn" class="primary-btn action-btn mt-2p">Generate API Key</button>
+        </div>
+    {% elif remaining_api_key_count != 0 and researcher.is_subscribed %}
+        <div>
+            <button id="generateAPIKeybtn" class="primary-btn action-btn mt-2p">Generate API Key</button>
+        </div>
+    {% elif remaining_api_key_count != 0 and community.is_approved %}
+        <div>
+            <button id="generateAPIKeybtn" class="primary-btn action-btn mt-2p">Generate API Key</button>
+        </div>
+    {% elif remaining_api_key_count != 0 and service_provider.is_certified %}
         <div>
             <button id="generateAPIKeybtn" class="primary-btn action-btn mt-2p">Generate API Key</button>
         </div>
@@ -57,11 +69,11 @@
                 {% elif researcher and not researcher.is_subscribed %}
                     The subscription process for your account is not completed yet.
                 {% elif service_provider and not service_provider.is_certified %}
-                    The certification process for your account is not completed yet.
+                    The certification process for your account is not completed yet. Please contact us for assistance.
                 {% elif community and not community.is_approved %}
                     The confirmation process for your account is not completed yet.
                 {% elif institution.is_subscribed or researcher.is_subscribed and remaining_api_key_count == 0 %}Your account has reached its API Key limit. Please delete an existing key or upgrade your subscription to add more keys.
-                {% elif service_provider.is_certified and remaining_api_key_count == 0 %}Your account has reached its API Key limit. Please delete your existing key to generate a new one or contact support for assistance.
+                {% elif service_provider.is_certified and remaining_api_key_count == 0 %}Your account has reached its API Key limit. Please delete your existing key to generate a new one or contact us for assistance.
                 {% endif %}
             </span>
         </div>

--- a/templates/accounts/dashboard.html
+++ b/templates/accounts/dashboard.html
@@ -19,7 +19,15 @@
     <section class="flex-this column">
 
         {% if not researcher and not user_communities and not user_institutions and not user_service_providers %}
-            <div class="set-height-empty-dash"></div>
+            <div class="dashcard w-100 center-text mt-16" style="margin-bottom:200px;">
+                <p class="center-text">
+                    <strong>There are no accounts yet.</strong>
+                    <br>
+                    <small>
+                        Click the link above to create an account or browse the registry to join an existing account.
+                    </small>
+                </p>
+            </div>
         {% endif %}
 
         {% if researcher %}

--- a/templates/accounts/member-invitations.html
+++ b/templates/accounts/member-invitations.html
@@ -12,8 +12,8 @@
                     <div class="dashcard">
                         <div class="flex-this">
                             <div class="dashcard-img-container">
-                                <img loading="lazy" 
-                                    class="profile-img" 
+                                <img loading="lazy"
+                                    class="profile-img"
                                     src="{% if invite.institution.image %} {{ invite.institution.image.url }} {% else %} {% static 'images/placeholders/institution-place.jpg' %}{% endif %}" 
                                     alt="{{ invite.institution.invite.institution_name }} image"
                                 >
@@ -22,7 +22,7 @@
 
                                 <div class="flex-this space-between">
                                     <div><h3 class="dashcard-h3 darkteal-text">{{ invite.institution }}</h3></div>
- 
+
                                     <div class="dashcard-btn-container">
                                         <div class="mr-16 mt-8">
                                             <a href="{% url 'delete-member-invitation' invite.id %}" class="default-a">Delete invite</a>
@@ -44,17 +44,17 @@
                                                 {% endif %}
                                             </form>
                                         </div>
-                                    </div>                                 
+                                    </div>
                                 </div>
 
                                 <div>
-                                    <p class="dashcard-subheader">Institution | Members: {% if invite.institution.get_member_count < 10 %}0{{ invite.institution.get_member_count }}{% else %}{{ invite.institution.get_member_count }}{% endif %} | 
+                                    <p class="dashcard-subheader">Institution | Members: {% if invite.institution.get_member_count < 10 %}0{{ invite.institution.get_member_count }}{% else %}{{ invite.institution.get_member_count }}{% endif %} |
                                         Location: {{ invite.institution.get_location }}
                                     </p>
-                                </div>  
+                                </div>
 
                                 <div><p class="dashcard-description description-sm">{% if invite.institution.description %}{{ invite.institution.description }} {% else %} No description provided. {% endif %}</p></div>
-                                
+
                                 <div>
                                     <p class="w-70">
                                         <span class="bold primary-black-text">Invitation Sent By:</span> {% display_name invite.sender %}<br>
@@ -82,8 +82,8 @@
 
                         <div class="flex-this">
                             <div class="dashcard-img-container">
-                                <img loading="lazy" 
-                                    class="profile-img" 
+                                <img loading="lazy"
+                                    class="profile-img"
                                     src="{% if invite.community.image %} {{ invite.community.image.url }} {% else %} {% static 'images/placeholders/community-place.jpg' %}{% endif %}" 
                                     alt="{{ invite.community.invite.community_name }} image"
                                 >
@@ -101,17 +101,17 @@
                                                 {% csrf_token %}
                                                 <input value="{{ invite.id }}" type="hidden" name="invite_id">
                                                 <button class="action-btn primary-btn">Accept invite</button>
-                                            </form>                                            
+                                            </form>
                                         </div>
                                     </div>
                                 </div>
 
                                 <div>
-                                    <p class="dashcard-subheader">Community | Members: {% if invite.community.get_member_count < 10 %}0{{ invite.community.get_member_count }}{% else %}{{ invite.community.get_member_count }}{% endif %} | 
+                                    <p class="dashcard-subheader">Community | Members: {% if invite.community.get_member_count < 10 %}0{{ invite.community.get_member_count }}{% else %}{{ invite.community.get_member_count }}{% endif %} |
                                         Location: {{ invite.community.get_location }}
                                     </p>
                                 </div>
-                                
+
                                 <div><p class="dashcard-description description-sm">{% if invite.community.description %}{{ invite.community.description }} {% else %} No description provided. {% endif %}</p></div>
 
                                 <div>
@@ -142,8 +142,8 @@
 
                         <div class="flex-this">
                             <div class="dashcard-img-container">
-                                <img loading="lazy" 
-                                    class="profile-img" 
+                                <img loading="lazy"
+                                    class="profile-img"
                                     src="{% if invite.service_provider.image %} {{ invite.service_provider.image.url }} {% else %} {% static 'images/placeholders/service-provider-place.jpg' %}{% endif %}" 
                                     alt="{{ invite.service_provider.invite.name }} image"
                                 >
@@ -161,7 +161,7 @@
                                                 {% csrf_token %}
                                                 <input value="{{ invite.id }}" type="hidden" name="invite_id">
                                                 <button class="action-btn primary-btn">Accept invite</button>
-                                            </form>                                            
+                                            </form>
                                         </div>
                                     </div>
                                 </div>
@@ -169,7 +169,7 @@
                                 <div>
                                     <p class="dashcard-subheader">Service Provider</p>
                                 </div>
-                                
+
                                 <div><p class="dashcard-description description-sm">{% if invite.service_provider.description %}{{ invite.service_provider.description }} {% else %} No description provided. {% endif %}</p></div>
 
                                 <div>
@@ -197,9 +197,17 @@
 
             {% endfor %}
         {% else %}
-            <p class="center-text">You currently have no new invitations. <br><small>Invitations appear when someone from a community or institution invites you to join their account.</small></p>
+            <div class="dashcard w-100 center-text mt-16 mb-16">
+                <p class="center-text">
+                    <strong>You currently have no new invitations.</strong>
+                    <br>
+                    <small>
+                        Invitations appear when someone from a community or institution invites you to join their account.
+                    </small>
+                </p>
+            </div>
         {% endif %}
-        
+
     </section>
 
 {% endblock %}

--- a/templates/accounts/preparation.html
+++ b/templates/accounts/preparation.html
@@ -173,24 +173,20 @@
                     Please note the following before creating a service provider account:
                 </p>
                 <p>
-                    <strong>01 An institution account is for a cultural or research institution, data repository, or other organization that will use Notices.</strong> 
-                    An archive, library, museum, historical society, gallery, data repository, university, research lab, or media production company might create an institution account. 
-                    This account will represent your organization on the Hub and potentially in relationships with sovereign Indigenous communities. If you are an Indigenous institution 
-                    and plan to use Labels on behalf of your community, a community account may be a better fit. Please <a class="default-a" href="mailto:support@localcontexts.org" target="_blank" rel="noopener">contact us</a> if you have any questions.
+                    <strong>
+                        1. A service provider account is for an organization that integrates a connection to the Local Contexts Hub into their platforms to enable other account types to access their Labels and Notices.
+                    </strong>
+                    A service provider could be a collections management system, repository workflow platform, or information aggregator. Service providers allow Members and Subscribers to easily integrate Labels and Notices into local workflows and systems.
                     <br><br>
 
-                    <strong>02 As the creator of this new account, you will become the main administrator by default. </strong>
-                    As the main administrator, you will be the point of contact for the account and responsible for adding other users to the account. If you would like to change the 
-                    account contact or your role after creating your account, please <a class="default-a" href="mailto:support@localcontexts.org" target="_blank" rel="noopener">contact us</a>.
+                    <strong>
+                        2. As the creator of this new account, you will become the main administrator by default.
+                    </strong>
+                    As the main administrator, you will be the point of contact for the account and responsible for adding other users to the account. If you would like to change the account contact or your role after creating your account, please <a class="default-a" href="mailto:support@localcontexts.org" target="_blank" rel="noopener">contact us</a>.
                     <br><br>
 
-                    <strong>03 A subscription program for institution accounts will be launched in October 2024.</strong>
-                    More information about this program is available on our 
-                    <a class="default-a" href="https://localcontexts.org/generational-sustainability-of-local-contexts/" target="_blank" rel="noopener">website blog</a> 
-                    and <a class="default-a" href="https://localcontexts.org/members-subscribers-and-service-providers/" target="_blank" rel="noopener">subscribers page</a>. 
-                    After you complete the institution account creation process, you will have 
-                    limited account functionality until completion of the subscription agreement. We will reach out to you, and any institutional contacts you indicate, to discuss which 
-                    subscription tier is best for your organization. If we do not hear from you within 90 days, this incomplete account will be deleted.
+                    <strong>3. A certification program for service provider accounts was launched in October 2024.</strong>
+                    More information about this program is available on our <a class="default-a" href="https://localcontexts.org/generational-sustainability-of-local-contexts/" target="_blank" rel="noopener">website blog</a> and <a class="default-a" href="https://localcontexts.org/members-subscribers-and-service-providers/" target="_blank" rel="noopener">subscribers page</a>. You will have limited account functionality until completion of the certification program and service provider agreement. We will reach out to you, and any contacts you indicate, to discuss the service provider program. If we do not hear from you within 90 days, this incomplete account will be deleted.
                 </p>
             {% endif %}
         {% endif %}
@@ -199,7 +195,7 @@
     <div class="flex-this w-90">
         {% if community and not environment == "SANDBOX" %}
             <div class="w-60">
-                <a 
+                <a
                     href="{% url 'download-community-support-letter' %}"
                     class="primary-btn blue-btn"
                 > Download letter template <i class="fa-solid fa-download"></i>

--- a/templates/accounts/registry.html
+++ b/templates/accounts/registry.html
@@ -7,7 +7,7 @@
         <div class="w-80">
             <h2 class="mb-0">The Local Contexts Registry</h2>
             <p>
-                This is the registry for accounts that are registered with the Local Contexts Hub. Visit an account's public page to contact or request to join, and to view public projects, Open to Collaborate Notices, and Labels in use.
+                This is the registry for accounts that are registered with the Local Contexts Hub. Visit an account's public page to contact or request to join, and to view public Projects, Open to Collaborate Notices, and Labels in use.
             </p>
             <p>
                 After you register on the Hub, you can request to join accounts for communities and institutions that you are already affiliated with. <strong>If you wish to collaborate with a community or institution you are not affiliated with, you will connect with them through Projects.</strong> You do not need to join their account.

--- a/templates/accounts/registry.html
+++ b/templates/accounts/registry.html
@@ -178,7 +178,7 @@
 
     {% if not items %}
         <div class="dashcard w-100 center-text mt-16 mb-16">
-            <h2>There are no public accounts by that name.</h2>
+            <p class="bold">There are no public accounts by that name.</p>
         </div>
     {% endif %}
 

--- a/templates/accounts/select-account.html
+++ b/templates/accounts/select-account.html
@@ -32,7 +32,7 @@
                         <p class="mb-0 mt-0"><strong>Community Account</strong></p>
                         <div class="tooltip ml-8"><strong>i</strong>
                             <span class="tooltiptext">
-                                A community entity might be an Indigenous or local community’s Cultural Department; Tribal and Historical Preservation Office; Community Center; Preservation Office; Community Library, Archive, or Museum; Land Council; or Indigenous Rangers.
+                                A community may be represented by an entity such as an Indigenous or local community’s Cultural Department; Library, Archive, or Museum; Community Center; Tribal and Historic Preservation Office; Land Council or Corporation; or Indigenous Rangers.
                             </span>
                         </div>
                     </div>
@@ -63,7 +63,7 @@
                         <p class="mb-0 mt-0"><strong>Institution Account</strong></p>
                         <div class="tooltip ml-8"><strong>i</strong>
                             <span class="tooltiptext">
-                                An institution might be an archive, library, museum, historical society, gallery, data repository, university, or media production company. If you are an Indigenous institution, choose the community account.
+                                An institution could be an archive, library, museum, historical society, gallery, data repository, university, or media production company. If you are an Indigenous institution, a community account may be a better fit.
                             </span>
                         </div>
                     </div>
@@ -92,11 +92,6 @@
                 <div class="flex-this column w-80">
                     <div class="flex-this">
                         <p class="mb-0 mt-0"><strong>Researcher Account</strong></p>
-                        <div class="tooltip ml-8"><strong>i</strong>
-                            <span class="tooltiptext">
-                                An individual who carries out academic or scientific research independently or in an institution.
-                            </span>
-                        </div>
                     </div>
                     <p class="mb-0 mt-0">
                         An individual who carries out academic or scientific research independently or in an institution can create projects and generate Notices.
@@ -125,11 +120,11 @@
                         <p class="mb-0 mt-0"><strong>Service Provider Account</strong></p>
                         <div class="tooltip ml-8"><strong>i</strong>
                             <span class="tooltiptext">
-                                A Service Provider is an organization that offers platforms that can be used by customers/users to organize or share collections or data. This includes collections management systems, digital asset management systems, repositories, and databases.
+                                A service provider could be a collections management system, repository workflow platform, or information aggregator.
                             </span>
                         </div>
                     </div>
-                    <p class="mb-0 mt-0">Any organization that integrates Local Contexts Labels and Notices into their products.</p>
+                    <p class="mb-0 mt-0">An organization that integrates a connection to the Local Contexts Hub into their platforms to enable other account types to access their Labels and Notices.</p>
                 </div>
             </div>
         </div>

--- a/templates/partials/_member-requests.html
+++ b/templates/partials/_member-requests.html
@@ -1,8 +1,8 @@
 <div class="content-card-v2 content-card-space">
     <div class="mb-16">
         <small class="bold">
-            <a 
-                class="darkteal-text" 
+            <a
+                class="darkteal-text"
                 {% if community %}
                     href="{% url 'members' community.id %}"
                 {% endif %}
@@ -12,7 +12,7 @@
                 {% if service_provider %}
                     href="{% url 'service-provider-members' service_provider.id %}"
                 {% endif %}
-            >Members</a> 
+            >Members</a>
             <span class="grey-text"> >> Member {% if not service_provider %}Requests{% elif service_provider %}Invites{% endif %}</span>
         </small>
     </div>
@@ -30,41 +30,41 @@
                 <div>
                     <small class="grey-text bold">Request Sent: {{ join_request.date_sent }}</small>
                 </div>
-                
+
                 {% if member_role == 'admin' %}
                     <div class="flex-this dash-btn-container flex-end">
                         <div class="mt-0 mr-8">
-                            <a 
-                                class="primary-btn white-btn" 
+                            <a
+                                class="primary-btn white-btn"
                                 {% if community %}
-                                    href="{% url 'delete-join-request' community.id join_request.id %}" 
+                                    href="{% url 'delete-join-request' community.id join_request.id %}"
                                 {% endif %}
                                 {% if institution %}
-                                    href="{% url 'institution-delete-join-request' institution.id join_request.id %}" 
+                                    href="{% url 'institution-delete-join-request' institution.id join_request.id %}"
                                 {% endif %}
                             >Delete Request</a>
                         </div>
                         <div><a id="{{join_request.id}}" onclick="acceptJoinRequestModal(this)" class="primary-btn action-btn">Accept Request</a></div>
-                    </div>  
+                    </div>
                 {% endif %}
-                
+
                 <div id="acceptJoinRequestModal_{{join_request.id}}" class="modal hide">
                     <div class="modal-defaults add-member-modal flex-this column w-100">
-                    
+
                         <div class="flex-this flex-end close-modal-btn">
                             <div id="closeModal{{join_request.id}}" class="mr-8 primary-btn white-btn">Close <i class="fa fa-times" aria-hidden="true"></i></div>
                         </div>
                         <div class="w-100">
-                
-                            <h2 class="mt-0 primary-black-text">Accept a join request</h2>  
+
+                            <h2 class="mt-0 primary-black-text">Accept a join request</h2>
                             <p>
                                 To accept this new member, please select their responsibility below.
                             </p>
-                
+
                             <div class="w-100 flex-this column">
                                 <form method="POST" action="">
                                     {% csrf_token %}
-                        
+
                                     <div>
                                         <label>Responsibility</label><br>
                                         <select name="selected_role" class="w-100">
@@ -74,15 +74,15 @@
                                             <option>Editor</option>
                                             {% endif %}
                                             <option>Viewer</option>
-                                        </select> 
+                                        </select>
                                     </div>
 
-                                    <input 
-                                        type="hidden" 
-                                        value="{{join_request.id}}" 
+                                    <input
+                                        type="hidden"
+                                        value="{{join_request.id}}"
                                         name="join_request_id"
                                     >
-                                
+
                                     <div class="flex-this flex-end mt-16">
                                         <button class="primary-btn action-btn">Accept Request</button>
                                     </div>
@@ -91,7 +91,7 @@
                             </div>
 
                         </div>
-                
+
                     </div>
                 </div>
 
@@ -135,7 +135,7 @@
                     <div>
                         <p>
                             <span class="bold">Email:</span><i> {{ join_request.user_from.email }}</i>
-                        </p>                    
+                        </p>
                     </div>
                 {% endif %}
 
@@ -146,7 +146,7 @@
                             {% if join_request.role == 'admin' %} Administrator {% endif %}
                             {% if join_request.role == 'editor' %} Editor {% endif %}
                             {% if join_request.role == 'viewer' %} Viewer {% endif %}
-                        </i>                    
+                        </i>
                     </div>
                 {% endif %}
 
@@ -154,7 +154,7 @@
                     <div>
                         <p>
                             <span class="bold">Message:</span><i> {{ join_request.message }}</i>
-                        </p>                    
+                        </p>
                     </div>
                 {% endif %}
 
@@ -171,13 +171,13 @@
                 <div>
                     <small class="grey-text bold">Request Sent: {{ invite.created }}</small>
                 </div>
-                
+
                 {% if member_role == 'admin' %}
                     <div class="flex-this dash-btn-container flex-end">
                         <div class="mt-0 mr-8">
                             <a class="primary-btn white-btn" href="{% url 'delete-member-invite' invite.id %}">Cancel Invite</a>
                         </div>
-                    </div>  
+                    </div>
                 {% endif %}
 
             </div>
@@ -218,7 +218,7 @@
                     <div>
                         <p>
                             <span class="bold">Email:</span><i> {{ invite.receiver.email }}</i>
-                        </p>                    
+                        </p>
                     </div>
                 {% endif %}
 
@@ -237,7 +237,7 @@
                                 {% if invite.role == 'admin' %} Administrator {% endif %}
                                 {% if invite.role == 'editor' %} Editor {% endif %}
                                 {% if invite.role == 'viewer' %} Viewer {% endif %}
-                            </i>  
+                            </i>
                         </p>
                     </div>
                 {% endif %}
@@ -246,7 +246,7 @@
                     <div>
                         <p>
                             <span class="bold">Message:</span><i> {{ invite.message }}</i>
-                        </p>                    
+                        </p>
                     </div>
                 {% endif %}
 
@@ -254,4 +254,22 @@
 
         </section>
     {% endfor %}
+{% endif %}
+
+{% if not join_requests or not member_invites %}
+    <div class="dashcard w-100 center-text mt-16 mb-16">
+        <p class="center-text">
+            <strong>
+                {% if service_provider %}
+                    No invitations pending.
+                {% else %}
+                    No requests or invitations pending.
+                {% endif %}
+            </strong>
+            <br>
+            <small>
+                To invite someone to join this account, click "Add a New Member" on the member tab.
+            </small>
+        </p>
+    </div>
 {% endif %}

--- a/templates/partials/_notices.html
+++ b/templates/partials/_notices.html
@@ -2,8 +2,12 @@
 <div class="content-card content-card-space white-bg">
     <h2 class="mt-0">Notices</h2>
     <p class="mt-0 w-75">
-        Institutions and researchers can only generate Notices. Applying Notices allows institutions and researchers to engage, acknowledge, and make visible Indigenous interests in collections, information, and data. Notices are a precursor for communities to add their Labels to a project if they choose. <br><br>
-        We recommend beginning with the Open to Collaborate Notice, which you can download from this page without creating a Project. To apply the disclosure Notices, you will create a Project to describe the context.
+        {% if service_provider %}
+            A certified service provider has access to the Engagement Notice, the Open to Collaborate Notice. This Notice can be downloaded from this page and added to your website.
+        {% else %}
+            Institutions and researchers can only generate Notices. Applying Notices allows institutions and researchers to engage, acknowledge, and make visible Indigenous interests in collections, information, and data. Notices are a precursor for communities to add their Labels to a project if they choose. <br><br>
+            We recommend beginning with the Open to Collaborate Notice, which you can download from this page without creating a Project. To apply the disclosure Notices, you will create a Project to describe the context.
+        {% endif %}
     </p>
 </div>
 

--- a/templates/partials/_notices.html
+++ b/templates/partials/_notices.html
@@ -56,7 +56,7 @@
                         {% if urls %}
                             <a id="shareBtn" class="primary-btn">Share Notice <i class="fa-solid fa-share-nodes"></i></a>
                         {% else %}
-                            <a id="addURLBtn" class="primary-btn disabled-btn" title="Add a link in order to share the Notice.">Share <i class="fa-solid fa-share-nodes"></i></a>
+                            <a id="addURLBtn" class="primary-btn disabled-btn" title="Add a link to share the Notice.">Share <i class="fa-solid fa-share-nodes"></i></a>
                         {% endif %}
                     {% else %}
                         <a class="primary-btn disabled-btn" title="{% if not_approved_download_notice %}{{ not_approved_download_notice }}{% endif %}{% if is_sandbox %}{{ download_notice_on_sandbox }}{% endif %}">Download Notice <i class="fa-regular fa-arrow-down-to-line"></i></a>

--- a/templates/projects/projects.html
+++ b/templates/projects/projects.html
@@ -206,11 +206,15 @@
       </div>
 
     {% if not results and not items %}
-        <div class="w-100 center-text mt-16 mb-16" style="margin-top: 100px;">
-            <h2>There are no Projects yet</h2>
-            <h3>Let's create a Project!</h3>
-            <p>Click the button above to start.</p>
-        </div>  
+        <div class="dashcard w-100 center-text mt-16 mb-16">
+            <p class="center-text">
+                <strong>There are no Projects yet.</strong>
+                <br>
+                <small>
+                    Let's create a Project! Click the button above to start.
+                </small>
+            </p>
+        </div>
     {% endif %}
 
     {% include 'snippets/pagination.html' %}

--- a/templates/serviceproviders/create-service-provider.html
+++ b/templates/serviceproviders/create-service-provider.html
@@ -18,9 +18,10 @@
     </div>
 
     <p class="mb-0 mt-0">
-        The service provider details provided below will default to a public display in the Local Contexts Registry.
-        Providing your details will give consent to publicly being listed on the Registry.
-        Read more about our privacy standards <a class="default-a" href="https://localcontexts.org/privacy-policy/" target="_blank" rel="noopener">here <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>
+        A <a class="default-a" href="https://localcontexts.org/members-subscribers-and-service-providers/" target="_blank" rel="noopener">certification program</a> for service provider accounts was launched in October 2024. After you submit this form, we will reach out to you and any contacts you indicate below to discuss the certification process.
+    </p>
+    <p class="mb-0">
+        The service provider name, location, and description will be displayed in the Local Contexts Registry. Read more about our privacy standards <a class="default-a" href="https://localcontexts.org/privacy-policy/" target="_blank" rel="noopener">here<i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i></a>.
     </p>
 
 
@@ -45,17 +46,10 @@
             </label>
             {{ form.name }}
 
-            {% if form.errors %}
-                <div class="w-100 mt-1p">
-                    {% for field_name, errors in form.errors.items %}
-                        <div class="red-text">
-                            <strong>{{ field_name }}</strong>:
-                            {% for error in errors %}
-                                <span>{{ error }}</span>
-                            {% endfor %}
-                        </div>
-                    {% endfor %}
-                </div>
+            {% if form.name.errors %}
+                <div class="msg-red w-50"><small>{{ form.name.errors.as_text }}</small></div>
+            {% elif form.non_field_errors %}
+                <div class="msg-red w-50"><small>{{ form.non_field_errors.as_text }}</small></div>
             {% endif %}
 
             {% include 'partials/_alerts.html' %}
@@ -64,9 +58,12 @@
         <div class="w-100 mt-8">
             <label for="description">Service Provider Description<span class="orange-text required-label" title="">*</span></label>
             <div class="tooltip"><strong>i</strong>
-                <span class="tooltiptext">A service provider description allows you to share key public information about your organization with other users on the Hub.</span>
+                <span class="tooltiptext">A brief description of your organization/platform to share with others on the Hub.</span>
             </div>
             {{ form.description }}
+            {% if form.description.errors %}
+                <div class="msg-red w-50"><small>{{ form.description.errors.as_text }}</small></div>
+            {% endif %}
             <small id="charCount" class="block text-align-right">200/200</small>
         </div>
 


### PR DESCRIPTION
- Content updates from doc.
    - CU-8689exv4q: updated select account content
    - CU-8688wn3rd: Updated Notices content page for SP
    - CU-8688wn8m5: Updated Notice error message content
    - CU-86890yuz8: no results cards updated
    - CU-8688vk435: prep step content updated for SP
    - CU-8688vnfvn: Create account content updated
    - CU-8688xv8pf: API Key settings content updated
    - CU-8688w5419: Minor registry content update
- Small UI changes for "No Results cards" to match across the Hub:

### Before:
#### Registry
![image](https://github.com/user-attachments/assets/4ef8c873-9d2e-41bb-9085-9167c970b54c)
#### User Invitations
![image](https://github.com/user-attachments/assets/914871bc-c0f1-4fcd-b10c-2da7678bf7de)
#### Dashboard
![image](https://github.com/user-attachments/assets/553b5050-fdfb-47b5-9379-a410d093ff2f)
#### Projects Page
![image](https://github.com/user-attachments/assets/a19ce7b0-56b3-4859-a09b-92ed0f1bce25)
---
### After
![image](https://github.com/user-attachments/assets/b967269f-78b8-42c3-b4c3-7c4a2d4e7db5)
![image](https://github.com/user-attachments/assets/d4500a85-ae58-47fb-8487-a2f3fb9c466c)
