### PR TITLE
#86897hg9q Updated UI of sub projects

### DIFF
--- a/localcontexts/static/css/main.css
+++ b/localcontexts/static/css/main.css
@@ -1845,3 +1845,7 @@ i[data-tooltip]:hover:after {
     background-color: #EF6C00;
     color: #fff;
 }
+
+.right-auto {
+    right: auto !important 
+}

--- a/templates/partials/_project-actions.html
+++ b/templates/partials/_project-actions.html
@@ -84,6 +84,17 @@
                     </p></div>
                 </div>
             {% endif %}
+            {% if project.source_project_uuid %}
+                <div class="flex-this">
+                    <div class="project-left-sidebar"><p class="bold">Level</p></div>
+                    <div>
+                        <p>
+                            <i class="fa-regular fa-diagram-subtask mr-5"></i>Sub Project
+                        
+                        </p>
+                    </div>
+                </div>
+            {% endif %}
         </div>
 
         <div>

--- a/templates/projects/project-overview.html
+++ b/templates/projects/project-overview.html
@@ -13,7 +13,19 @@
                         href="{% url 'view-project' project.unique_id %}" 
                     {% endif %}
                 >
-                    {{ project.title }}
+                    <div class="flex-this row">
+                        {% if project.source_project_uuid %}
+                        <div class="btn-with-helptext mr-2p">
+                            <i class="fa-regular fa-diagram-subtask"></i>
+                            <span class="btn-help-text mr-55p right-auto">
+                            This is a Sub project.
+                            </span>
+                        </div>
+                        {% endif %}
+                        <div>  
+                            {{ project.title }}
+                        </div>
+                    </div>
                 </a>
             </td>
             <td>


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/86897hg9q)**

**Description:**
Problem: Users are finding it difficult to identify which projects are sub/source projects on the project view page
Solution: Sub Project Icons have been added to sub projects on the project gallery page and project view page

Use the icons way of differentiating sub-Projects only in the Projects Board.

**Solution:**
- Updated `_project-actions` template to include the new meta data field "Level"
- Updated `project-overview` template to include the icon and tooltip for subprojects
- Updated `main.css` to include the added styles


**Before:**
<img width="1449" alt="Screenshot 2024-10-16 at 2 19 20 PM" src="https://github.com/user-attachments/assets/6079f656-59d7-4a7d-8ee7-9da0d9db10e7">

**After:**
<img width="1507" alt="Screenshot 2024-10-16 at 1 14 42 PM" src="https://github.com/user-attachments/assets/0c8f1116-04bb-4f01-8df5-8deb2427de63">
