### PR TITLE
#86895nwwj Update copyright in Hub footer and email footers

### DIFF
--- a/templates/partials/footers/_auth-footer.html
+++ b/templates/partials/footers/_auth-footer.html
@@ -27,7 +27,7 @@
                         <h4 class="underline bold w-100"> Creative Commons License</h4>
                         <p>
                             This work is licensed under a Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License.<br>
-                            Traditional Knowledge and Biocultural Labels, Notices and Template Text © 2015-{% now "Y" %} Local Contexts. All Rights Reserved.<br><br>
+                            All Labels and Notices Icons and Template Texts © 2010-{% now "Y" %} Local Contexts. All Rights Reserved.<br><br>
 
                             All images and marks are subject to copyright and trademark protection.<br>
                             All educational material is being shared collaboratively but does not constitute binding legal advice.<br>


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/86895nwwj)**

**Description:**
Our copyright should be updated from the following:

> Traditional Knowledge (TK) and Biocultural (BC) Labels, Notices and Template Text © 2010 - 2024 Local Contexts. All Rights Reserved.

New text:

> All Labels and Notices Icons and Template Texts © 2010 - 2024 Local Contexts. All Rights Reserved.

**Solution:**
- Updated the auth Footer in the HUB 
- Updated the  email templates on Mailgun

**Before:**
<img width="1439" alt="Copyright(before)" src="https://github.com/user-attachments/assets/f80bec0b-97e1-423f-ade0-fd5fc3ffed0f">

**After:**
<img width="1481" alt="Copyright(after)" src="https://github.com/user-attachments/assets/63ec2f9b-2136-4cbc-a427-62828b2279f3">
