### PR TITLE
#868acy3kb UI Fix: Contact Us message modal

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -151,7 +151,8 @@ class ContactOrganizationForm(forms.Form):
         widget=forms.Textarea(attrs={
             "rows": 4,
             "cols": 65,
-            'class': 'w-100'
+            'class': 'w-100',
+            'style': 'resize: vertical;'
         })
     )
 


### PR DESCRIPTION
**[Issue:](https://app.clickup.com/t/8689agzvf)**

**Description:**
While working on the UI Fix of the Request to Join Us message modal, I found that the message modal in Contact Us is also resizable and the user can stretch the width of the message box beyond the div.

![image](https://github.com/user-attachments/assets/75824a8d-d228-4c37-ac4e-4cee54f6c4f3)



**Solution:**
- Updated the resizing property of `ContactOrganizationForm` which translates into Contact Us modal message box

**After:**

https://github.com/user-attachments/assets/bf4de47d-107c-4200-bc19-20f8df7eb86c


