### PR TITLE
#8689c0ert Remove User From Account Bug & Refactoring

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path('update-profile/', views.update_profile, name='update-profile'),
     path('confirm-email/<uidb64>/<token>/', views.confirm_email, name='confirm_email'),
     path('manage/', views.manage_organizations, name='manage-orgs'),
+    path('leave-account/<str:account_type><int:account_id>', views.leave_account, name="leave-account"),
     path('link-account/', views.link_account, name='link-account'),
     path('change-password/', views.change_password, name='change-password'),
     path('deactivate/', views.deactivate_user, name='deactivate-user'),

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -30,8 +30,8 @@ urlpatterns = [
     path('confirm-email/<uidb64>/<token>/', views.confirm_email, name='confirm_email'),
     path('manage/', views.manage_organizations, name='manage-orgs'),
     path(
-        'leave-account/<str:account_type><int:account_id>', 
-        views.leave_account, 
+        'leave-account/<str:account_type><int:account_id>',
+        views.leave_account,
         name='leave-account'
         ),
     path('link-account/', views.link_account, name='link-account'),

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -29,7 +29,11 @@ urlpatterns = [
     path('update-profile/', views.update_profile, name='update-profile'),
     path('confirm-email/<uidb64>/<token>/', views.confirm_email, name='confirm_email'),
     path('manage/', views.manage_organizations, name='manage-orgs'),
-    path('leave-account/<str:account_type><int:account_id>', views.leave_account, name="leave-account"),
+    path(
+        'leave-account/<str:account_type><int:account_id>', 
+        views.leave_account, 
+        name='leave-account'
+        ),
     path('link-account/', views.link_account, name='link-account'),
     path('change-password/', views.change_password, name='change-password'),
     path('deactivate/', views.deactivate_user, name='deactivate-user'),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -465,9 +465,9 @@ def leave_account(request, account_type, account_id):
     if account:
         # Check if the user holds a role in the account
         if (request.user in account.admins.all() or
-            request.user in account.editors.all() or
-            request.user in account.viewers.all()):
-            
+                request.user in account.editors.all() or
+                request.user in account.viewers.all()):
+
             remove_user_from_account(request.user, account)
         else:
             # Return a 403 Forbidden response if the user does not hold a role in the account

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -449,6 +449,7 @@ def manage_organizations(request):
         }
     )
 
+
 @login_required(login_url='login')
 def leave_account(request, account_type, account_id):
     # Define a dictionary to map account types to their respective models
@@ -463,8 +464,8 @@ def leave_account(request, account_type, account_id):
 
     if account:
         # Check if the user holds a role in the account
-        if (request.user in account.admins.all() or 
-            request.user in account.editors.all() or 
+        if (request.user in account.admins.all() or
+            request.user in account.editors.all() or
             request.user in account.viewers.all()):
             
             remove_user_from_account(request.user, account)

--- a/communities/views.py
+++ b/communities/views.py
@@ -21,7 +21,7 @@ from localcontexts.utils import dev_prod_or_local
 from projects.utils import *
 from helpers.utils import *
 from tklabels.utils import data as labels_data
-from accounts.utils import get_users_name
+from accounts.utils import get_users_name, remove_user_from_account
 from notifications.utils import *
 from helpers.downloads import download_labels_zip
 from helpers.emails import *
@@ -426,18 +426,8 @@ def delete_join_request(request, pk, join_id):
 def remove_member(request, pk, member_id):
     community = get_community(pk)
     member = User.objects.get(id=member_id)
-    # what role does member have
-    # remove from role
-    if member in community.admins.all():
-        community.admins.remove(member)
-    if member in community.editors.all():
-        community.editors.remove(member)
-    if member in community.viewers.all():
-        community.viewers.remove(member)
-
-    # remove community from userAffiliation instance
-    affiliation = UserAffiliation.objects.get(user=member)
-    affiliation.communities.remove(community)
+    
+    remove_user_from_account(member, community)
 
     # Delete join request for this community if exists
     if JoinRequest.objects.filter(user_from=member, community=community).exists():

--- a/institutions/views.py
+++ b/institutions/views.py
@@ -11,6 +11,7 @@ from projects.utils import *
 from helpers.utils import *
 from notifications.utils import *
 from .utils import *
+from accounts.utils import remove_user_from_account
 
 from .models import *
 from projects.models import *
@@ -461,18 +462,8 @@ def delete_join_request(request, pk, join_id):
 def remove_member(request, pk, member_id):
     institution = get_institution(pk)
     member = User.objects.get(id=member_id)
-    # what role does member have
-    # remove from role
-    if member in institution.admins.all():
-        institution.admins.remove(member)
-    if member in institution.editors.all():
-        institution.editors.remove(member)
-    if member in institution.viewers.all():
-        institution.viewers.remove(member)
-
-    # remove institution from userAffiliation instance
-    affiliation = UserAffiliation.objects.prefetch_related('institutions').get(user=member)
-    affiliation.institutions.remove(institution)
+    
+    remove_user_from_account(member, institution)
 
     # Delete join request for this institution if exists
     if JoinRequest.objects.filter(user_from=member, institution=institution).exists():

--- a/templates/snippets/modals/leave-account-modal.html
+++ b/templates/snippets/modals/leave-account-modal.html
@@ -24,10 +24,10 @@
                 <a 
                     id="leaveAccountBtn" 
                     {% if community %} 
-                        href="{% url 'remove-member' community.id request.user.id %}" 
+                        href="{% url 'leave-account' 'community' community.id %}" 
                     {% endif %}
                     {% if institution %} 
-                        href="{% url 'remove-institution-member' institution.id request.user.id %}" 
+                        href="{% url 'leave-account' 'institution' institution.id %}" 
                     {% endif %}
                     class="primary-btn white-btn mr-1p"
                 >Yes, leave account</a>    


### PR DESCRIPTION
Issue:
- Going to profile -> accounts and then trying to leave an account, the user would hit a 403 error because the `remove_member` views in `communities/views.py` and `institutions/views.py` at some point got a decorator which only allowed admins of that account to remove members.

Solution:
- Create a `leave_account` view in `accounts/views.py` where the user could remove themselves from an account that they did not create but were just a member of.
