### PR TITLE
Misc SP Updates

### DIFF
--- a/accounts/decorators.py
+++ b/accounts/decorators.py
@@ -50,7 +50,7 @@ def zero_account_user(view_func):
                 messages.add_message(
                     request,
                     messages.INFO,
-                    "Try creating account from Create an account button.")
+                    "Try creating an account using the Create an account button.")
                 return redirect('dashboard')
             else:
                 return view_func(request, *args, **kwargs)

--- a/serviceproviders/forms.py
+++ b/serviceproviders/forms.py
@@ -32,11 +32,9 @@ class CreateServiceProviderForm(forms.ModelForm):
 
 class UpdateServiceProviderForm(forms.ModelForm):
 
-    show_connections = forms.BooleanField(required=False)
-
     class Meta:
         model = ServiceProvider
-        fields = ['image', 'description', 'website', 'documentation', 'show_connections']
+        fields = ['image', 'description', 'website', 'documentation']
         widgets = {
             'description': forms.Textarea(attrs={'class': 'w-100', 'rows': 3,}),
             'image': forms.ClearableFileInput(

--- a/serviceproviders/templatetags/custom_service_provider_tags.py
+++ b/serviceproviders/templatetags/custom_service_provider_tags.py
@@ -11,21 +11,25 @@ register = template.Library()
 # Count of Accounts connected to Service Provider
 @register.simple_tag
 def connections_count(service_provider):
-    institutions = ServiceProviderConnections.objects.filter(
-            service_provider=service_provider
-        ).annotate(institution_count = Count('institutions')).values_list(
-            'institution_count', flat=True
-        ).first()
-    communities = ServiceProviderConnections.objects.filter(
-            service_provider=service_provider
-        ).annotate(community_count = Count('communities')).values_list(
-            'community_count', flat=True
-        ).first()
-    researchers = ServiceProviderConnections.objects.filter(
-            service_provider=service_provider
-        ).annotate(researcher_count = Count('researchers')).values_list(
-            'researcher_count', flat=True
-        ).first()
-    totals = institutions + communities + researchers
+    try:
+        institutions = ServiceProviderConnections.objects.filter(
+                service_provider=service_provider
+            ).annotate(institution_count = Count('institutions')).values_list(
+                'institution_count', flat=True
+            ).first()
+        communities = ServiceProviderConnections.objects.filter(
+                service_provider=service_provider
+            ).annotate(community_count = Count('communities')).values_list(
+                'community_count', flat=True
+            ).first()
+        researchers = ServiceProviderConnections.objects.filter(
+                service_provider=service_provider
+            ).annotate(researcher_count = Count('researchers')).values_list(
+                'researcher_count', flat=True
+            ).first()
+        totals = institutions + communities + researchers
 
-    return totals
+        return totals
+
+    except:
+        return 0

--- a/serviceproviders/urls.py
+++ b/serviceproviders/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
 
     # Settings
     path('update/<str:pk>/', views.update_service_provider, name="update-service-provider"),
+    path('preferences/<str:pk>/', views.account_preferences, name="preferences-service-provider"),
     path('api-key/<str:pk>/', views.api_keys, name="service-provider-api-key"),
 
     # Public view

--- a/serviceproviders/views.py
+++ b/serviceproviders/views.py
@@ -552,7 +552,7 @@ def account_preferences(request, pk):
                 request, messages.SUCCESS, 'Your preferences have been updated!'
             )
 
-            return redirect("preferences-institution", service_provider.id)
+            return redirect("preferences-service-provider", service_provider.id)
 
         context = {
             'member_role': member_role,

--- a/serviceproviders/views.py
+++ b/serviceproviders/views.py
@@ -532,6 +532,40 @@ def update_service_provider(request, pk):
 
 @login_required(login_url="login")
 @member_required(roles=["admin", "editor"])
+def account_preferences(request, pk):
+    try:
+        service_provider = get_service_provider(pk)
+        member_role = check_member_role(request.user, service_provider)
+
+        if request.method == "POST":
+
+            # Set Show/Hide account in Service Provider connections
+            if request.POST.get('show_connections') == 'on':
+                service_provider.show_connections = True
+                service_provider.save()
+
+            elif request.POST.get('show_connections') == None:
+                service_provider.show_connections = False
+                service_provider.save()
+
+            messages.add_message(
+                request, messages.SUCCESS, 'Your preferences have been updated!'
+            )
+
+            return redirect("preferences-institution", service_provider.id)
+
+        context = {
+            'member_role': member_role,
+            'service_provider': service_provider,
+        }
+        return render(request, 'account_settings_pages/_preferences.html', context)
+
+    except:
+        raise Http404()
+
+
+@login_required(login_url="login")
+@member_required(roles=["admin", "editor"])
 def api_keys(request, pk):
     service_provider = get_service_provider(pk)
     member_role = check_member_role(request.user, service_provider)

--- a/templates/account-settings-base.html
+++ b/templates/account-settings-base.html
@@ -59,7 +59,7 @@
                 </a>
 
                 <!-- Account Preferences -->
-                <a href="{% if community %}{% url 'preferences-community' community.id %}{% endif %}{% if institution %}{% url 'preferences-institution' institution.id %}{% endif %}{% if researcher %}{% url 'preferences-researcher' researcher.id %}{% endif %}">
+                <a href="{% if community %}{% url 'preferences-community' community.id %}{% endif %}{% if institution %}{% url 'preferences-institution' institution.id %}{% endif %}{% if researcher %}{% url 'preferences-researcher' researcher.id %}{% endif %}{% if service_provider %}{% url 'preferences-service-provider' service_provider.id %}{% endif %}">
                     <div
                         class="flex-this side-nav-item {% if '/preferences/' in request.path %} selected {% else %} grey-text {% endif %}"
                     >

--- a/templates/account_settings_pages/_preferences.html
+++ b/templates/account_settings_pages/_preferences.html
@@ -36,7 +36,7 @@
         <div class="flex-this space-between border-top-bottom-grey w-100 align-center pad-top-1 padding-bottom-1">
             <div class="w-90">
                 <h4 class="mt-15 mb-0">Show Connections in Public View Page</h4>
-                <p class="font-size-14 mt-8">Allow other Hub accounts that have connected to your account to be displayed on your <a class="default-a" href="{% url 'public-service-provider' service_provider.id%}">Public View Page</a> in the Registry.</p>
+                <p class="font-size-14 mt-8">Allow other Hub accounts that have connected to your account to be displayed on your <a class="default-a" href="{% url 'public-service-provider' service_provider.id%}">Public Page</a> in the Registry.</p>
             </div>
             <div>
                 <input

--- a/templates/account_settings_pages/_preferences.html
+++ b/templates/account_settings_pages/_preferences.html
@@ -10,24 +10,45 @@
 <form method="POST">
     {% csrf_token %}
 
-    <!-- Show/Hide Connections -->
-    <div class="flex-this space-between border-top-bottom-grey w-100 align-center pad-top-1 padding-bottom-1">
-        <div>
-            <h4 class="mt-15 mb-0">Show Account in Service Provider Connections</h4>
-            <p class="font-size-14 mt-8">Allow your account to be included on a Service Provider's public Registry page when you connect to their account.</p>
+    {% if not service_provider %}
+        <!-- Show/Hide Hub Account in SP Connections -->
+        <div class="flex-this space-between border-top-bottom-grey w-100 align-center pad-top-1 padding-bottom-1">
+            <div class="w-90">
+                <h4 class="mt-15 mb-0">Show Account in Service Provider Connections</h4>
+                <p class="font-size-14 mt-8">Allow your account to be included on a Service Provider's public Registry page when you connect to their account.</p>
+            </div>
+            <div>
+                <input
+                    class="toggle"
+                    type="checkbox"
+                    name="show_sp_connection"
+                    {% if researcher and researcher.show_sp_connection %}checked
+                    {% elif community and community.show_sp_connection %}checked
+                    {% elif institution and institution.show_sp_connection %}checked
+                    {% endif %}
+                >
+            </div>
         </div>
-        <div>
-            <input
-                class="toggle"
-                type="checkbox"
-                name="show_sp_connection"
-                {% if researcher and researcher.show_sp_connection %}checked
-                {% elif community and community.show_sp_connection %}checked
-                {% elif institution and institution.show_sp_connection %}checked
-                {% endif %}
-            >
+    {% endif %}
+
+    {% if service_provider %}
+        <!-- Show/Hide SP Connections in Registry -->
+        <div class="flex-this space-between border-top-bottom-grey w-100 align-center pad-top-1 padding-bottom-1">
+            <div class="w-90">
+                <h4 class="mt-15 mb-0">Show Connections in Public View Page</h4>
+                <p class="font-size-14 mt-8">Allow other Hub accounts that have connected to your account to be displayed on your <a class="default-a" href="{% url 'public-service-provider' service_provider.id%}">Public View Page</a> in the Registry.</p>
+            </div>
+            <div>
+                <input
+                    class="toggle"
+                    type="checkbox"
+                    name="show_connections"
+                    {% if service_provider.show_connections %}checked
+                    {% endif %}
+                >
+            </div>
         </div>
-    </div>
+    {% endif %}
 
     <div>
         <button id="savePreferences" class="primary-btn action-btn mt-2p">Save changes</button>

--- a/templates/account_settings_pages/_update-account.html
+++ b/templates/account_settings_pages/_update-account.html
@@ -144,14 +144,6 @@
                 </div>
             {% endif %}
         </div>
-
-        <!-- Show/Hide Connections -->
-        <div class="mt-16 mb-8">
-            {{ update_form.show_connections }} <label for="show_connections">Show connections in Registry</label>
-        </div>
-        {% if update_form.show_connections.errors %}
-            <div class="msg-red w-50"><small>{{ update_form.show_connections.errors.as_text }}</small></div>
-        {% endif %}
     {% endif %}
 
     <!-- Location -->

--- a/templates/accounts/select-account.html
+++ b/templates/accounts/select-account.html
@@ -130,7 +130,7 @@
         </div>
     </div>
 
-    <p>Create a new account or Join an existing account</p>
+    <p>Create a new account or Join an existing account. Not sure which account type to create? <a class="default-a">Contact us</a>.</p>
     <div class="flex-this gap-1">
         <a id="create-account" class="primary-btn disabled-btn">Create</a>
         <a id="join-account" class="primary-btn disabled-btn">Join</a>

--- a/templates/accounts/select-account.html
+++ b/templates/accounts/select-account.html
@@ -130,7 +130,7 @@
         </div>
     </div>
 
-    <p>Create a new account or Join an existing account. Not sure which account type to create? <a class="default-a">Contact us</a>.</p>
+    <p>Create a new account or Join an existing account. Not sure which account type to create? <a class="default-a" href="mailto:support@localcontexts.org">Contact us</a>.</p>
     <div class="flex-this gap-1">
         <a id="create-account" class="primary-btn disabled-btn">Create</a>
         <a id="join-account" class="primary-btn disabled-btn">Join</a>

--- a/templates/partials/_connections.html
+++ b/templates/partials/_connections.html
@@ -101,3 +101,21 @@
         });
     </script>
 {% endif %}
+
+{% if not institutions and not researchers and not communities %}
+    <div class="dashcard w-100 center-text mt-16" style="margin-bottom:200px;">
+        <p class="center-text">
+            <strong>There are no connections yet.</strong>
+            <br>
+            <small>
+                {% if service_provider %}
+                    Connections will appear here as other Hub accounts connect to your platform{% if not service_provider.is_certified %} once your account is certified{% endif %}.
+                {% elif community %}
+                    Apply Labels to a shared project to establish connections.
+                {% else %}
+                    Notify a community of a project or add other accounts as contributors on a Project to establish connections.
+                {% endif %}
+            </small>
+        </p>
+    </div>
+{% endif %}

--- a/templates/public.html
+++ b/templates/public.html
@@ -408,8 +408,8 @@
                         </ul>
                     </div>
                 </div>
-            {% endif %}
-        </div>
+            </div>
+        {% endif %}
     {% endif %}
 
     {% if researcher %}


### PR DESCRIPTION
Misc SP updates based on our discussions

- #8689kbeef: Add content to create account page if users are unsure of which account to create
![image](https://github.com/user-attachments/assets/77186206-8b54-42d9-8f8c-c49f9cdfd6c0)
---
- #8689kbe8d: Move show connections SP setting to preferences page
![image](https://github.com/user-attachments/assets/ad3da358-52df-457b-9a49-f9737c6e84ca)
---
- #8689kbb95: connections section bug in SP public view page
Fixed bug where the connections section was not showing in the card on the public view page when no OTC notices were added:
Before:
![image](https://github.com/user-attachments/assets/fc082db5-0606-4e2f-a270-485056126b4d)
After:
![image](https://github.com/user-attachments/assets/14313c3f-7836-4110-bbc9-1efabe1c7a45)
---
- #8689k5g0k: uncertified SP connections count error
Fixed bug where an uncertified SP account was not loading due to connections count tag.
---
- #8689k5xfk: Add no results card to connections pages for all accounts when no connections are made.