### PR TITLE
#8689u5wnm Redirect back to the Project after Label application

### DIFF
--- a/communities/views.py
+++ b/communities/views.py
@@ -34,7 +34,8 @@ from .decorators import member_required
 from .utils import *
 
 # pdfs
-from django.http import HttpResponse, Http404
+from django.http import HttpResponse, Http404, HttpResponseRedirect
+from django.urls import reverse
 from django.template.loader import get_template
 from xhtml2pdf import pisa
 
@@ -1248,7 +1249,8 @@ def apply_labels(request, pk, project_uuid):
                 project_id=project.id
             )
 
-            return redirect('apply-labels', community.id, project.unique_id)
+            # return redirect('community-project-actions', community.id, project.unique_id)
+            return HttpResponseRedirect(f"{reverse('community-project-actions', args=[community.id, project.unique_id])}#labels")
 
     context = {
         'member_role': member_role,

--- a/templates/partials/_project-actions.html
+++ b/templates/partials/_project-actions.html
@@ -1225,6 +1225,8 @@
     </div>
 {% endif %}
 
+{% include 'partials/_alerts.html' %}
+
 <script>
     var notification_count = {{ subscription.notification_count }};
 </script>


### PR DESCRIPTION
Before:
When a community went to apply Labels to a Project, they would be redirected back to the apply Labels page, which was a bit inconvenient and confusing for users.

After:
After a community applies Labels to a Project, they are redirected to the Project actions page, under the Label header so they can review the Labels they have added to the Project. It also now shows an alert that indicates Labels have been applied.


https://github.com/user-attachments/assets/2cc1b23e-3a38-4444-b871-47f22910c0be

