### PR TITLE
#868aaqu6r Bug: Account creation forms 

### DIFF
--- a/communities/forms.py
+++ b/communities/forms.py
@@ -29,6 +29,9 @@ class CreateCommunityForm(forms.ModelForm):
             'community_name': {
                 'unique': _("A community by that name already exists."),
             },
+            'contact_email': {
+                'invalid': _("Please use a valid email."),
+            }
         }
 
 

--- a/institutions/forms.py
+++ b/institutions/forms.py
@@ -15,6 +15,9 @@ class CreateInstitutionForm(forms.ModelForm):
             'institution_name': {
                 'unique': _("This institution is already on the Hub."),
             },
+            'contact_email': {
+                'invalid': _("Please use a valid email."),
+            }
         }
         widgets = {
             'institution_name': forms.TextInput(attrs={'id':'organizationInput', 'name':'institution_name', 'class': 'w-100', 'autocomplete': 'off', 'required': True, 'placeholder': 'Search ROR institutions...'}),
@@ -46,6 +49,9 @@ class CreateInstitutionNoRorForm(forms.ModelForm):
             'institution_name': {
                 'unique': _("This institution is already on the Hub."),
             },
+            'contact_email': {
+                'invalid': _("Please use a valid email."),
+            }
         }
         widgets = {
             'institution_name': forms.TextInput(attrs={'name':'institution_name', 'class': 'w-100', 'autocomplete': 'off', 'required': True}),

--- a/localcontexts/static/javascript/main.js
+++ b/localcontexts/static/javascript/main.js
@@ -100,6 +100,17 @@ document.addEventListener('DOMContentLoaded', () => {
         countCharacters();
         textArea.addEventListener('input', countCharacters);
     };
+    
+    const clearInputFields = () => {
+        const inputs = document.querySelectorAll('input[type="text"], input[type="email"], textarea');
+        inputs.forEach(input => {
+            if (input.name !== 'first_name' && input.name !== 'last_name') {
+                input.value = '';
+            }
+        });
+    };
+
+    clearInputFields();
 
     const url = window.location.href;
     const createPages = ['create-community', 'create-institution', 'connect-researcher', 'create-service-provider'];

--- a/templates/communities/create-community.html
+++ b/templates/communities/create-community.html
@@ -99,14 +99,14 @@
             <div class="w-50">
                 <label>Contact Email<span class="orange-text required-label" title="">*</span></label><br>
                 {{ form.contact_email }}
+                {% if form.contact_email.errors %}
+                    <div class="msg-red w-50"><small>{{ form.contact_email.errors.as_text }}</small></div>
+                {% endif %}
             </div>
         </div>
 
         <div class="flex-this space-between">
             <div>
-                {% if form.errors %}
-                    <small class="red-text">{{ form.errors }}</small>
-                {% endif %}
                 {% include 'partials/_alerts.html' %}
             </div>
     

--- a/templates/institutions/create-custom-institution.html
+++ b/templates/institutions/create-custom-institution.html
@@ -138,6 +138,9 @@
             <div class="w-50">
                 <label>Contact Email<span class="orange-text required-label" title="">*</span></label><br>
                 {{ noror_form.contact_email }}
+                {% if noror_form.contact_email.errors %}
+                    <div class="msg-red w-50"><small>{{ noror_form.contact_email.errors.as_text }}</small></div>
+                {% endif %}
             </div>
         </div>
 

--- a/templates/institutions/create-institution.html
+++ b/templates/institutions/create-institution.html
@@ -122,6 +122,9 @@
             <div class="w-50">
                 <label>Contact Email<span class="orange-text required-label" title="">*</span></label><br>
                 {{ form.contact_email }}
+                {% if form.contact_email.errors %}
+                    <div class="msg-red w-50"><small>{{ form.contact_email.errors.as_text }}</small></div>
+                {% endif %}
             </div>
         </div>
 


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/868aaqu6r)**

**Description:**
Whenever a user goes to create an institution or community account and inputs an invalid email, the form does not get submitted and no error message or alerts gets displayed to help the user know what went wrong.

Add an error message to the form when the contact email is invalid:
`Please use a valid email `

**Solution:**
- Updated `CreateCommunityForm`, `CreateInstitutionForm` and `CreateInstitutionNoRorForm` forms to add custom email invalid message
- Updated `create-community`, `create-custom-institution` and `create-institution` templates to include the error message div
- Updated `main.js` to remove all the inputs for consistency

**After:**
- **Community Account:**

https://github.com/user-attachments/assets/7bf779f5-b1f2-4c44-a92c-a3fb12e68587

- **Institution Account:**

https://github.com/user-attachments/assets/082accba-11b1-4ef1-81d2-c1590a7826f9

- **non-ROR Institution Account:**

https://github.com/user-attachments/assets/9997f16b-55e2-4366-ad68-b214f9bdf4b5

