### PR TITLE
#8689eh6h8 Updated the access of subscription

### DIFF
--- a/accounts/decorators.py
+++ b/accounts/decorators.py
@@ -1,7 +1,4 @@
 from django.shortcuts import redirect
-from django.contrib import messages
-from researchers.utils import is_user_researcher
-from localcontexts.utils import dev_prod_or_local
 
 
 def unauthenticated_user(view_func):
@@ -12,49 +9,6 @@ def unauthenticated_user(view_func):
         if request.user.is_authenticated:
             return redirect('dashboard')
         else:
-            return view_func(request, *args, **kwargs)
-
-    return wrapper_func
-
-
-def zero_account_user(view_func):
-
-    def wrapper_func(request, *args, **kwargs):
-        if dev_prod_or_local(request.get_host()) == "SANDBOX":
-            messages.add_message(
-                    request,
-                    messages.INFO,
-                    "This page is not available on the sandbox site. ")
-            return redirect('login')
-        if request.user.is_authenticated:
-            user = request.user
-            affiliations = (
-                user.user_affiliations.prefetch_related(
-                    "institutions",
-                    "service_providers",
-                )
-                .all()
-            )
-            has_institutions = any(
-                affiliation.institutions.exists()
-                for affiliation in affiliations
-            )
-            has_service_provider = any(
-                affiliation.service_providers.exists()
-                for affiliation in affiliations
-            )
-            if (
-                has_institutions or has_service_provider or
-                is_user_researcher(user)
-            ):
-                messages.add_message(
-                    request,
-                    messages.INFO,
-                    "Try creating an account using the Create an account button.")
-                return redirect('dashboard')
-            else:
-                return view_func(request, *args, **kwargs)
-        elif not request.user.is_authenticated:
             return view_func(request, *args, **kwargs)
 
     return wrapper_func

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -58,7 +58,7 @@ from institutions.models import Institution
 from researchers.models import Researcher
 from serviceproviders.models import ServiceProvider
 
-from .decorators import unauthenticated_user, zero_account_user
+from .decorators import unauthenticated_user
 from maintenance_mode.decorators import force_maintenance_mode_off
 
 
@@ -851,7 +851,6 @@ def newsletter_unsubscription(request, emailb64):
         return redirect("login")
 
 
-@zero_account_user
 def subscription_inquiry(request):
     form = SubscriptionForm(request.POST or None)
     form.fields.pop('account_type', None)


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8689eh6h8)**

**Description:**
Currently, in the top navigation Subscriptions is only clickable when the user is anonymous (not logged in) or when a user has not created any accounts.

![image](https://github.com/user-attachments/assets/996de679-4c57-4e80-82d1-78e19582d000)

A logged in user should be able to use/submit the subscription form, even if they already have an account with an active subscription. This is in case they are a part of multiple organizations and are not sure what kind of account they need to create.

**Solution:**
- Removed the decorator of zero_account_user
- Removed the definition of he same decorator function 

**Before:**

https://github.com/user-attachments/assets/633dd7d2-74af-49e7-ae31-c2cca1c1db01

**After:**

**lead_data:**
`{'hubId': '', 'companyName': '', 'email': '[sabeen.ammar+123@localcontexts.org](mailto:sabeen.ammar+123@localcontexts.org)', 'firstname': 'Test', 'lastName': 'Test', 'oppName': '', 'inquiryType': 'Subscription', 'isBusinessTrue': True}`

https://github.com/user-attachments/assets/1bcd058c-1efd-4506-ba7d-85ea081ca7b9

