### PR TITLE
#8689agzvf UI Fix: Request to Join modal message box

### DIFF
--- a/communities/forms.py
+++ b/communities/forms.py
@@ -174,5 +174,5 @@ class JoinRequestForm(forms.ModelForm):
         fields = ['role', 'message']
         widgets = {
             'role': forms.Select(attrs={'class': 'w-100'}),
-            'message': forms.Textarea(attrs={'rows': 3, 'class':'w-100'}),
+            'message': forms.Textarea(attrs={'rows': 3, 'class':'w-100', 'style': 'resize: vertical;'}),
         }


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8689agzvf)**

**Description:**
The message box allows for the user to adjust the size of the message box in the bottom right corner. This should be limited to the width of the modal. The height works well (having the modal height grow with the message box is the expected behavior. The width should be locked at the original width so it doesn't go beyond the modal box.

![image](https://github.com/user-attachments/assets/00ae6525-5d56-4eaa-9eaf-58380216a09c)


**Solution:**
- Updated the resizing property of `JoinRequestForm` which translates into join modal message box

**After:**

https://github.com/user-attachments/assets/383b2ced-c99a-43eb-adbc-0302ac641180

