### PR TITLE
#8689zbgd9 Memberships: registry

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -633,7 +633,7 @@ def registry(request, filtertype=None):
             if filtertype == "community-all":
                 cards = c
             elif filtertype == "community-members":
-                cards = c.filter(is_approved=True)
+                cards = c.filter(is_member=True)
             elif filtertype == "institution-all":
                 cards = i
             elif filtertype == "institution-subscribed":

--- a/localcontexts/admin.py
+++ b/localcontexts/admin.py
@@ -1499,7 +1499,7 @@ admin_site.register(BCLabel, BCLabelAdmin)
 class CommunityAdmin(admin.ModelAdmin):
     form = CommunityModelForm
     list_display = (
-        'community_name', 'community_creator', 'contact_name', 'contact_email', 'is_approved',
+        'community_name', 'community_creator', 'contact_name', 'contact_email', 'is_member',
         'created', 'country'
     )
     search_fields = (

--- a/templates/partials/infocards/_community-card.html
+++ b/templates/partials/infocards/_community-card.html
@@ -15,8 +15,8 @@
         <div class="flex-this column w-50">
             <div class="subscribed-icon-wrapper">
                 <h3 class="dashcard-h3 darkteal-text">{{ community.community_name }}</h3>
-                {% if community.is_approved %}
-                    <i class="fa-sharp fa-solid fa-circle-check subscribed-icon fa-lg" title="Active"></i>
+                {% if community.is_member %}
+                    <i class="fa-sharp fa-solid fa-circle-check subscribed-icon fa-lg" title="Member"></i>
                 {% endif %}
             </div>
             <div>

--- a/templates/public.html
+++ b/templates/public.html
@@ -38,7 +38,7 @@
                             {% join_request_comm community.id request.user as request_exists %}
                             {% if request_exists or community in user_communities %}
                                 <div class="primary-btn disabled-btn">Request sent <i class="fa fa-check" aria-hidden="true"></i></div>
-                            {% else %}
+                            {% elif community.is_member %}
                                 <div class="mt-8 mb-8">
                                     <a id="openRequestToJoinModalBtn" class="default-a">Request to join</a>
                                 </div>
@@ -92,7 +92,7 @@
             <div class="flex-this column dashcard-text-container">
                 <div class="subscribed-icon-wrapper">
                     <h3 class="dashcard-h3">{{ community }}</h3>
-                    {% if community and community.is_approved %}
+                    {% if community and community.is_member %}
                         <i class="fa-sharp fa-solid fa-circle-check subscribed-icon fa-lg" title="Active"></i>
                     {% endif %}
                 </div>


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8689zbgd9)**

**Description:**
Currently in the registry, communities only appear if they have been confirmed, or when the is_approved  flag is set to True . 

This will need to be changed to show all created communities on the hub, but communities that are members will have an orange checkmark next to their names, like with subscriptions. 

Communities that are NOT members (will need to confirm this):
When a user goes to the public account page of that community, they will be able to contact the community but not Request to join , this option will be disabled.

**Solution:**
- Updated the query to fetch on member communities to show on registry 
- Updated the `_community-card` template to include the orange checkmark next to member communities name
- Updated the `public` template to include orange checkmark and hide request to join button


**Before:**

https://github.com/user-attachments/assets/c16d6a97-37ae-4377-bd1e-b458099f9845


**After:**

https://github.com/user-attachments/assets/ff301243-0fd7-4d64-b1ae-a67485256f63
